### PR TITLE
feat(observability): hot-path counters + external-call latency signals (P3-5)

### DIFF
--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -214,6 +214,15 @@ export const init = async (app) => {
     });
   });
 
+  // Hot-path metrics (P3-5). Counters + latency percentiles for lead capture,
+  // webhook delivery and every external call, since this instance came up. No
+  // secrets, no PII — names and numbers only — so it sits with /health rather
+  // than behind admin auth, matching how the other diagnostics here work.
+  app.get('/health/metrics', async (req, res) => {
+    const { getMetricsSnapshot } = await import('./services/observability.js');
+    res.status(200).json(getMetricsSnapshot());
+  });
+
   // Diagnostic: which public host does the backend see this request as?
   // Used during the redeem.sg cutover to verify the Render proxy preserves
   // the original Host / X-Forwarded-Host / Origin headers as expected before

--- a/backend/src/services/observability.js
+++ b/backend/src/services/observability.js
@@ -1,6 +1,50 @@
+/**
+ * In-process metrics for the hot paths (P3-5).
+ *
+ * The backend has good structured logging and targeted Sentry, but until now
+ * nothing counted anything. Several sweeps note conditions that are only
+ * visible as an ABSENCE — "a starving rotation shows up as a persistent zero" —
+ * and an absence cannot be grepped for. You cannot notice a log line that never
+ * gets written. A counter sitting at zero, you can.
+ *
+ * This is deliberately a small in-process sink rather than a Prometheus client:
+ * no new dependency, no scrape endpoint to secure, and it answers the question
+ * the sweeps actually raise ("is this number still moving?"). Counters reset on
+ * restart, which is the honest limitation — read them as "since this instance
+ * came up", and compare snapshots rather than trusting an absolute total.
+ *
+ * READING THEM
+ *
+ *   GET /health/metrics  →  { uptimeSeconds, counters, durations }
+ *
+ * `counters` are monotonic totals; `durations` carry count / min / max / p50 /
+ * p95 / total in milliseconds. Both use a flat label suffix
+ * (`lead.held{reason=no_funded_agent}`) so a metric name stays one greppable
+ * string.
+ *
+ * WHAT TO LOOK FOR
+ *
+ *   lead.captured stuck             capture is down, or traffic stopped
+ *   lead.held{reason=…} climbing    while lead.delivered stays flat → the
+ *                                   starving rotation: leads arrive and nothing
+ *                                   routes. This is the zero the sweeps mean.
+ *   webhook.delivery.failed rising  relative to .attempted → the receiver is
+ *                                   unhealthy. webhook.delivery.duration p95
+ *                                   usually climbs first.
+ *   external.call.failed{dep=…}     an upstream (WhatsApp, Apify) is degraded
+ *                                   before anyone files a ticket.
+ */
 import { logger } from '../utils/logger.js';
 
 const counters = new Map();
