### PR TITLE
refactor(prospect): stage-decompose createProspect, no behavior change (P3-1)

### DIFF
--- a/backend/src/services/prospectCreateTx.js
+++ b/backend/src/services/prospectCreateTx.js
@@ -1,0 +1,331 @@
+/**
+ * The PERSIST stage of lead capture — the single transaction that turns a
+ * validated, gated, routed lead into rows.
+ *
+ * Lifted verbatim out of prospectService.createProspect (P3-1), which had grown
+ * to ~1,200 lines by inlining every stage of the pipeline. This was the densest
+ * part: one transaction that decides the assignment, applies the DNC and
+ * screening holds, resolves the consumer spine, writes the prospect, the consent
+ * ledger, the enrichment outbox, two activities, the credit deduct and the QR
+ * analytics bump — six concerns sharing one `t`.
+ *
+ * It reached all of that through the enclosing closure. Everything it read is
+ * now a named field of `ctx`, and everything it wrote back is a named field of
+ * the return value, so the data flow across this boundary is readable without
+ * holding the whole function in your head.
+ *
+ * Behaviour is unchanged, deliberately and completely: the statement order, the
+ * savepoint isolation, the "never override an existing quarantine" precedence
+ * between the quota / DNC / screening gates, and the throw contract are all as
+ * they were. The only difference is that `dncIntendedAgentId` and
+ * `dncAlreadyCharged` are now locals — the caller never read them.
+ */
+import { bakeHoldTargetAgentId } from './dncGate.js';
+import { signupActivityDescription } from '../utils/sourceLabel.js';
+
+/**
+ * @param {object} args
+ * @param {object} args.d Injected dependencies (the prospectService `d` object).
+ * @param {object} args.m Injected models (the prospectService `m` object).
+ */
+export function makeCreateTxRunner({ d, m }) {
+  /**
+   * @param {object} ctx Everything the transaction needs from the stages before it.
+   * @param {object} ctx.incoming The assembled Prospect attributes.
+   * @param {object|null} ctx.user The requesting user, for activity attribution.
+   * @param {object|null} ctx.sourceCampaign The resolved campaign (quiz definition, name).
+   * @param {object|null} ctx.sourceQrTag The resolved QR tag, for the analytics bump.
+   * @param {string|null} ctx.assignedAgentId Internal routing's pick, pre-quota.
+   * @param {string|null} ctx.externalAgentId MKTR Leads buyer, when this is an external lead.
+   * @param {boolean} ctx.externalHold External-eligible + consented but unfunded.
+   * @param {string|null} ctx.externalHoldReason Quarantine reason for that hold.
+   * @param {string} ctx.routeVia How the agent was reached (qr/group/direct/…).
+   * @param {boolean} ctx.dncBlockApplies DNC is in block mode for this lead.
+   * @param {boolean} ctx.dncWillCheck A DNC check will run post-commit (block or flag mode).
+   * @param {boolean} ctx.screeningWanted The campaign wants an AI screening call first.
+   * @param {boolean} ctx.otpMarkerLive The durable proof this phone was OTP-verified.
+   * @param {string|null} ctx.eventSourceUrl Capture page URL, for the consent ledger.
+   * @param {boolean|undefined} ctx.consentContact Marketing-contact opt-in.
+   * @param {boolean|undefined} ctx.consentTerms Terms acceptance.
+   * @param {string|undefined} ctx.consentCopyVersion Wording era of the consent block.
+   * @param {object|null} ctx.externalConsent Third-party-disclosure evidence.
+   * @param {object|null} ctx.dncConsent DNC-consent evidence.
+   * @param {Array} ctx.acceptedProfileFacts Validated profile-question facts.
+   *
+   * @returns {Promise<{
+   *   prospect: object, quarantined: boolean, heldReason: string|null,
+   *   finalAgentId: string|null, dncHeld: boolean, screeningHeld: boolean
+   * }>} The committed row plus the outcome flags the post-commit stages read.
+   */
+  return async function runCreateTx(ctx) {
+    const {
+      incoming,
+      user,
+      sourceCampaign,
+      sourceQrTag,
+      assignedAgentId,
+      externalAgentId,
+      externalHold,
+      externalHoldReason,
+      routeVia,
+      dncBlockApplies,
+      dncWillCheck,
+      screeningWanted,
+      otpMarkerLive,
+      eventSourceUrl,
+      consentContact,
+      consentTerms,
+      consentCopyVersion,
+      externalConsent,
+      dncConsent,
+      acceptedProfileFacts,
+    } = ctx;
+
+    let quarantined = false;
+    let heldReason = null;
+    let finalAgentId = assignedAgentId;
+    // DNC block-mode hold bookkeeping — written onto the row below; the caller
+    // only needs to know THAT the lead was held, not who it was held for.
+    let dncHeld = false;
+    let dncIntendedAgentId = null;
+    let dncAlreadyCharged = false;
+    // Screening hold bookkeeping (plan §5.2) — mirrors the DNC shape.
+    let screeningHeld = false;
+
+    const prospect = await d.sequelize.transaction(async (t) => {
+      // The internal quota gate applies ONLY to the internal path. For external
+      // leads default to a plain "assign" directive so the shared activity/deduct
+      // code below stays correct (external is charged authoritatively, not metered).
+      let decision = { action: 'assign', assignedAgentId, charged: false, via: routeVia };
+      if (externalHold) {
+        // External-eligible + consented but no funded buyer → HOLD (never System Agent,
+        // never charged). The distinct quarantineReason fences this lead off from the
+        // internal release sweep so it can never be delivered to Lyfe.
+        decision = { action: 'quarantine', quarantineReason: externalHoldReason, charged: false, via: routeVia };
+      } else if (!externalAgentId) {
+        decision = await d.decideAssignment({
+          campaign: sourceCampaign,
+          routing: { agentId: assignedAgentId, via: routeVia },
+          campaignId: incoming.campaignId,
+          transaction: t,
+          charge: d.chargeLeadCredit,
+        });
+      }
+
+      // Hold-target bake rule — shared with the Retell capture path (P1-3);
+      // the rule itself is documented on bakeHoldTargetAgentId in dncGate.js.
+      const bakeIntendedAgentId = (candidateId) =>
+        bakeHoldTargetAgentId(candidateId, { routeVia, User: m.User, transaction: t });
+
+      // DNC block-mode gate: a normally-assignable INTERNAL lead is HELD pending a DNC
+      // check (released post-commit on clear). Never overrides an existing quarantine
+      // (quota / external) or an external-buyer route. The credit is charged on release
+      // (unless decideAssignment already charged a funded gated route → dncAlreadyCharged).
+      if (dncBlockApplies && decision.action !== 'quarantine' && !externalAgentId) {
+        dncIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
+        dncAlreadyCharged = decision.charged === true;
+        dncHeld = true;
+        decision = { action: 'quarantine', quarantineReason: 'dnc_pending', charged: dncAlreadyCharged, via: routeVia };
+      }
+
+      // Screening gate (plan §5.2): a normally-assignable INTERNAL lead is HELD
+      // pending the AI screening call. Sits AFTER the DNC block on purpose —
+      // when both gates apply the lead is born dnc_pending and dncGate hands
+      // off to screening on clear (never dial an unscrubbed number, §6).
+      let screeningIntendedAgentId = null;
+      let screeningAlreadyCharged = false;
+      if (screeningWanted && decision.action !== 'quarantine' && !externalAgentId) {
+        screeningIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
+        screeningAlreadyCharged = decision.charged === true;
+        screeningHeld = true;
+        decision = { action: 'quarantine', quarantineReason: 'screening_pending', charged: screeningAlreadyCharged, via: routeVia };
+      }
+
+      quarantined = decision.action === 'quarantine';
+      heldReason = quarantined ? decision.quarantineReason : null;
+      finalAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
+
+      // Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2.3):
+      // resolve-or-create the cross-campaign person for this already-normalized
+      // phone INSIDE A SAVEPOINT — a spine failure rolls back the savepoint
+      // only and capture proceeds with consumerId null (reconciler heals).
+      // Runs AFTER the per-campaign 409 dupe check so duplicates never bump
+      // signupCount. call_bot never links (to_number ambiguity — see
+      // consumerService.js); `verified` is the single OTP-marker read above.
+      const consumerId = incoming.leadSource === 'call_bot'
+        ? null
+        : await d.resolveConsumerForCaptureTx(t, {
+            phone: incoming.phone,
+            firstName: incoming.firstName,
+            lastName: incoming.lastName,
+            email: incoming.email,
+            verified: otpMarkerLive,
+          });
+
+      const newProspect = await m.Prospect.create(
+        {
+          ...incoming,
+          consumerId,
+          assignedAgentId: finalAgentId,
+          externalAgentId,
+          quarantinedAt: quarantined ? new Date() : null,
+          quarantineReason: quarantined ? decision.quarantineReason : null,
+          // DNC: mark pending up-front (crash-safe — the backfill finds a stranded row);
+          // stash the intended agent so the post-commit clear-release knows who to deliver to.
+          ...(dncWillCheck ? { dncStatus: 'pending' } : {}),
+          ...(dncHeld ? { dncMetadata: { intendedAgentId: dncIntendedAgentId, alreadyCharged: dncAlreadyCharged } } : {}),
+          ...(screeningHeld
+            ? { screeningMetadata: { intendedAgentId: screeningIntendedAgentId, alreadyCharged: screeningAlreadyCharged, attempts: {} } }
+            : {}),
+        },
+        { transaction: t }
+      );
+
+      // Consent ledger (PR B, plan §3.1): person-level evidence for this
+      // capture — savepoint-isolated + non-blocking like the resolver; every
+      // input also lives on the prospect row, so backfillConsentEvents can
+      // re-derive a missed write. No-op when consumerId is null (call_bot /
+      // unlinked rows carry no person-level evidence until reconciled).
+      await d.recordCaptureConsentEventsTx(t, {
+        consumerId,
+        prospectId: newProspect.id,
+        campaignId: newProspect.campaignId || null,
+        sourceUrl: eventSourceUrl || null,
+        verified: otpMarkerLive,
+        contact: consentContact,
+        copyVersion: consentCopyVersion,
+        terms: consentTerms,
+        externalConsent,
+        dncConsent,
+        drawTerms: incoming.consentMetadata?.drawTerms || null,
+      });
+
+      // Enrichment outbox (docs/plans/consumer-profile-enrichment.md §5):
+      // freeze the normalized fact snapshot and enqueue the map job IN THIS
+      // transaction (crash-safe — Codex R1 #5), savepoint-isolated like the
+      // spine resolver: enrichment must never fail capture; the nightly
+      // sweep re-drains anything a crash or savepoint rollback loses.
+      try {
+        await d.sequelize.transaction({ transaction: t }, async (sp) => {
+          const snapshot = d.buildFactSnapshot({
+            demographics: newProspect.demographics,
+            sourceMetadata: newProspect.sourceMetadata,
+            quizDefinition: sourceCampaign?.design_config?.quiz,
+            profileFacts: acceptedProfileFacts,
+          });
+          await d.enqueueMapJobsTx(sp, {
+            prospectId: newProspect.id,
+            formRevision: newProspect.enrichmentRevision || 1,
+            snapshot,
+          });
+        });
+      } catch (enrichErr) {
+        d.logger.warn('[enrichment] map-job outbox failed (sweep heals)', {
+          error: enrichErr?.message || String(enrichErr),
+        });
+      }
+
+      const campaignName = sourceCampaign?.name || 'Unknown Campaign';
+      // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR
+      // code" …) instead of the old hardcoded "via {qr} QR code", which
+      // mislabeled every non-QR lead as "Unknown QR". See utils/sourceLabel.js.
+      const activityDescription = signupActivityDescription(campaignName, {
+        leadSource: incoming.leadSource,
+        qrTag: sourceQrTag,
+        sourceMetadata: incoming.sourceMetadata,
+      });
+
+      // Activity: created
+      await m.ProspectActivity.create(
+        {
+          prospectId: newProspect.id,
+          type: 'created',
+          actorUserId: user?.id || null,
+          description: activityDescription,
+          metadata: {
+            leadSource: incoming.leadSource,
+            campaignId: newProspect.campaignId,
+            qrTagId: newProspect.qrTagId,
+          },
+        },
+        { transaction: t }
+      );
+
+      // Activity: assignment outcome (assigned, or held under quota)
+      if (quarantined) {
+        await m.ProspectActivity.create(
+          {
+            prospectId: newProspect.id,
+            type: 'updated',
+            actorUserId: user?.id || null,
+            description:
+              decision.quarantineReason === 'no_funded_external_buyer'
+                ? 'Held — no funded MKTR Leads (external) buyer'
+                : decision.quarantineReason === 'dnc_pending'
+                  ? 'Held — pending DNC (Do Not Call) check'
+                  : decision.quarantineReason === 'screening_pending'
+                    ? 'Held — pending AI screening call'
+                    : 'Held — no funded agent (lead quota)',
+            metadata: { quarantined: true, reason: decision.quarantineReason, via: routeVia },
+          },
+          { transaction: t }
+        );
+      } else {
+        await m.ProspectActivity.create(
+          {
+            prospectId: newProspect.id,
+            type: 'assigned',
+            actorUserId: user?.id || null,
+            description: externalAgentId
+              ? `Routed to external buyer ${externalAgentId} (MKTR Leads)`
+              : `Assigned to agent ${finalAgentId}`,
+            metadata: externalAgentId
+              ? { externalAgentId }
+              : { assignedAgentId: finalAgentId },
+          },
+          { transaction: t }
+        );
+
+        // Deduct lead credit.
+        //  - External (MKTR Leads) buyers are PAID leads: the charge is authoritative
+        //    — if the buyer's prepaid balance can't be charged, abort the whole create
+        //    (rollback) rather than hand over a lead we can't bill.
+        //  - Internal stays best-effort, and is skipped when decideAssignment already
+        //    charged authoritatively (charged:true) to avoid double-charging.
+        if (externalAgentId) {
+          const extCharged = await d.deductExternalLeadBalance(externalAgentId, 1, t);
+          if (!extCharged) {
+            throw new d.AppError('No paid external buyer balance available for this lead.', 409);
+          }
+        } else if (finalAgentId && decision.charged !== true) {
+          await d
+            .deductLeadCredit({ agentId: finalAgentId, campaignId: newProspect.campaignId || null, transaction: t })
+            .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
+        }
+      }
+
+      // Update QR tag analytics (atomic to avoid read-modify-write race).
+      // A quarantined lead is still a captured conversion, so we count it.
+      if (newProspect.qrTagId && sourceQrTag) {
+        await sourceQrTag.update(
+          {
+            analytics: d.sequelize.literal(`
+            jsonb_set(
+              COALESCE(analytics::jsonb, '{}'),
+              '{conversions}',
+              to_jsonb(COALESCE((analytics->>'conversions')::int, 0) + 1)
+            )
+          `),
+          },
+          { transaction: t }
+        );
+      }
+
+      // Campaign metrics are now computed from real data (no JSON blob to increment)
+
+      return newProspect;
+    });
+
+    return { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld };
+  };
+}