+/** name → { count, total, min, max, samples[] }. */
+const durations = new Map();
+
+/** Newest N samples per metric, so p50/p95 stay meaningful without growing
+ *  without bound on a long-lived process. */
+const MAX_SAMPLES = 512;
+
+const startedAt = Date.now();
 
 function getSampleRate() {
   const v = parseFloat(process.env.OBS_SAMPLE_RATE || '0');
@@ -9,13 +53,64 @@ function getSampleRate() {
   return v;
 }
 
-export function incCounter(name, value = 1) {
-  const cur = counters.get(name) || 0;
-  counters.set(name, cur + value);
+/**
+ * `lead.held` + `{ reason: 'dnc_pending' }` → `lead.held{reason=dnc_pending}`.
+ * Labels are sorted so the same set always yields the same key, and empty /
+ * null values are dropped rather than becoming the string "undefined".
+ */
+export function metricKey(name, labels) {
+  if (!labels) return name;
+  const parts = Object.keys(labels)
+    .sort()
+    .filter((k) => labels[k] !== null && labels[k] !== undefined && labels[k] !== '')
+    .map((k) => `${k}=${String(labels[k])}`);
+  return parts.length ? `${name}{${parts.join(',')}}` : name;
+}
+
+export function incCounter(name, value = 1, labels = null) {
+  const key = metricKey(name, labels);
+  counters.set(key, (counters.get(key) || 0) + value);
 }
 
 export function timeMs(start) {
   return Date.now() - start;
+}
+
+/**
+ * Record a latency sample in milliseconds. Silently ignores a nonsense value:
+ * an observability call that can fail a request is worse than no observability.
+ */
+export function observeDuration(name, ms, labels = null) {
+  if (!Number.isFinite(ms) || ms < 0) return;
+  const key = metricKey(name, labels);
+  let d = durations.get(key);
+  if (!d) {
+    d = { count: 0, total: 0, min: ms, max: ms, samples: [] };
+    durations.set(key, d);
+  }
+  d.count += 1;
+  d.total += ms;
+  if (ms < d.min) d.min = ms;
+  if (ms > d.max) d.max = ms;
+  d.samples.push(ms);
+  if (d.samples.length > MAX_SAMPLES) d.samples.shift();
+}
+
+/**
+ * Time an async call, recording latency either way plus a `.failed` counter
+ * when it throws. The error is always re-thrown — this measures, never swallows.
+ */
+export async function timed(name, fn, labels = null) {
+  const start = Date.now();
+  try {
+    const out = await fn();
+    observeDuration(name, timeMs(start), labels);
+    return out;
+  } catch (err) {
+    observeDuration(name, timeMs(start), { ...(labels || {}), outcome: 'error' });
+    incCounter(`${name}.failed`, 1, labels);
+    throw err;
+  }
 }
 
 export function logEvent(name, data = {}) {
@@ -29,10 +124,45 @@ export function logEvent(name, data = {}) {
   }
 }
 
+function percentile(sorted, p) {
+  if (!sorted.length) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)];
+}
+
 export function getCountersSnapshot() {
   const obj = {};
   for (const [k, v] of counters.entries()) obj[k] = v;
   return obj;
 }
 
+export function getDurationsSnapshot() {
+  const obj = {};
+  for (const [k, d] of durations.entries()) {
+    const sorted = [...d.samples].sort((a, b) => a - b);
+    obj[k] = {
+      count: d.count,
+      totalMs: d.total,
+      minMs: d.min,
+      maxMs: d.max,
+      p50Ms: percentile(sorted, 50),
+      p95Ms: percentile(sorted, 95),
+    };
+  }
+  return obj;
+}
 
+/** Everything GET /health/metrics serves. */
+export function getMetricsSnapshot() {
+  return {
+    uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+    counters: getCountersSnapshot(),
+    durations: getDurationsSnapshot(),
+  };
+}
+
+/** Tests only — the process itself never resets. */
+export function resetMetrics() {
+  counters.clear();
+  durations.clear();
+}

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -83,6 +83,7 @@ import {
 } from './prospectHelpers.js';
 import { scoreQuiz } from './quizScoringService.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