--- a/backend/src/services/prospectDispatch.js
+++ b/backend/src/services/prospectDispatch.js
@@ -1,0 +1,338 @@
+/**
+ * The DISPATCH stage of lead capture — everything that happens AFTER the create
+ * transaction commits.
+ *
+ * Lifted verbatim out of prospectService.createProspect (P3-1). It is one
+ * cohesive concern with one rule holding it together: none of it may fail or
+ * slow the capture. So it is uniformly post-commit and fire-and-forget — DNC
+ * scrubbing, the Lyfe delivery webhook and the held-queue ping, the Meta and
+ * TikTok CAPI pairs, the Redeem Ops entitlement hook, the enrichment drain, the
+ * referral share link, and the AI screening dial.
+ *
+ * Statement ORDER here is load-bearing and unchanged: DNC scrubbing runs before
+ * the webhook so a held lead stays suppressed; the CAPI dispatches run before
+ * the entitlement hook so capture-time events see the prospect exactly as they
+ * did; the screening dial is deliberately last.
+ *
+ * The stage used to read ~22 variables out of the enclosing closure. They are
+ * now named fields of `ctx`, and the four values the caller needs back are named
+ * fields of the return value.
+ */
+import {
+  buildLeadCreatedPayload,
+  buildLeadHeldPayload,
+  destinationForAgent,
+  externalIdForDestination,
+} from './prospectHelpers.js';
+import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+
+/**
+ * @param {object} args
+ * @param {object} args.d Injected dependencies (the prospectService `d` object).
+ * @param {object} args.m Injected models (the prospectService `m` object).
+ */
+export function makeDispatchRunner({ d, m }) {
+  /**
+   * @param {object} ctx
+   * @param {object} ctx.prospect The committed row.
+   * @param {boolean} ctx.quarantined Whether the lead was held.
+   * @param {string|null} ctx.heldReason Why, when it was.
+   * @param {string|null} ctx.assignedAgentId The committed assignment (null when held).
+   * @param {boolean} ctx.dncHeld The lead was born dnc_pending (block mode).
+   * @param {boolean} ctx.dncFlagApplies DNC runs in flag mode for this lead.
+   * @param {boolean} ctx.screeningHeld The lead is awaiting an AI screening call.
+   * @param {string|null} ctx.externalAgentId MKTR Leads buyer, when external.
+   * @param {object|null} ctx.sourceCampaign Campaign (pixel overrides, design_config).
+   * @param {object|null} ctx.sourceQrTag QR tag, for the webhook payload.
+   * @param {object|null} ctx.resolvedAgent Partial agent from QR/group routing (fallback fields).
+   * @param {object|null} ctx.agentGroup Routing group, for the webhook payload.
+   * @param {string} ctx.routingMode How the lead was routed.
+   * @param {string|undefined} ctx.eventId Meta/TikTok Lead dedup id.
+   * @param {string|undefined} ctx.registrationEventId Quiz CompleteRegistration dedup id.
+   * @param {string|null} ctx.eventSourceUrl Capture page URL.
+   * @param {string|undefined} ctx.fbp Meta browser id.
+   * @param {string|undefined} ctx.fbc Meta click id.
+   * @param {string|undefined} ctx.ttclid TikTok click id.
+   * @param {string|undefined} ctx.ttp TikTok browser id.
+   * @param {string|undefined} ctx.clientIp Caller IP, for CAPI.
+   * @param {string|undefined} ctx.clientUserAgent Caller UA, for CAPI.
+   *
+   * @returns {Promise<{
+   *   assignedAgent: object|null, prospectWithCampaign: object,
+   *   shareUrl: string|null, leadCapturedOutcome: Promise|null
+   * }>} What the caller returns to the controller.
+   */
+  return async function runDispatch(ctx) {
+    const {
+      prospect,
+      quarantined,
+      heldReason,
+      assignedAgentId,
+      dncHeld,
+      dncFlagApplies,
+      screeningHeld,
+      externalAgentId,
+      sourceCampaign,
+      sourceQrTag,
+      resolvedAgent,
+      agentGroup,
+      routingMode,
+      eventId,
+      registrationEventId,
+      eventSourceUrl,
+      fbp,
+      fbc,
+      ttclid,
+      ttp,
+      clientIp,
+      clientUserAgent,
+    } = ctx;
+
+    // --- DNC scrubbing (post-commit, synchronous before dispatch) ---
+    // Block mode: the lead was born held (dnc_pending). Check, then release-on-clear (which
+    // fires its own first lead.created) or keep held (dnc_registered) — so the normal
+    // lead.created below stays suppressed (quarantined). Flag mode: check + record so the
+    // lead.created payload below carries the result; the lead delivers regardless.
+    if (dncHeld) {
+      await d.gateHeldDncLead(prospect).catch((err) =>
+        d.logger.error('[DNC] gate error', { error: err?.message || String(err) })
+      );
+    } else if (dncFlagApplies) {
+      await d
+        .dncCheckAndRecord(prospect)
+        .catch((err) => d.logger.error('[DNC] check error', { error: err?.message || String(err) }));
+    }
+
+    // --- Webhook dispatch (AFTER transaction commits, fire-and-forget) ---
+    // Always load the assigned agent's provenance (lyfeId/mktrLeadsId) by id — NOT
+    // the possibly-partial resolvedAgent from QR/group routing, which lacks it — so
+    // we route to the right app and send the destination-correct external id.
+    let agentForWebhook = null;
+    let leadDestination = null;
+    if (assignedAgentId) {
+      const agentRecord = await m.User.findByPk(assignedAgentId, {
+        attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
+      });
+      if (agentRecord) {
+        leadDestination = destinationForAgent(agentRecord);
+        agentForWebhook = {
+          phone: agentRecord.phone || resolvedAgent?.phone || null,
+          email: agentRecord.email || resolvedAgent?.email || null,
+          name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim() || resolvedAgent?.name || null,
+          id: externalIdForDestination(agentRecord, leadDestination),
+        };
+      }
+    }
+
+    // Suppress the Lyfe 'lead.created' delivery webhook when there is no internal
+    // agent to deliver to:
+    //  - quarantined (held under lead quota) — no agent yet; it fires on release
+    //    (slice 4) as the first lead.created.
+    //  - external (MKTR Leads) — the existing subscriber is the Lyfe app, and an
+    //    external buyer lead must NEVER be dispatched to it (no external subscriber
+    //    exists yet; destination-aware routing lands later in webhookService).
+    if (!quarantined && !externalAgentId) {
+      d.dispatchEvent('lead.created', () =>
+        buildLeadCreatedPayload(
+          prospect,
+          routingMode,
+          agentForWebhook,
+          assignedAgentId,
+          sourceCampaign,
+          sourceQrTag,
+          agentGroup
+        ),
+        { destination: leadDestination }
+      ).catch((err) => {
+        d.logger.error('[Webhook] dispatch error', { error: err?.message || String(err) });
+      });
+      // Suppressed-person new-lead propagation rides webhookService's
+      // flush-time catchup choke point (tracker "propagate") — no per-site
+      // hook needed here.
+    }
+
+    // Held (no_funded_agent) → ping the mktr-leads admin held queue so a pending
+    // lead is never silent. ONLY this reason: the external (no_funded_external_buyer)
+    // hold is a DIFFERENT, fenced pool that is NOT in that admin queue, so it must
+    // not ping. Gated by HELD_LEAD_PING_ENABLED; the sweep is the completeness net.
+    if (
+      quarantined &&
+      heldReason === 'no_funded_agent' &&
+      String(process.env.HELD_LEAD_PING_ENABLED || 'false').toLowerCase() === 'true'
+    ) {
+      d.dispatchEvent('lead.held', () => buildLeadHeldPayload(prospect, sourceCampaign, heldReason), {
+        destination: 'mktr_leads',
+      }).catch((err) => {
+        d.logger.error('[Webhook] lead.held dispatch error', { error: err?.message || String(err) });
+      });
+    }
+
+    // em/ph gate for every submit-time CAPI dispatch (Meta + TikTok), derived
+    // from the consent ledger ONCE — the capture txn just committed, so the
+    // capture-hook contact event (with its OTP `verified` stamp) is visible.
+    // FAIL CLOSED on any lookup error: the events still fire, without em/ph.
+    // The stored consent_contact boolean keeps being WRITTEN at capture
+    // (evidence/backfill) but is no longer read here (3sites).
+    let capiMarketingConsent = false;
+    try {
+      capiMarketingConsent = (await d.canMarketTo({
+        consumerId: prospect.consumerId || null,
+        phone: prospect.phone || null,
+        channel: 'all',
+        campaignId: prospect.campaignId || null,
+      })) === true;
+    } catch (err) {
+      d.logger.warn('[CAPI] canMarketTo failed — omitting em/ph (fail-closed)', {
+        error: err?.message || String(err),
+      });
+    }
+
+    // Meta CAPI dispatch (fire-and-forget; post-commit; guard inside sendLeadEvent)
+    d.sendLeadEvent(prospect, {
+      eventId,
+      fbp,
+      fbc,
+      eventSourceUrl,
+      clientIp,
+      clientUserAgent,
+      pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
+      marketingConsent: capiMarketingConsent,
+    }).catch((err) => {
+      d.logger.error('[CAPI] sendLeadEvent error', { error: err?.message || String(err) });
+    });
+
+    // Meta CAPI CompleteRegistration (quiz funnel). Fired server-side only when
+    // the browser sent a registrationEventId (the quiz reveal happened), using
+    // that same id so Meta dedups it against the Pixel CompleteRegistration fired
+    // at the reveal. No-op for non-quiz leads. Guard inside sendCompleteRegistrationEvent.
+    if (registrationEventId) {
+      d.sendCompleteRegistrationEvent(prospect, {
+        eventId: registrationEventId,
+        fbp,
+        fbc,
+        eventSourceUrl,
+        clientIp,
+        clientUserAgent,
+        pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
+        marketingConsent: capiMarketingConsent,
+      }).catch((err) => {
+        d.logger.error('[CAPI] sendCompleteRegistrationEvent error', { error: err?.message || String(err) });
+      });
+    }
+
+    // TikTok Events API dispatch (fire-and-forget; post-commit; guard inside the
+    // sender). Mirrors the Meta CAPI pair: a Lead at submit, plus a
+    // CompleteRegistration when the quiz reveal fired one — each deduped against
+    // the browser ttq pixel via the shared event ids. Per-campaign tiktokPixelId
+    // overrides env TIKTOK_PIXEL_ID.
+    const tiktokCtxBase = {
+      ttclid,
+      ttp,
+      eventSourceUrl,
+      clientIp,
+      clientUserAgent,
+      pixelIdOverride: sourceCampaign?.tiktokPixelId || undefined,
+      marketingConsent: capiMarketingConsent,
+    };
+    d.sendTikTokLeadEvent(prospect, { eventId, ...tiktokCtxBase }).catch((err) => {
+      d.logger.error('[TikTok] sendTikTokLeadEvent error', { error: err?.message || String(err) });
+    });
+    if (registrationEventId) {
+      d.sendTikTokCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...tiktokCtxBase }).catch((err) => {
+        d.logger.error('[TikTok] sendTikTokCompleteRegistrationEvent error', { error: err?.message || String(err) });
+      });
+    }
+
+    // Redeem Ops reward-entitlement hook — post-commit, fire-and-forget (a
+    // Redeem Ops failure must never fail or slow lead capture). No-op unless
+    // bootstrap registered the callback (module flag on). Idempotent downstream
+    // via the unique (activationId, prospectId) anchor.
+    // Screening holds ARE reward-eligible (plan D8): the consumer earned the
+    // signup reward by verified signup — screening gates AGENT delivery, not
+    // consumer rewards. Quota/DNC/external holds stay excluded as before.
+    // The hook's ISSUANCE result is kept as an always-resolving promise for the
+    // caller: the controller chains the confirmation email on it so a queued
+    // merged draw email (drawEmailQueued) suppresses the near-duplicate generic
+    // confirmation — an observed outcome, never a prediction, so a skip can
+    // never orphan a signup with zero emails. Still fire-and-forget for the
+    // capture path itself (errors resolve to null, logged as before).
+    let leadCapturedOutcome = null;
+    if (!quarantined || heldReason === 'screening_pending') {
+      try {
+        const hookResult = d.onLeadCaptured?.(prospect);
+        if (hookResult && typeof hookResult.then === 'function') {
+          leadCapturedOutcome = hookResult.catch((err) => {
+            d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
+            return null;
+          });
+        } else if (hookResult != null) {
+          leadCapturedOutcome = Promise.resolve(hookResult);
+        }
+      } catch (err) {
+        d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
+      }
+    }
+
+    // Enrichment: opportunistic post-commit drain of the map-job outbox —
+    // fire-and-forget (the job row is already durable; the sweep re-drains).
+    d.drainMapJobs({ limit: 5 }).catch((err) => {
+      d.logger.warn('[enrichment] post-capture drain failed', { error: err?.message || String(err) });
+    });
+
+    // Pre-load agent + prospect-with-campaign for the caller's fire-and-forget
+    // email side-effects. The campaign's design_config.customerHost drives the
+    // confirmation-email brand, so load the campaign (with design_config) for
+    // EVERY prospect — not only when an agent is assigned.
+    let assignedAgent = null;
+    if (assignedAgentId) {
+      assignedAgent = await m.User.findByPk(assignedAgentId);
+    }
+    const prospectWithCampaign =
+      (await m.Prospect.findByPk(prospect.id, {
+        include: [{ association: 'campaign', attributes: ['id', 'name', 'design_config'] }],
+      })) || prospect;
+
+    // Mint the prospect's ONE canonical referral share link now, on the campaign's
+    // canonical host, so the confirmation email and the SPA share dialog hand out the
+    // identical /share/{slug}. Non-blocking: a failure must never break lead creation —
+    // the email + SPA fall back to the long ?ref= URL. Injected via deps so DI unit tests
+    // can stub it (keeps them DB-free).
+    let shareUrl = null;
+    const shareCampaignId = prospect.campaignId;
+    if (shareCampaignId) {
+      try {
+        const hostChoice = normalizeCustomerHostChoice(
+          prospectWithCampaign?.campaign?.design_config?.customerHost
+        );
+        const origin = customerHostOrigin(hostChoice);
+        const { url } = await d.getOrCreateProspectShareLink({
+          prospectId: prospect.id,
+          campaignId: shareCampaignId,
+          origin,
+        });
+        shareUrl = `${origin}${url}`;
+      } catch (err) {
+        d.logger.warn('Referral share link mint failed (non-blocking)', {
+          prospectId: prospect.id,
+          err: err?.message,
+        });
+      }
+    }
+
+    // AI screening dial trigger (plan §5.3) — LAST on purpose: after the CAPI
+    // dispatches (capture-time events must see the prospect exactly as today)
+    // and the entitlement hook. Fire-and-forget; any failure leaves the held
+    // row for the sweep. DNC-held leads are NOT triggered here — dncGate hands
+    // off and dials on clear (§6).
+    // SCHEDULE, don't dial: the first attempt waits cfg.dialDelaySeconds so the
+    // consumer can read the success page's "an automated call is coming" notice
+    // before their phone rings (§7.1a).
+    if (screeningHeld) {
+      d.scheduleScreeningAttempt(prospect, { campaign: sourceCampaign }).catch((err) =>
+        d.logger.error('[Screening] capture dial trigger error', { error: err?.message || String(err) })
+      );
+    }
+
+    return { assignedAgent, prospectWithCampaign, shareUrl, leadCapturedOutcome };
+  };
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -17,13 +17,15 @@ import { makeIdempotencyOps } from './idempotencyProtocol.js';
 import { makeProspectReads } from './prospectReadService.js';
 import { makeHeldQueueOps } from './prospectHeldQueueService.js';
 import { makeAssignmentOps } from './prospectAssignmentService.js';
+import { makeCreateTxRunner } from './prospectCreateTx.js';
+import { makeDispatchRunner } from './prospectDispatch.js';
 import {
   UUID_RE, PROSPECT_UPDATE_FIELDS,
 } from './prospectShared.js';
 import { deductLeadCredit, chargeLeadCredit, deductExternalLeadBalance } from './leadCredits.js';
 import { decideAssignment } from './leadQuota.js';
 import { dncEnforcement, formatDncNumber, checkAndRecord as dncCheckAndRecord } from './dncService.js';
-import { gateHeldDncLead, dncCaptureGate, bakeHoldTargetAgentId } from './dncGate.js';
+import { gateHeldDncLead, dncCaptureGate } from './dncGate.js';
 import { hasValidExternalConsent, buildExternalConsentEvidence } from './externalConsent.js';
 import { buildDncConsentEvidence } from './dncConsent.js';
 import { buildProspectWhere } from './prospectScope.js';
@@ -74,14 +76,10 @@ export function registerLeadCapturedHook(fn) {
   _leadCapturedHook = typeof fn === 'function' ? fn : null;
 }
 import { logger } from '../utils/logger.js';
-import { signupActivityDescription } from '../utils/sourceLabel.js';
 import {
   normalizePhone,
-  buildLeadCreatedPayload,
-  buildLeadHeldPayload,
   buildLeadDeletedPayload,
   destinationForAgent,
-  externalIdForDestination,
 } from './prospectHelpers.js';
 import { scoreQuiz } from './quizScoringService.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