+import { incCounter } from './observability.js';
 
 
 const defaultDeps = {
@@ -895,6 +896,14 @@ export function makeProspectService(overrides = {}) {
     }
 
     const { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld } = txOutcome;
+
+    // Hot-path signals (P3-5). Every capture lands here exactly once, after the
+    // row commits, so these three answer "are leads arriving, and are they
+    // getting to anyone?" — held climbing while delivered stays flat IS the
+    // starving rotation the sweeps describe as a persistent zero.
+    incCounter('lead.captured', 1, { source: incoming.leadSource || 'unknown' });
+    if (quarantined) incCounter('lead.held', 1, { reason: heldReason || 'unknown' });
+    else incCounter('lead.delivered', 1, { external: externalAgentId ? 'yes' : 'no' });
 
     // Reflect the committed outcome (null when quarantined) for the rest of the
     // function — webhook dispatch, agent load, and the returned payload.

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -4,6 +4,7 @@ import { WebhookSubscriber, WebhookDelivery, sequelize } from '../models/index.j
 import { logger } from '../utils/logger.js';
 import { signWebhookAttempt, signatureVersionForSubscriber } from './webhookSigning.js';
 import { Sentry } from '../utils/sentryInit.js';
+import { incCounter, observeDuration, timeMs } from './observability.js';
 
 const AUTO_DISABLE_THRESHOLD = 50;
 
@@ -270,6 +271,12 @@ export function makeWebhookService(overrides = {}) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
 
+    // Delivery latency + outcome (P3-5). The clock starts at the SEND, not at
+    // the claim — a slow claim is a database problem, not a receiver problem,
+    // and conflating them makes p95 unreadable.
+    const sentAt = Date.now();
+    incCounter('webhook.delivery.attempted', 1, { event: delivery.eventType });
+
     try {
       const headers = {
         'Content-Type': 'application/json',
@@ -288,6 +295,9 @@ export function makeWebhookService(overrides = {}) {
       });
 
       clearTimeout(timeout);
+      observeDuration('webhook.delivery.duration', timeMs(sentAt), {
+        event: delivery.eventType, outcome: response.ok ? 'ok' : 'http_error',
+      });
 
       if (response.ok) {
         await delivery.update({
@@ -312,6 +322,11 @@ export function makeWebhookService(overrides = {}) {
       }
     } catch (err) {
       clearTimeout(timeout);
+      // A timeout is its own outcome: it is the shape a dying receiver takes,
+      // and it looks nothing like an HTTP error in the latency distribution.
+      observeDuration('webhook.delivery.duration', timeMs(sentAt), {
+        event: delivery.eventType, outcome: err.name === 'AbortError' ? 'timeout' : 'network_error',
+      });
 
       await handleFailure(delivery, subscriber, {
         responseCode: null,
@@ -322,6 +337,10 @@ export function makeWebhookService(overrides = {}) {
   }
 
   async function handleFailure(delivery, subscriber, { responseCode, responseBody, errorMessage }) {
+    // Every failed attempt funnels through here — HTTP error, timeout and
+    // network error alike — so this is the one honest failure count. Read it
+    // against webhook.delivery.attempted, not on its own.
+    incCounter('webhook.delivery.failed', 1, { event: delivery.eventType });
     // The claim already incremented `attempts` for a real row; an injected fake
     // (no reload()) never went through it, so it still counts its own.
     const claimed = delivery.status === 'sending';

--- a/backend/src/utils/externalFetch.js
+++ b/backend/src/utils/externalFetch.js
@@ -16,6 +16,7 @@
  * as-is for the caller to handle; retrying it just spends quota to be told the
  * same thing.
  */
+import { incCounter, observeDuration } from '../services/observability.js';
 
 /** Long enough for a slow-but-alive provider, short enough that a hang is not a hostage. */
 export const DEFAULT_TIMEOUT_MS = 12_000;
@@ -65,15 +66,33 @@ export async function retryingFetch(fetchImpl, url, opts = {}, {
   logger = noopLogger,
   logPrefix = 'external_fetch',
 } = {}) {
+  // Every external call — WhatsApp Graph and Apify both — comes through here
+  // (P2-1 unified the transport), so this is the one place that can measure
+  // them, and `logPrefix` already names the dependency (P3-5).
+  //
+  // The clock covers the WHOLE call including retries and backoff sleeps: that
+  // is the latency the caller actually waited, and a dependency that only
+  // succeeds on its third attempt is degraded even though each attempt looks
+  // fine on its own.
+  const startedAt = Date.now();
+  const dep = { dep: logPrefix, label: label || 'unlabelled' };
+
   let lastErr;
   for (let i = 1; i <= attempts; i += 1) {
     try {
       const res = await fetchWithTimeout(fetchImpl, url, opts, { timeoutMs, label });
       if (res.status >= 500 && i < attempts) {
         logger.warn(`${logPrefix}.retry_5xx`, { label, status: res.status, attempt: i });
+        incCounter('external.call.retried', 1, { ...dep, cause: '5xx' });
         await sleep(300 * i);
         continue;
       }
+      // 4xx is a deterministic answer, not a fault of the dependency — it is
+      // recorded as a completed call so a bad template cannot masquerade as an
+      // outage. Only exhausted retries below count as failed.
+      observeDuration('external.call.duration', Date.now() - startedAt, {
+        ...dep, outcome: res.ok ? 'ok' : 'http_error',
+      });
       return res; // ok or 4xx — caller decides
     } catch (err) {
       lastErr = err;
@@ -81,10 +100,13 @@ export async function retryingFetch(fetchImpl, url, opts = {}, {
         logger.warn(`${logPrefix}.retry_network`, {
           label, error: err?.message, timeout: Boolean(err?.timeout), attempt: i,
         });
+        incCounter('external.call.retried', 1, { ...dep, cause: err?.timeout ? 'timeout' : 'network' });
         await sleep(300 * i);
         continue;
       }
     }
   }
+  observeDuration('external.call.duration', Date.now() - startedAt, { ...dep, outcome: 'failed' });
+  incCounter('external.call.failed', 1, { ...dep, cause: lastErr?.timeout ? 'timeout' : 'network' });
   throw lastErr;
 }

--- a/backend/test/hotPathMetrics.test.js
+++ b/backend/test/hotPathMetrics.test.js
@@ -1,0 +1,230 @@
+/**
+ * P3-5: the hot-path counters actually move.
+ *
+ * The gap this closes is that several conditions in this system are only
+ * visible as an ABSENCE. "A starving rotation shows up as a persistent zero" —
+ * and you cannot grep for a log line that never got written. These signals turn
+ * that into a number you can watch.
+ *
+ * So the tests that matter are the ones proving the numbers move on the real
+ * paths: a capture increments capture, a held lead increments held and NOT
+ * delivered, a webhook attempt records a latency sample, and an exhausted
+ * external call is counted as failed while a 4xx is not.
+ */
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  incCounter, observeDuration, resetMetrics, metricKey,
+  getCountersSnapshot, getDurationsSnapshot, getMetricsSnapshot,
+} from '../src/services/observability.js';
+import { retryingFetch } from '../src/utils/externalFetch.js';
+import { randomUUID } from 'crypto';
+import { WebhookSubscriber, WebhookDelivery } from '../src/models/index.js';
+import { makeWebhookService } from '../src/services/webhookService.js';
+
+let app, admin, campaign, subscriber;
+const silent = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  campaign = await createTestCampaign(admin.user.id, { name: 'Metrics Campaign' });
+  subscriber = await WebhookSubscriber.create({
+    name: 'Metrics Receiver', url: 'https://receiver.test/hook', secret: 'shhh',
+    events: ['lead.created'], enabled: true,
+  });
+});
+
+afterAll(async () => {
+  await WebhookDelivery.destroy({ where: { subscriberId: subscriber.id } });
+  await subscriber.destroy();
+  await closeDb();
+});
+
+/** A delivery ready to send, so attemptDelivery does the real thing. */
+const pendingDelivery = (over = {}) => WebhookDelivery.create({
+  subscriberId: subscriber.id, deliveryId: randomUUID(), eventType: 'lead.created',
+  payload: { event: 'lead.created', data: { id: 'lead-1' } },
+  status: 'pending', attempts: 0, maxAttempts: 1, ...over,
+});
+
+describe('webhook delivery records latency and outcome', () => {
+  beforeEach(() => resetMetrics());
+
+  it('counts an attempt and times a successful send', async () => {
+    const row = await pendingDelivery();
+    const svc = makeWebhookService({
+      logger: silent,
+      fetch: async () => ({ ok: true, status: 200, text: async () => 'ok' }),
+    });
+
+    await svc.attemptDelivery(row, subscriber);
+
+    const c = getCountersSnapshot();
+    expect(c['webhook.delivery.attempted{event=lead.created}']).toBe(1);
+    expect(c['webhook.delivery.failed{event=lead.created}']).toBeUndefined();
+    expect(getDurationsSnapshot()['webhook.delivery.duration{event=lead.created,outcome=ok}'].count).toBe(1);
+  });
+
+  it('separates a timeout from an HTTP error in the latency distribution', async () => {
+    // A dying receiver times out; a broken one 500s. They need different rows
+    // or p95 tells you nothing about which is happening.
+    const httpRow = await pendingDelivery();
+    await makeWebhookService({
+      logger: silent,
+      fetch: async () => ({ ok: false, status: 500, text: async () => 'boom' }),
+    }).attemptDelivery(httpRow, subscriber);
+
+    const abortRow = await pendingDelivery();
+    await makeWebhookService({
+      logger: silent,
+      fetch: async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; },
+    }).attemptDelivery(abortRow, subscriber);
+
+    const d = getDurationsSnapshot();
+    expect(d['webhook.delivery.duration{event=lead.created,outcome=http_error}'].count).toBe(1);
+    expect(d['webhook.delivery.duration{event=lead.created,outcome=timeout}'].count).toBe(1);
+    // Both funnel through handleFailure, so the failure count sees both.
+    expect(getCountersSnapshot()['webhook.delivery.failed{event=lead.created}']).toBe(2);
+  });
+});
+
+describe('the metrics sink', () => {
+  beforeEach(() => resetMetrics());
+
+  it('renders labels as a stable, greppable suffix', () => {
+    // Sorted, so the same label set is always the same key — otherwise the
+    // "same" metric splits into two rows and both look half as busy.
+    expect(metricKey('lead.held', { reason: 'dnc_pending' })).toBe('lead.held{reason=dnc_pending}');
+    expect(metricKey('x', { b: 2, a: 1 })).toBe('x{a=1,b=2}');
+    expect(metricKey('x', null)).toBe('x');
+  });
+
+  it('drops empty labels instead of writing the word undefined', () => {
+    expect(metricKey('x', { a: 1, b: undefined, c: null, d: '' })).toBe('x{a=1}');
+  });
+
+  it('accumulates counters per label set', () => {
+    incCounter('lead.held', 1, { reason: 'no_funded_agent' });
+    incCounter('lead.held', 1, { reason: 'no_funded_agent' });
+    incCounter('lead.held', 1, { reason: 'dnc_pending' });
+
+    expect(getCountersSnapshot()).toMatchObject({
+      'lead.held{reason=no_funded_agent}': 2,
+      'lead.held{reason=dnc_pending}': 1,
+    });
+  });
+
+  it('summarises latency rather than keeping every sample forever', () => {
+    for (const ms of [10, 20, 30, 40, 100]) observeDuration('webhook.delivery.duration', ms);
+
+    const d = getDurationsSnapshot()['webhook.delivery.duration'];
+    expect(d).toMatchObject({ count: 5, minMs: 10, maxMs: 100, totalMs: 200 });
+    expect(d.p50Ms).toBe(30);
+    expect(d.p95Ms).toBe(100);
+  });
+
+  it('ignores a nonsense duration instead of poisoning the metric', () => {
+    // Observability must never be able to break the thing it observes.
+    observeDuration('x', NaN);
+    observeDuration('x', -5);
+    observeDuration('x', undefined);
+    expect(getDurationsSnapshot().x).toBeUndefined();
+  });
+});
+
+describe('lead capture increments the capture counters', () => {
+  beforeEach(() => resetMetrics());
+
+  it('counts a delivered lead as captured AND delivered, never held', async () => {
+    const res = await request(app)
+      .post('/api/prospects')
+      .send({
+        firstName: 'Metric', lastName: 'Lead', phone: '+6591234501',
+        email: 'metric1@test.com', campaignId: campaign.id, leadSource: 'website',
+        consent_contact: true, consent_terms: true,
+      });
+    expect(res.status).toBeLessThan(300);
+
+    const c = getCountersSnapshot();
+    expect(c['lead.captured{source=website}']).toBe(1);
+    // Exactly one of delivered/held fires — they partition every capture, which
+    // is what makes "held climbing while delivered is flat" readable.
+    const delivered = Object.entries(c).filter(([k]) => k.startsWith('lead.delivered'));
+    const held = Object.entries(c).filter(([k]) => k.startsWith('lead.held'));
+    expect(delivered.length + held.length).toBe(1);
+  });
+
+  it('labels the counter with the lead source', async () => {
+    await request(app)
+      .post('/api/prospects')
+      .send({
+        firstName: 'Metric', lastName: 'Two', phone: '+6591234502',
+        email: 'metric2@test.com', campaignId: campaign.id, leadSource: 'qr_code',
+        consent_contact: true, consent_terms: true,
+      });
+
+    expect(getCountersSnapshot()['lead.captured{source=qr_code}']).toBe(1);
+  });
+});
+
+describe('external calls are measured at the shared transport', () => {
+  beforeEach(() => resetMetrics());
+
+  const okRes = { ok: true, status: 200 };
+
+  it('records latency for a successful call, and no failure', async () => {
+    await retryingFetch(async () => okRes, 'https://example.test/x', {}, { label: 'message_send', logPrefix: 'wa_graph' });
+
+    const d = getDurationsSnapshot();
+    expect(d['external.call.duration{dep=wa_graph,label=message_send,outcome=ok}'].count).toBe(1);
+    expect(Object.keys(getCountersSnapshot())).toHaveLength(0);
+  });
+
+  it('does NOT count a 4xx as a dependency failure', async () => {
+    // A bad template is our bug, not an outage. Counting it as failed would
+    // make a deterministic config error look like Meta going down.
+    await retryingFetch(async () => ({ ok: false, status: 400 }), 'https://example.test/x', {}, { label: 'message_send', logPrefix: 'wa_graph' });
+
+    const c = getCountersSnapshot();
+    expect(Object.keys(c).filter((k) => k.startsWith('external.call.failed'))).toHaveLength(0);
+    expect(getDurationsSnapshot()['external.call.duration{dep=wa_graph,label=message_send,outcome=http_error}'].count).toBe(1);
+  });
+
+  it('counts an exhausted call as failed, and its retries on the way', async () => {
+    const boom = async () => { const e = new Error('ECONNRESET'); throw e; };
+
+    await expect(
+      retryingFetch(boom, 'https://example.test/x', {}, {
+        label: 'startRun', logPrefix: 'apify', attempts: 3, sleep: async () => {},
+      })
+    ).rejects.toThrow('ECONNRESET');
+
+    const c = getCountersSnapshot();
+    expect(c['external.call.failed{cause=network,dep=apify,label=startRun}']).toBe(1);
+    expect(c['external.call.retried{cause=network,dep=apify,label=startRun}']).toBe(2);
+  });
+});
+
+describe('GET /health/metrics', () => {
+  it('serves the snapshot with uptime, counters and durations', async () => {
+    resetMetrics();
+    incCounter('lead.captured', 3, { source: 'website' });
+    observeDuration('webhook.delivery.duration', 42, { event: 'lead.created' });
+
+    const res = await request(app).get('/health/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    expect(res.body.counters['lead.captured{source=website}']).toBe(3);
+    expect(res.body.durations['webhook.delivery.duration{event=lead.created}']).toMatchObject({ count: 1, maxMs: 42 });
+  });
+
+  it('exposes names and numbers only — no payloads, no PII', async () => {
+    const snap = getMetricsSnapshot();
+    for (const v of Object.values(snap.counters)) expect(typeof v).toBe('number');
+    for (const v of Object.values(snap.durations)) {
+      expect(Object.values(v).every((n) => typeof n === 'number')).toBe(true);
+    }
+  });
+});

--- a/docs/reference/hot-path-metrics.md
+++ b/docs/reference/hot-path-metrics.md
@@ -1,0 +1,98 @@
+# Hot-path metrics
+
+Six signals on the paths that matter, and how to read them. Added by P3-5.
+
+## Why these exist
+
+The backend already had good structured logging and targeted Sentry. What it
+had no way to answer was **"is this still happening?"** — because several of the
+failures here are only visible as an *absence*. The review's own phrasing: *"a
+starving rotation shows up as a persistent zero."*
+
+You cannot grep for a log line that never got written. A counter sitting at zero,
+you can see.
+
+## Reading them
+
+```
+GET /health/metrics
+```
+
+```jsonc
+{
+  "uptimeSeconds": 4213,
+  "counters":  { "lead.captured{source=website}": 812, ... },
+  "durations": { "webhook.delivery.duration{event=lead.created,outcome=ok}":
+                 { "count": 790, "totalMs": 214300, "minMs": 88,
+                   "maxMs": 9900, "p50Ms": 210, "p95Ms": 940 } }
+}
+```
+
+No auth, because it carries **names and numbers only** — no payloads, no PII, no
+secrets. It sits with the other `/health/*` diagnostics.
+
+**Counters are since this instance came up.** They reset on restart and Render
+runs more than one. So compare *snapshots over time*, or watch a ratio; never
+read an absolute total as a business figure. If you want durable numbers, the
+database already has them — this is for "is the pipe flowing right now".
+
+Labels are a flat, sorted suffix (`lead.held{reason=dnc_pending}`) so a metric
+name stays one greppable string.
+
+## The signals
+
+| Metric | Labels | Emitted at |
+|---|---|---|
+| `lead.captured` | `source` | `prospectService`, post-commit, once per capture |
+| `lead.delivered` | `external` | same point, when the lead got an agent |
+| `lead.held` | `reason` | same point, when it did not |
+| `webhook.delivery.attempted` | `event` | `webhookService.attemptDelivery`, at the send |
+| `webhook.delivery.failed` | `event` | `handleFailure` — the one funnel every failed attempt passes |
+| `webhook.delivery.duration` | `event`, `outcome` | around the send: `ok` / `http_error` / `timeout` / `network_error` |
+| `external.call.duration` | `dep`, `label`, `outcome` | `utils/externalFetch` — the shared transport |
+| `external.call.retried` | `dep`, `label`, `cause` | each retry, before the backoff sleep |
+| `external.call.failed` | `dep`, `label`, `cause` | only when retries are exhausted |
+
+`lead.delivered` and `lead.held` **partition** every capture — exactly one fires.
+That is what makes the starving-rotation reading below work.
+
+## What to look for
+
+**`lead.captured` flat.** Either capture is broken or traffic stopped. Check the
+funnel before assuming the backend.
+
+**`lead.held{reason=…}` climbing while `lead.delivered` stays flat.** This is the
+starving rotation. Leads are arriving and nothing is routing them. The `reason`
+label says which gate: `no_funded_agent` (quota — fund an agent),
+`no_funded_external_buyer` (MKTR Leads buyer balance), `dnc_pending` /
+`screening_pending` (these should drain on their own; if they do not, the gate
+that releases them is stuck).
+
+**`webhook.delivery.failed` rising against `.attempted`.** The receiver is
+unhealthy. Look at `webhook.delivery.duration` p95 first — it usually climbs
+before failures start, and the `outcome` label tells you *how* it is failing:
+`timeout` is a receiver dying, `http_error` is one that is broken but answering.
+
+**`external.call.failed{dep=…}`.** An upstream is degraded — `wa_graph` for
+WhatsApp, `apify` for Discovery — usually before anyone files a ticket.
+`external.call.retried` climbing while `failed` stays at zero means the
+dependency is *flaky but recovering*: worth watching, not worth paging.
+
+A 4xx is deliberately **not** counted as a failed external call. A bad template
+is our bug, not an outage, and counting it as failure makes a deterministic
+config error look like Meta going down.
+
+## Adding a signal
+
+```js
+import { incCounter, observeDuration, timed } from '../services/observability.js';
+
+incCounter('thing.happened', 1, { kind: 'x' });
+observeDuration('thing.duration', elapsedMs, { kind: 'x' });
+await timed('thing.duration', () => doIt(), { kind: 'x' });  // records + counts failures
+```
+
+Two rules. Keep the label cardinality **low** — never a lead id, a phone or a
+UUID; each distinct combination is a permanent row in memory. And never let an
+observability call fail a request: `observeDuration` ignores nonsense input on
+purpose, and `timed` always re-throws rather than swallowing.


### PR DESCRIPTION
**P3-5** — `backend/src/services/observability.js` · request path

## The gap

The backend has good structured logging and targeted Sentry, but it counted nothing: `observability.js` existed with an `incCounter` nobody called and a snapshot nobody read.

That matters because several failures here are only visible as an **absence**. The review's own phrasing: *"a starving rotation shows up as a persistent zero."* You cannot grep for a log line that never got written. A counter sitting at zero, you can see.

## The signals

Six, each wired at the one place its path funnels through:

| Metric | Labels | Where |
|---|---|---|
| `lead.captured` | `source` | `prospectService`, post-commit, once per capture |
| `lead.delivered` | `external` | same point, when the lead got an agent |
| `lead.held` | `reason` | same point, when it did not |
| `webhook.delivery.attempted` / `.failed` | `event` | `attemptDelivery` / `handleFailure` |
| `webhook.delivery.duration` | `event`, `outcome` | around the send — `ok` / `http_error` / `timeout` / `network_error` |
| `external.call.duration` / `.retried` / `.failed` | `dep`, `label`, `cause`/`outcome` | `utils/externalFetch` |

**`delivered` and `held` partition every capture** — exactly one fires. That is what makes the starving rotation readable: *held climbing while delivered stays flat*, with the `reason` label naming which gate is stuck.

**External calls are instrumented at `utils/externalFetch`**, which P2-1 already made the single transport for both WhatsApp Graph and Apify — so one insertion point covers every external call, and `logPrefix` already names the dependency. The clock spans retries and backoff sleeps, because that is the latency the caller actually waited: a dependency that only succeeds on its third attempt is degraded even though each attempt looks fine alone.

**A 4xx is deliberately not a failed external call.** A bad template is our bug, not an outage, and counting it as failure makes a deterministic config error look like Meta going down.

## Reading them

`GET /health/metrics` → `{ uptimeSeconds, counters, durations }` with count / min / max / p50 / p95 per duration. Names and numbers only — no payloads, no PII, no secrets — so it sits with the other `/health/*` diagnostics rather than behind admin auth.

Counters reset on restart and Render runs more than one instance. `docs/reference/hot-path-metrics.md` says that plainly, and covers what each signal means when it moves — including which `lead.held` reason points at which fix.

A lightweight in-process sink rather than a Prometheus client: no new dependency, no scrape endpoint to secure, and it answers the question the sweeps actually raise.

## Test proof

`backend/test/hotPathMetrics.test.js` — 14 cases driving the **real** paths, not the primitives:

- a real HTTP `POST /api/prospects` increments `lead.captured{source=…}`, and exactly one of delivered/held
- real `attemptDelivery` calls record latency, with `timeout` and `http_error` kept in separate rows (they need to be — p95 tells you nothing about *which* is happening if they're merged)
- an exhausted external call counts as `failed` plus its retries; a 4xx counts as neither
- `observeDuration` ignores NaN/negative input, because observability must never break the thing it observes

## Verification

- Unit tier: **130 suites / 2,215 tests** pass
- Full integration tier: **149 suites / 2,614 tests** pass
- `eslint --quiet` clean, backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)