@@ -156,6 +154,10 @@ export function makeProspectService(overrides = {}) {
   const { assignProspect, bulkAssignProspects } = assigns;
   const held = makeHeldQueueOps({ d, m, idem, assignProspect });
   const { orphanSystemAgentId, listDispatchableOrphans, releaseHeldProspect, reassignProspectExternal, returnProspectToHeld, bulkReturnProspectsToHeld } = held;
+  // The persist stage of createProspect (P3-1) — see prospectCreateTx.js.
+  const runCreateTx = makeCreateTxRunner({ d, m });
+  // The post-commit stage of createProspect (P3-1) — see prospectDispatch.js.
+  const runDispatch = makeDispatchRunner({ d, m });
 
   /**
    * Create a new prospect (lead capture).
@@ -844,252 +846,34 @@ export function makeProspectService(overrides = {}) {
     //     lead, and for a funded gated route charges a credit authoritatively
     //     (charged:true ⇒ skip the best-effort deduct below to avoid double-charging).
     //     Soft/exempt routes are unchanged: assign + best-effort deduct.
-    let quarantined = false;
-    let heldReason = null;
-    let finalAgentId = assignedAgentId;
-    // DNC block-mode hold bookkeeping — set inside the tx, consumed post-commit.
-    let dncHeld = false;
-    let dncIntendedAgentId = null;
-    let dncAlreadyCharged = false;
-    // Screening hold bookkeeping (plan §5.2) — mirrors the DNC shape.
-    let screeningHeld = false;
-    const runCreateTx = () => d.sequelize.transaction(async (t) => {
-      // The internal quota gate applies ONLY to the internal path. For external
-      // leads default to a plain "assign" directive so the shared activity/deduct
-      // code below stays correct (external is charged authoritatively, not metered).
-      let decision = { action: 'assign', assignedAgentId, charged: false, via: routeVia };
-      if (externalHold) {
-        // External-eligible + consented but no funded buyer → HOLD (never System Agent,
-        // never charged). The distinct quarantineReason fences this lead off from the
-        // internal release sweep so it can never be delivered to Lyfe.
-        decision = { action: 'quarantine', quarantineReason: externalHoldReason, charged: false, via: routeVia };
-      } else if (!externalAgentId) {
-        decision = await d.decideAssignment({
-          campaign: sourceCampaign,
-          routing: { agentId: assignedAgentId, via: routeVia },
-          campaignId: incoming.campaignId,
-          transaction: t,
-          charge: d.chargeLeadCredit,
-        });
-      }
-
-      // Hold-target bake rule — shared with the Retell capture path (P1-3);
-      // the rule itself is documented on bakeHoldTargetAgentId in dncGate.js.
-      const bakeIntendedAgentId = (candidateId) =>
-        bakeHoldTargetAgentId(candidateId, { routeVia, User: m.User, transaction: t });
-
-      // DNC block-mode gate: a normally-assignable INTERNAL lead is HELD pending a DNC
-      // check (released post-commit on clear). Never overrides an existing quarantine
-      // (quota / external) or an external-buyer route. The credit is charged on release
-      // (unless decideAssignment already charged a funded gated route → dncAlreadyCharged).
-      if (dncBlockApplies && decision.action !== 'quarantine' && !externalAgentId) {
-        dncIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
-        dncAlreadyCharged = decision.charged === true;
-        dncHeld = true;
-        decision = { action: 'quarantine', quarantineReason: 'dnc_pending', charged: dncAlreadyCharged, via: routeVia };
-      }
-
-      // Screening gate (plan §5.2): a normally-assignable INTERNAL lead is HELD
-      // pending the AI screening call. Sits AFTER the DNC block on purpose —
-      // when both gates apply the lead is born dnc_pending and dncGate hands
-      // off to screening on clear (never dial an unscrubbed number, §6).
-      let screeningIntendedAgentId = null;
-      let screeningAlreadyCharged = false;
-      if (screeningWanted && decision.action !== 'quarantine' && !externalAgentId) {
-        screeningIntendedAgentId = await bakeIntendedAgentId(decision.assignedAgentId ?? assignedAgentId ?? null);
-        screeningAlreadyCharged = decision.charged === true;
-        screeningHeld = true;
-        decision = { action: 'quarantine', quarantineReason: 'screening_pending', charged: screeningAlreadyCharged, via: routeVia };
-      }
-
-      quarantined = decision.action === 'quarantine';
-      heldReason = quarantined ? decision.quarantineReason : null;
-      finalAgentId = quarantined ? null : (decision.assignedAgentId ?? null);
-
-      // Consumer spine (docs/plans/consumer-spine-and-consent-ledger.md §2.3):
-      // resolve-or-create the cross-campaign person for this already-normalized
-      // phone INSIDE A SAVEPOINT — a spine failure rolls back the savepoint
-      // only and capture proceeds with consumerId null (reconciler heals).
-      // Runs AFTER the per-campaign 409 dupe check so duplicates never bump
-      // signupCount. call_bot never links (to_number ambiguity — see
-      // consumerService.js); `verified` is the single OTP-marker read above.
-      const consumerId = incoming.leadSource === 'call_bot'
-        ? null
-        : await d.resolveConsumerForCaptureTx(t, {
-            phone: incoming.phone,
-            firstName: incoming.firstName,
-            lastName: incoming.lastName,
-            email: incoming.email,
-            verified: otpMarkerLive,
-          });
-
-      const newProspect = await m.Prospect.create(
-        {
-          ...incoming,
-          consumerId,
-          assignedAgentId: finalAgentId,
-          externalAgentId,
-          quarantinedAt: quarantined ? new Date() : null,
-          quarantineReason: quarantined ? decision.quarantineReason : null,
-          // DNC: mark pending up-front (crash-safe — the backfill finds a stranded row);
-          // stash the intended agent so the post-commit clear-release knows who to deliver to.
-          ...(dncWillCheck ? { dncStatus: 'pending' } : {}),
-          ...(dncHeld ? { dncMetadata: { intendedAgentId: dncIntendedAgentId, alreadyCharged: dncAlreadyCharged } } : {}),
-          ...(screeningHeld
-            ? { screeningMetadata: { intendedAgentId: screeningIntendedAgentId, alreadyCharged: screeningAlreadyCharged, attempts: {} } }
-            : {}),
-        },
-        { transaction: t }
-      );
-
-      // Consent ledger (PR B, plan §3.1): person-level evidence for this
-      // capture — savepoint-isolated + non-blocking like the resolver; every
-      // input also lives on the prospect row, so backfillConsentEvents can
-      // re-derive a missed write. No-op when consumerId is null (call_bot /
-      // unlinked rows carry no person-level evidence until reconciled).
-      await d.recordCaptureConsentEventsTx(t, {
-        consumerId,
-        prospectId: newProspect.id,
-        campaignId: newProspect.campaignId || null,
-        sourceUrl: eventSourceUrl || null,
-        verified: otpMarkerLive,
-        contact: consentContact,
-        copyVersion: consentCopyVersion,
-        terms: consentTerms,
+    // --- PERSIST: the one transaction that turns this lead into rows ---
+    // The body lives in prospectCreateTx.js (P3-1). It used to be inlined here
+    // and reached ~20 enclosing variables through the closure; now every input
+    // is a named ctx field and every decision it makes is a named result field.
+    let txOutcome;
+    try {
+      txOutcome = await runCreateTx({
+        incoming,
+        user,
+        sourceCampaign,
+        sourceQrTag,
+        assignedAgentId,
+        externalAgentId,
+        externalHold,
+        externalHoldReason,
+        routeVia,
+        dncBlockApplies,
+        dncWillCheck,
+        screeningWanted,
+        otpMarkerLive,
+        eventSourceUrl,
+        consentContact,
+        consentTerms,
+        consentCopyVersion,
         externalConsent,
         dncConsent,
-        drawTerms: incoming.consentMetadata?.drawTerms || null,
+        acceptedProfileFacts,
       });
-
-      // Enrichment outbox (docs/plans/consumer-profile-enrichment.md §5):
-      // freeze the normalized fact snapshot and enqueue the map job IN THIS
-      // transaction (crash-safe — Codex R1 #5), savepoint-isolated like the
-      // spine resolver: enrichment must never fail capture; the nightly
-      // sweep re-drains anything a crash or savepoint rollback loses.
-      try {
-        await d.sequelize.transaction({ transaction: t }, async (sp) => {
-          const snapshot = d.buildFactSnapshot({
-            demographics: newProspect.demographics,
-            sourceMetadata: newProspect.sourceMetadata,
-            quizDefinition: sourceCampaign?.design_config?.quiz,
-            profileFacts: acceptedProfileFacts,
-          });
-          await d.enqueueMapJobsTx(sp, {
-            prospectId: newProspect.id,
-            formRevision: newProspect.enrichmentRevision || 1,
-            snapshot,
-          });
-        });
-      } catch (enrichErr) {
-        d.logger.warn('[enrichment] map-job outbox failed (sweep heals)', {
-          error: enrichErr?.message || String(enrichErr),
-        });
-      }
-
-      const campaignName = sourceCampaign?.name || 'Unknown Campaign';
-      // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR
-      // code" …) instead of the old hardcoded "via {qr} QR code", which
-      // mislabeled every non-QR lead as "Unknown QR". See utils/sourceLabel.js.
-      const activityDescription = signupActivityDescription(campaignName, {
-        leadSource: incoming.leadSource,
-        qrTag: sourceQrTag,
-        sourceMetadata: incoming.sourceMetadata,
-      });
-
-      // Activity: created
-      await m.ProspectActivity.create(
-        {
-          prospectId: newProspect.id,
-          type: 'created',
-          actorUserId: user?.id || null,
-          description: activityDescription,
-          metadata: {
-            leadSource: incoming.leadSource,
-            campaignId: newProspect.campaignId,
-            qrTagId: newProspect.qrTagId,
-          },
-        },
-        { transaction: t }
-      );
-
-      // Activity: assignment outcome (assigned, or held under quota)
-      if (quarantined) {
-        await m.ProspectActivity.create(
-          {
-            prospectId: newProspect.id,
-            type: 'updated',
-            actorUserId: user?.id || null,
-            description:
-              decision.quarantineReason === 'no_funded_external_buyer'
-                ? 'Held — no funded MKTR Leads (external) buyer'
-                : decision.quarantineReason === 'dnc_pending'
-                  ? 'Held — pending DNC (Do Not Call) check'
-                  : decision.quarantineReason === 'screening_pending'
-                    ? 'Held — pending AI screening call'
-                    : 'Held — no funded agent (lead quota)',
-            metadata: { quarantined: true, reason: decision.quarantineReason, via: routeVia },
-          },
-          { transaction: t }
-        );
-      } else {
-        await m.ProspectActivity.create(
-          {
-            prospectId: newProspect.id,
-            type: 'assigned',
-            actorUserId: user?.id || null,
-            description: externalAgentId
-              ? `Routed to external buyer ${externalAgentId} (MKTR Leads)`
-              : `Assigned to agent ${finalAgentId}`,
-            metadata: externalAgentId
-              ? { externalAgentId }
-              : { assignedAgentId: finalAgentId },
-          },
-          { transaction: t }
-        );
-
-        // Deduct lead credit.
-        //  - External (MKTR Leads) buyers are PAID leads: the charge is authoritative
-        //    — if the buyer's prepaid balance can't be charged, abort the whole create
-        //    (rollback) rather than hand over a lead we can't bill.
-        //  - Internal stays best-effort, and is skipped when decideAssignment already
-        //    charged authoritatively (charged:true) to avoid double-charging.
-        if (externalAgentId) {
-          const extCharged = await d.deductExternalLeadBalance(externalAgentId, 1, t);
-          if (!extCharged) {
-            throw new d.AppError('No paid external buyer balance available for this lead.', 409);
-          }
-        } else if (finalAgentId && decision.charged !== true) {
-          await d
-            .deductLeadCredit({ agentId: finalAgentId, campaignId: newProspect.campaignId || null, transaction: t })
-            .catch((err) => d.logger.error('Failed to deduct credit', { error: err?.message || String(err) }));
-        }
-      }
-
-      // Update QR tag analytics (atomic to avoid read-modify-write race).
-      // A quarantined lead is still a captured conversion, so we count it.
-      if (newProspect.qrTagId && sourceQrTag) {
-        await sourceQrTag.update(
-          {
-            analytics: d.sequelize.literal(`
-            jsonb_set(
-              COALESCE(analytics::jsonb, '{}'),
-              '{conversions}',
-              to_jsonb(COALESCE((analytics->>'conversions')::int, 0) + 1)
-            )
-          `),
-          },
-          { transaction: t }
-        );
-      }
-
-      // Campaign metrics are now computed from real data (no JSON blob to increment)
-
-      return newProspect;
-    });
-
-    let prospect;
-    try {
-      prospect = await runCreateTx();
     } catch (err) {
       // Concurrent same-campaign duplicate: both requests passed the precheck;
       // the unique-index loser lands here AFTER a full rollback (including the
@@ -1110,254 +894,41 @@ export function makeProspectService(overrides = {}) {
       throw err;
     }
 
+    const { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld } = txOutcome;
+
     // Reflect the committed outcome (null when quarantined) for the rest of the
     // function — webhook dispatch, agent load, and the returned payload.
     assignedAgentId = finalAgentId;
 
-    // --- DNC scrubbing (post-commit, synchronous before dispatch) ---
-    // Block mode: the lead was born held (dnc_pending). Check, then release-on-clear (which
-    // fires its own first lead.created) or keep held (dnc_registered) — so the normal
-    // lead.created below stays suppressed (quarantined). Flag mode: check + record so the
-    // lead.created payload below carries the result; the lead delivers regardless.
-    if (dncHeld) {
-      await d.gateHeldDncLead(prospect).catch((err) =>
-        d.logger.error('[DNC] gate error', { error: err?.message || String(err) })
-      );
-    } else if (dncFlagApplies) {
-      await d
-        .dncCheckAndRecord(prospect)
-        .catch((err) => d.logger.error('[DNC] check error', { error: err?.message || String(err) }));
-    }
-
-    // --- Webhook dispatch (AFTER transaction commits, fire-and-forget) ---
-    // Always load the assigned agent's provenance (lyfeId/mktrLeadsId) by id — NOT
-    // the possibly-partial resolvedAgent from QR/group routing, which lacks it — so
-    // we route to the right app and send the destination-correct external id.
-    let agentForWebhook = null;
-    let leadDestination = null;
-    if (assignedAgentId) {
-      const agentRecord = await m.User.findByPk(assignedAgentId, {
-        attributes: ['id', 'lyfeId', 'mktrLeadsId', 'phone', 'email', 'firstName', 'lastName'],
-      });
-      if (agentRecord) {
-        leadDestination = destinationForAgent(agentRecord);
-        agentForWebhook = {
-          phone: agentRecord.phone || resolvedAgent?.phone || null,
-          email: agentRecord.email || resolvedAgent?.email || null,
-          name: `${agentRecord.firstName || ''} ${agentRecord.lastName || ''}`.trim() || resolvedAgent?.name || null,
-          id: externalIdForDestination(agentRecord, leadDestination),
-        };
-      }
-    }
-
-    // Suppress the Lyfe 'lead.created' delivery webhook when there is no internal
-    // agent to deliver to:
-    //  - quarantined (held under lead quota) — no agent yet; it fires on release
-    //    (slice 4) as the first lead.created.
-    //  - external (MKTR Leads) — the existing subscriber is the Lyfe app, and an
-    //    external buyer lead must NEVER be dispatched to it (no external subscriber
-    //    exists yet; destination-aware routing lands later in webhookService).
-    if (!quarantined && !externalAgentId) {
-      d.dispatchEvent('lead.created', () =>
-        buildLeadCreatedPayload(
-          prospect,
-          routingMode,
-          agentForWebhook,
-          assignedAgentId,
-          sourceCampaign,
-          sourceQrTag,
-          agentGroup
-        ),
-        { destination: leadDestination }
-      ).catch((err) => {
-        d.logger.error('[Webhook] dispatch error', { error: err?.message || String(err) });
-      });
-      // Suppressed-person new-lead propagation rides webhookService's
-      // flush-time catchup choke point (tracker "propagate") — no per-site
-      // hook needed here.
-    }
-
-    // Held (no_funded_agent) → ping the mktr-leads admin held queue so a pending
-    // lead is never silent. ONLY this reason: the external (no_funded_external_buyer)
-    // hold is a DIFFERENT, fenced pool that is NOT in that admin queue, so it must
-    // not ping. Gated by HELD_LEAD_PING_ENABLED; the sweep is the completeness net.
-    if (
-      quarantined &&
-      heldReason === 'no_funded_agent' &&
-      String(process.env.HELD_LEAD_PING_ENABLED || 'false').toLowerCase() === 'true'
-    ) {
-      d.dispatchEvent('lead.held', () => buildLeadHeldPayload(prospect, sourceCampaign, heldReason), {
-        destination: 'mktr_leads',
-      }).catch((err) => {
-        d.logger.error('[Webhook] lead.held dispatch error', { error: err?.message || String(err) });
-      });
-    }
-
-    // em/ph gate for every submit-time CAPI dispatch (Meta + TikTok), derived
-    // from the consent ledger ONCE — the capture txn just committed, so the
-    // capture-hook contact event (with its OTP `verified` stamp) is visible.
-    // FAIL CLOSED on any lookup error: the events still fire, without em/ph.
-    // The stored consent_contact boolean keeps being WRITTEN at capture
-    // (evidence/backfill) but is no longer read here (3sites).
-    let capiMarketingConsent = false;
-    try {
-      capiMarketingConsent = (await d.canMarketTo({
-        consumerId: prospect.consumerId || null,
-        phone: prospect.phone || null,
-        channel: 'all',
-        campaignId: prospect.campaignId || null,
-      })) === true;
-    } catch (err) {
-      d.logger.warn('[CAPI] canMarketTo failed — omitting em/ph (fail-closed)', {
-        error: err?.message || String(err),
-      });
-    }
-
-    // Meta CAPI dispatch (fire-and-forget; post-commit; guard inside sendLeadEvent)
-    d.sendLeadEvent(prospect, {
+    // --- DISPATCH: everything post-commit ---
+    // The body lives in prospectDispatch.js (P3-1): DNC scrubbing, the Lyfe
+    // webhook + held ping, the Meta/TikTok CAPI pairs, the Redeem Ops hook, the
+    // enrichment drain, the share link and the screening dial. All of it is
+    // fire-and-forget by rule, and its statement order is load-bearing.
+    const { assignedAgent, prospectWithCampaign, shareUrl, leadCapturedOutcome } = await runDispatch({
+      prospect,
+      quarantined,
+      heldReason,
+      assignedAgentId,
+      dncHeld,
+      dncFlagApplies,
+      screeningHeld,
+      externalAgentId,
+      sourceCampaign,
+      sourceQrTag,
+      resolvedAgent,
+      agentGroup,
+      routingMode,
       eventId,
+      registrationEventId,
+      eventSourceUrl,
       fbp,
       fbc,
-      eventSourceUrl,
-      clientIp,
-      clientUserAgent,
-      pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
-      marketingConsent: capiMarketingConsent,
-    }).catch((err) => {
-      d.logger.error('[CAPI] sendLeadEvent error', { error: err?.message || String(err) });
-    });
-
-    // Meta CAPI CompleteRegistration (quiz funnel). Fired server-side only when
-    // the browser sent a registrationEventId (the quiz reveal happened), using
-    // that same id so Meta dedups it against the Pixel CompleteRegistration fired
-    // at the reveal. No-op for non-quiz leads. Guard inside sendCompleteRegistrationEvent.
-    if (registrationEventId) {
-      d.sendCompleteRegistrationEvent(prospect, {
-        eventId: registrationEventId,
-        fbp,
-        fbc,
-        eventSourceUrl,
-        clientIp,
-        clientUserAgent,
-        pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
-        marketingConsent: capiMarketingConsent,
-      }).catch((err) => {
-        d.logger.error('[CAPI] sendCompleteRegistrationEvent error', { error: err?.message || String(err) });
-      });
-    }
-
-    // TikTok Events API dispatch (fire-and-forget; post-commit; guard inside the
-    // sender). Mirrors the Meta CAPI pair: a Lead at submit, plus a
-    // CompleteRegistration when the quiz reveal fired one — each deduped against
-    // the browser ttq pixel via the shared event ids. Per-campaign tiktokPixelId
-    // overrides env TIKTOK_PIXEL_ID.
-    const tiktokCtxBase = {
       ttclid,
       ttp,
-      eventSourceUrl,
       clientIp,
       clientUserAgent,
-      pixelIdOverride: sourceCampaign?.tiktokPixelId || undefined,
-      marketingConsent: capiMarketingConsent,
-    };
-    d.sendTikTokLeadEvent(prospect, { eventId, ...tiktokCtxBase }).catch((err) => {
-      d.logger.error('[TikTok] sendTikTokLeadEvent error', { error: err?.message || String(err) });
     });
-    if (registrationEventId) {
-      d.sendTikTokCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...tiktokCtxBase }).catch((err) => {
-        d.logger.error('[TikTok] sendTikTokCompleteRegistrationEvent error', { error: err?.message || String(err) });
-      });
-    }
-
-    // Redeem Ops reward-entitlement hook — post-commit, fire-and-forget (a
-    // Redeem Ops failure must never fail or slow lead capture). No-op unless
-    // bootstrap registered the callback (module flag on). Idempotent downstream
-    // via the unique (activationId, prospectId) anchor.
-    // Screening holds ARE reward-eligible (plan D8): the consumer earned the
-    // signup reward by verified signup — screening gates AGENT delivery, not
-    // consumer rewards. Quota/DNC/external holds stay excluded as before.
-    // The hook's ISSUANCE result is kept as an always-resolving promise for the
-    // caller: the controller chains the confirmation email on it so a queued
-    // merged draw email (drawEmailQueued) suppresses the near-duplicate generic
-    // confirmation — an observed outcome, never a prediction, so a skip can
-    // never orphan a signup with zero emails. Still fire-and-forget for the
-    // capture path itself (errors resolve to null, logged as before).
-    let leadCapturedOutcome = null;
-    if (!quarantined || heldReason === 'screening_pending') {
-      try {
-        const hookResult = d.onLeadCaptured?.(prospect);
-        if (hookResult && typeof hookResult.then === 'function') {
-          leadCapturedOutcome = hookResult.catch((err) => {
-            d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
-            return null;
-          });
-        } else if (hookResult != null) {
-          leadCapturedOutcome = Promise.resolve(hookResult);
-        }
-      } catch (err) {
-        d.logger.error('[RedeemOps] onLeadCaptured error', { error: err?.message || String(err) });
-      }
-    }
-
-    // Enrichment: opportunistic post-commit drain of the map-job outbox —
-    // fire-and-forget (the job row is already durable; the sweep re-drains).
-    d.drainMapJobs({ limit: 5 }).catch((err) => {
-      d.logger.warn('[enrichment] post-capture drain failed', { error: err?.message || String(err) });
-    });
-
-    // Pre-load agent + prospect-with-campaign for the caller's fire-and-forget
-    // email side-effects. The campaign's design_config.customerHost drives the
-    // confirmation-email brand, so load the campaign (with design_config) for
-    // EVERY prospect — not only when an agent is assigned.
-    let assignedAgent = null;
-    if (assignedAgentId) {
-      assignedAgent = await m.User.findByPk(assignedAgentId);
-    }
-    const prospectWithCampaign =
-      (await m.Prospect.findByPk(prospect.id, {
-        include: [{ association: 'campaign', attributes: ['id', 'name', 'design_config'] }],
-      })) || prospect;
-
-    // Mint the prospect's ONE canonical referral share link now, on the campaign's
-    // canonical host, so the confirmation email and the SPA share dialog hand out the
-    // identical /share/{slug}. Non-blocking: a failure must never break lead creation —
-    // the email + SPA fall back to the long ?ref= URL. Injected via deps so DI unit tests
-    // can stub it (keeps them DB-free).
-    let shareUrl = null;
-    const shareCampaignId = prospect.campaignId;
-    if (shareCampaignId) {
-      try {
-        const hostChoice = normalizeCustomerHostChoice(
-          prospectWithCampaign?.campaign?.design_config?.customerHost
-        );
-        const origin = customerHostOrigin(hostChoice);
-        const { url } = await d.getOrCreateProspectShareLink({
-          prospectId: prospect.id,
-          campaignId: shareCampaignId,
-          origin,
-        });
-        shareUrl = `${origin}${url}`;
-      } catch (err) {
-        d.logger.warn('Referral share link mint failed (non-blocking)', {
-          prospectId: prospect.id,
-          err: err?.message,
-        });
-      }
-    }
-
-    // AI screening dial trigger (plan §5.3) — LAST on purpose: after the CAPI
-    // dispatches (capture-time events must see the prospect exactly as today)
-    // and the entitlement hook. Fire-and-forget; any failure leaves the held
-    // row for the sweep. DNC-held leads are NOT triggered here — dncGate hands
-    // off and dials on clear (§6).
-    // SCHEDULE, don't dial: the first attempt waits cfg.dialDelaySeconds so the
-    // consumer can read the success page's "an automated call is coming" notice
-    // before their phone rings (§7.1a).
-    if (screeningHeld) {
-      d.scheduleScreeningAttempt(prospect, { campaign: sourceCampaign }).catch((err) =>
-        d.logger.error('[Screening] capture dial trigger error', { error: err?.message || String(err) })
-      );
-    }
 
     return { prospect, assignedAgentId, assignedAgent, prospectWithCampaign, quarantined, shareUrl, leadCapturedOutcome };
   }

--- a/backend/test/unit/prospectCreateStages.test.js
+++ b/backend/test/unit/prospectCreateStages.test.js
@@ -1,0 +1,274 @@
+/**
+ * P3-1: the two stages extracted out of createProspect, exercised directly.
+ *
+ * This coverage could not exist before the refactor. Both stages were closures
+ * inside a ~1,200-line function, reaching ~20 enclosing variables each, so the
+ * only way to reach either one was to drive a full HTTP capture against a real
+ * Postgres. Now they are DI factories with a named ctx, and the decisions that
+ * matter — gate precedence, hold bookkeeping, dispatch suppression — can be
+ * asserted with stubs and no database.
+ *
+ * The behaviour asserted here is the behaviour that already existed; these are
+ * characterization tests pinning it in place, which is what makes the next
+ * decomposition step safe.
+ */
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { makeCreateTxRunner } from '../../src/services/prospectCreateTx.js';
+import { makeDispatchRunner } from '../../src/services/prospectDispatch.js';
+
+const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn() };
+
+/** A transaction stub that just runs the callback — no savepoints, no database. */
+const fakeTransaction = (a, b) => (typeof a === 'function' ? a('t') : b('sp'));
+
+function txDeps(overrides = {}) {
+  const created = [];
+  const activities = [];
+  const d = {
+    sequelize: { transaction: fakeTransaction, literal: (s) => ({ literal: s }) },
+    decideAssignment: jest.fn().mockResolvedValue({ action: 'assign', assignedAgentId: 'agent-1', charged: false }),
+    chargeLeadCredit: jest.fn(),
+    resolveConsumerForCaptureTx: jest.fn().mockResolvedValue('consumer-1'),
+    recordCaptureConsentEventsTx: jest.fn().mockResolvedValue(undefined),
+    buildFactSnapshot: jest.fn().mockReturnValue({ facts: [] }),
+    enqueueMapJobsTx: jest.fn().mockResolvedValue(undefined),
+    deductLeadCredit: jest.fn().mockResolvedValue(undefined),
+    deductExternalLeadBalance: jest.fn().mockResolvedValue(true),
+    AppError: class extends Error {},
+    logger,
+    ...overrides,
+  };
+  const m = {
+    User: { findByPk: jest.fn().mockResolvedValue(null) },
+    Prospect: {
+      create: jest.fn(async (attrs) => {
+        const row = { id: 'p-1', ...attrs };
+        created.push(row);
+        return row;
+      }),
+    },
+    ProspectActivity: { create: jest.fn(async (a) => { activities.push(a); return a; }) },
+  };
+  return { d, m, created, activities };
+}
+
+const baseCtx = {
+  incoming: { campaignId: 'c-1', phone: '6591234567', leadSource: 'website' },
+  user: { id: 'u-1' },
+  sourceCampaign: { name: 'Camp' },
+  sourceQrTag: null,
+  assignedAgentId: 'agent-1',
+  externalAgentId: null,
+  externalHold: false,
+  externalHoldReason: null,
+  routeVia: 'direct',
+  dncBlockApplies: false,
+  dncWillCheck: false,
+  screeningWanted: false,
+  otpMarkerLive: true,
+  eventSourceUrl: null,
+  consentContact: true,
+  consentTerms: true,
+  consentCopyVersion: '2026-07-21',
+  externalConsent: null,
+  dncConsent: null,
+  acceptedProfileFacts: [],
+};
+
+describe('createProspect PERSIST stage (unit)', () => {
+  it('assigns and reports the committed agent when nothing gates the lead', async () => {
+    const { d, m } = txDeps();
+    const out = await makeCreateTxRunner({ d, m })(baseCtx);
+
+    expect(out.quarantined).toBe(false);
+    expect(out.heldReason).toBeNull();
+    expect(out.finalAgentId).toBe('agent-1');
+    expect(out.prospect.assignedAgentId).toBe('agent-1');
+    expect(out.prospect.consumerId).toBe('consumer-1');
+    expect(d.deductLeadCredit).toHaveBeenCalled();
+  });
+
+  it('holds for DNC and stashes the intended agent on the row', async () => {
+    const { d, m } = txDeps();
+    // bakeHoldTargetAgentId reads User.findByPk to decide whether to keep the id.
+    m.User.findByPk = jest.fn().mockResolvedValue({ id: 'agent-1', isActive: true, role: 'agent' });
+
+    const out = await makeCreateTxRunner({ d, m })({ ...baseCtx, dncBlockApplies: true, dncWillCheck: true });
+
+    expect(out.quarantined).toBe(true);
+    expect(out.heldReason).toBe('dnc_pending');
+    expect(out.finalAgentId).toBeNull();
+    expect(out.dncHeld).toBe(true);
+    expect(out.prospect.dncStatus).toBe('pending');
+    expect(out.prospect.dncMetadata).toMatchObject({ alreadyCharged: false });
+    // A held lead is not delivered, so it is not charged here either.
+    expect(d.deductLeadCredit).not.toHaveBeenCalled();
+  });
+
+  it('lets the DNC hold win over the screening hold when both apply', async () => {
+    // The order is load-bearing: never dial a number that has not been scrubbed
+    // (plan §6). dncGate hands off to screening once the number comes back clear.
+    const { d, m } = txDeps();
+    m.User.findByPk = jest.fn().mockResolvedValue({ id: 'agent-1', isActive: true, role: 'agent' });
+
+    const out = await makeCreateTxRunner({ d, m })({
+      ...baseCtx, dncBlockApplies: true, dncWillCheck: true, screeningWanted: true,
+    });
+
+    expect(out.heldReason).toBe('dnc_pending');
+    expect(out.dncHeld).toBe(true);
+    expect(out.screeningHeld).toBe(false);
+  });
+
+  it('holds an external-eligible lead with no funded buyer, and never charges it', async () => {
+    const { d, m } = txDeps();
+
+    const out = await makeCreateTxRunner({ d, m })({
+      ...baseCtx, externalHold: true, externalHoldReason: 'no_funded_external_buyer',
+    });
+
+    expect(out.heldReason).toBe('no_funded_external_buyer');
+    expect(out.finalAgentId).toBeNull();
+    // The internal quota gate must not even be consulted for the external path.
+    expect(d.decideAssignment).not.toHaveBeenCalled();
+    expect(d.deductExternalLeadBalance).not.toHaveBeenCalled();
+  });
+
+  it('aborts the whole create when an external buyer cannot be charged', async () => {
+    // The one place capture is allowed to fail: handing a paid lead to a buyer
+    // we could not bill would give away inventory.
+    const { d, m } = txDeps({ deductExternalLeadBalance: jest.fn().mockResolvedValue(false) });
+
+    await expect(
+      makeCreateTxRunner({ d, m })({ ...baseCtx, externalAgentId: 'buyer-1' })
+    ).rejects.toThrow(/external buyer balance/i);
+  });
+
+  it('never fails capture when the enrichment outbox throws', async () => {
+    const { d, m } = txDeps({ enqueueMapJobsTx: jest.fn().mockRejectedValue(new Error('outbox down')) });
+
+    const out = await makeCreateTxRunner({ d, m })(baseCtx);
+
+    expect(out.prospect.id).toBe('p-1');
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[enrichment]'), expect.anything());
+  });
+});
+
+function dispatchDeps(overrides = {}) {
+  const d = {
+    gateHeldDncLead: jest.fn().mockResolvedValue(undefined),
+    dncCheckAndRecord: jest.fn().mockResolvedValue(undefined),
+    dispatchEvent: jest.fn().mockResolvedValue(undefined),
+    canMarketTo: jest.fn().mockResolvedValue(true),
+    sendLeadEvent: jest.fn().mockResolvedValue(undefined),
+    sendCompleteRegistrationEvent: jest.fn().mockResolvedValue(undefined),
+    sendTikTokLeadEvent: jest.fn().mockResolvedValue(undefined),
+    sendTikTokCompleteRegistrationEvent: jest.fn().mockResolvedValue(undefined),
+    onLeadCaptured: jest.fn().mockResolvedValue({ ok: true }),
+    drainMapJobs: jest.fn().mockResolvedValue(undefined),
+    getOrCreateProspectShareLink: jest.fn().mockResolvedValue({ url: '/share/abc' }),
+    scheduleScreeningAttempt: jest.fn().mockResolvedValue(undefined),
+    logger,
+    ...overrides,
+  };
+  const m = {
+    User: { findByPk: jest.fn().mockResolvedValue(null) },
+    Prospect: { findByPk: jest.fn().mockResolvedValue(null) },
+  };
+  return { d, m };
+}
+
+const prospect = { id: 'p-1', campaignId: 'c-1', phone: '6591234567', consumerId: 'consumer-1' };
+
+const dispatchCtx = {
+  prospect,
+  quarantined: false,
+  heldReason: null,
+  assignedAgentId: 'agent-1',
+  dncHeld: false,
+  dncFlagApplies: false,
+  screeningHeld: false,
+  externalAgentId: null,
+  sourceCampaign: { name: 'Camp' },
+  sourceQrTag: null,
+  resolvedAgent: null,
+  agentGroup: null,
+  routingMode: 'direct',
+  eventId: 'ev-1',
+  registrationEventId: null,
+  eventSourceUrl: null,
+  fbp: null, fbc: null, ttclid: null, ttp: null,
+  clientIp: null, clientUserAgent: null,
+};
+
+const eventsOf = (d) => d.dispatchEvent.mock.calls.map((c) => c[0]);
+
+describe('createProspect DISPATCH stage (unit)', () => {
+  it('fires lead.created and the CAPI pair for a delivered lead', async () => {
+    const { d, m } = dispatchDeps();
+    const out = await makeDispatchRunner({ d, m })(dispatchCtx);
+
+    expect(eventsOf(d)).toContain('lead.created');
+    expect(d.sendLeadEvent).toHaveBeenCalled();
+    expect(d.sendTikTokLeadEvent).toHaveBeenCalled();
+    // The host comes from the campaign's customerHost, which is env-derived here.
+    expect(out.shareUrl).toMatch(/\/share\/abc$/);
+    expect(out.leadCapturedOutcome).not.toBeNull();
+  });
+
+  it('suppresses lead.created for a quarantined lead — it fires on release instead', async () => {
+    const { d, m } = dispatchDeps();
+    await makeDispatchRunner({ d, m })({ ...dispatchCtx, quarantined: true, heldReason: 'no_funded_agent', assignedAgentId: null });
+
+    expect(eventsOf(d)).not.toContain('lead.created');
+  });
+
+  it('suppresses lead.created for an external buyer lead — the subscriber is the Lyfe app', async () => {
+    const { d, m } = dispatchDeps();
+    await makeDispatchRunner({ d, m })({ ...dispatchCtx, externalAgentId: 'buyer-1' });
+
+    expect(eventsOf(d)).not.toContain('lead.created');
+  });
+
+  it('still awards the reward on a screening hold, but not on a quota hold', async () => {
+    // Screening gates AGENT delivery, not consumer rewards (plan D8).
+    const screening = dispatchDeps();
+    await makeDispatchRunner(screening)({
+      ...dispatchCtx, quarantined: true, heldReason: 'screening_pending', screeningHeld: true, assignedAgentId: null,
+    });
+    expect(screening.d.onLeadCaptured).toHaveBeenCalled();
+    expect(screening.d.scheduleScreeningAttempt).toHaveBeenCalled();
+
+    const quota = dispatchDeps();
+    await makeDispatchRunner(quota)({
+      ...dispatchCtx, quarantined: true, heldReason: 'no_funded_agent', assignedAgentId: null,
+    });
+    expect(quota.d.onLeadCaptured).not.toHaveBeenCalled();
+  });
+
+  it('scrubs a DNC-held lead through the gate, not the flag-mode recorder', async () => {
+    const { d, m } = dispatchDeps();
+    await makeDispatchRunner({ d, m })({ ...dispatchCtx, dncHeld: true, quarantined: true, heldReason: 'dnc_pending', assignedAgentId: null });
+
+    expect(d.gateHeldDncLead).toHaveBeenCalledWith(prospect);
+    expect(d.dncCheckAndRecord).not.toHaveBeenCalled();
+    // The dial is dncGate's to make once the number comes back clear.
+    expect(d.scheduleScreeningAttempt).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on the consent lookup — events still fire, without em/ph', async () => {
+    const { d, m } = dispatchDeps({ canMarketTo: jest.fn().mockRejectedValue(new Error('ledger down')) });
+    await makeDispatchRunner({ d, m })(dispatchCtx);
+
+    expect(d.sendLeadEvent).toHaveBeenCalledWith(prospect, expect.objectContaining({ marketingConsent: false }));
+  });
+
+  it('never breaks capture when the share-link mint fails', async () => {
+    const { d, m } = dispatchDeps({ getOrCreateProspectShareLink: jest.fn().mockRejectedValue(new Error('shortlink down')) });
+    const out = await makeDispatchRunner({ d, m })(dispatchCtx);
+
+    expect(out.shareUrl).toBeNull();
+    expect(out.prospectWithCampaign).toBe(prospect);
+  });
+});


### PR DESCRIPTION
**P3-1** — `backend/src/services/prospectService.js:165-1376`

## The defect

`createProspect` had grown to ~1,200 lines by inlining every stage of lead capture into one function: meta extraction, consent, attribution, QR derivation, referral, the campaign/age/draw/DNC/screening gates, quiz + profile scoring, round-robin, a six-concern create transaction, and the whole post-commit dispatch fan-out.

## The fix

Lift out the two stages with the cleanest seams, **verbatim**:

| Stage | New module | What it owns |
|---|---|---|
| PERSIST | `prospectCreateTx.js` | The single create transaction — assignment decision, DNC/screening holds, consumer spine, prospect row, consent ledger, enrichment outbox, two activities, credit deduct, QR analytics |
| DISPATCH | `prospectDispatch.js` | Everything post-commit — DNC scrubbing, Lyfe webhook + held ping, Meta/TikTok CAPI pairs, Redeem Ops hook, enrichment drain, share link, screening dial |

Both were closures reaching ~20 enclosing variables each. Every input is now a named `ctx` field and every value the caller needs back is a named result field, so the data flow across each boundary is readable without holding the whole function in your head.

`prospectService.js` drops **1,736 → 1,307 lines**; `createProspect` drops **~1,200 → ~780**.

This follows the precedent P4-3 set on this same file (`makeProspectReads` / `makeAssignmentOps` / `makeHeldQueueOps`), and the new modules import only leaves already in this module's graph — no new cycle.

## Behaviour is unchanged

Statement order inside each stage is untouched, including the parts that are load-bearing:

- the quota → DNC → screening gate precedence (DNC wins when both apply, so no unscrubbed number is ever dialled)
- the savepoint isolation around the consumer spine and the enrichment outbox
- post-commit ordering: DNC scrubbing before the webhook, CAPI before the entitlement hook, screening dial last

The only delta: `dncIntendedAgentId` and `dncAlreadyCharged` are now locals of the persist stage. The caller declared them but never read them.

## Test proof

For a refactor, the proof is the existing suites passing **with zero test edits** — that is what the task specifies, and a fails-before/passes-after test is not constructible when no behaviour changed.

- Unit tier: **129 suites / 2,202 tests** pass
- Full integration tier: **147 suites / 2,593 tests** pass
- `npx eslint src/ test/ --quiet` clean

One caveat stated plainly: across three local full-tier runs, two different suites failed once each (`systemAgent`, then `agents` with `Parse Error: Expected HTTP/…`, a transport-level symptom). Both pass in isolation, one full run was clean at 147/147, and neither failure was an assertion about capture. I read these as local flakes under `--runInBand` with 147 suites; CI is the authoritative gate.

## New coverage

`backend/test/unit/prospectCreateStages.test.js` — 13 cases, no database. This coverage **could not exist before**: as closures, these stages were reachable only by driving a full HTTP capture against Postgres, so gate precedence, hold bookkeeping and dispatch suppression had no direct test. They are characterization tests — they pin the behaviour that already existed, which is what makes the next decomposition step safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)