### PR TITLE
fix(observability): metric labels carrying ids leaked memory (P3-5 regression)

### DIFF
--- a/backend/src/services/observability.js
+++ b/backend/src/services/observability.js
@@ -44,6 +44,41 @@ const durations = new Map();
  *  without bound on a long-lived process. */
 const MAX_SAMPLES = 512;
 
+/**
+ * Hard cap on DISTINCT metric keys.
+ *
+ * A metric name plus its labels is a map key that lives for the life of the
+ * process, and a duration key carries up to MAX_SAMPLES numbers with it. One
+ * caller interpolating an id into a label is therefore a memory leak — and the
+ * documented "keep cardinality low" rule did not prevent exactly that: the
+ * Apify client passed `apify GET /actor-runs/${runId}`, minting a permanent key
+ * per Discovery run, and it shipped.
+ *
+ * So the rule is enforced here rather than merely written down. Past the cap we
+ * stop MINTING keys; every key already being tracked keeps updating, so the
+ * signals that matter (which are few and stable) never go blind. The overflow
+ * is counted under a fixed key and logged once, because silently dropping
+ * telemetry is its own outage.
+ */
+const MAX_KEYS = 500;
+const OVERFLOW_KEY = 'observability.keys_dropped';
+let overflowWarned = false;
+
+/** True when `key` may be created. Existing keys always pass. */
+function admitKey(map, key) {
+  if (map.has(key)) return true;
+  if (counters.size + durations.size < MAX_KEYS) return true;
+  counters.set(OVERFLOW_KEY, (counters.get(OVERFLOW_KEY) || 0) + 1);
+  if (!overflowWarned) {
+    overflowWarned = true;
+    logger.warn('[observability] metric key cap reached — new keys dropped', {
+      cap: MAX_KEYS,
+      hint: 'a label is probably carrying an id; see docs/reference/hot-path-metrics.md',
+    });
+  }
+  return false;
+}
+
 const startedAt = Date.now();
 
 function getSampleRate() {
@@ -69,6 +104,7 @@ export function metricKey(name, labels) {
 
 export function incCounter(name, value = 1, labels = null) {
   const key = metricKey(name, labels);
+  if (!admitKey(counters, key)) return;
   counters.set(key, (counters.get(key) || 0) + value);
 }
 
@@ -83,6 +119,7 @@ export function timeMs(start) {
 export function observeDuration(name, ms, labels = null) {
   if (!Number.isFinite(ms) || ms < 0) return;
   const key = metricKey(name, labels);
+  if (!admitKey(durations, key)) return;
   let d = durations.get(key);
   if (!d) {
     d = { count: 0, total: 0, min: ms, max: ms, samples: [] };
@@ -165,4 +202,5 @@ export function getMetricsSnapshot() {
 export function resetMetrics() {
   counters.clear();
   durations.clear();
+  overflowWarned = false;
 }

--- a/backend/src/services/redeemOps/discovery/apifyClient.js
+++ b/backend/src/services/redeemOps/discovery/apifyClient.js
@@ -39,6 +39,18 @@ export function makeApifyClient(overrides = {}) {
     if (!d.token) throw new Error('APIFY_TOKEN is not set');
   }
 
+/**
+ * Collapse the id segments of an Apify path so it can be used as a metric
+ * label: `/actor-runs/abc123` → `/actor-runs/:id`. Anything that looks like an
+ * id — long, or containing a digit — becomes `:id`; the fixed route words stay.
+ */
+function templatePath(path) {
+  return String(path)
+    .split('/')
+    .map((seg) => (seg.length > 24 || /\d/.test(seg) ? ':id' : seg))
+    .join('/');
+}
+
   async function call(method, path, { body, query } = {}) {
     assertConfigured();
     const url = new URL(`${d.baseUrl}${path}`);
@@ -56,7 +68,10 @@ export function makeApifyClient(overrides = {}) {
       headers: body ? { 'Content-Type': 'application/json' } : undefined,
       body: body ? JSON.stringify(body) : undefined,
     }, {
-      label: `apify ${method} ${path}`,
+      // TEMPLATED, not the real path: runId and datasetId are unique per run,
+      // and this label is a metric dimension (P3-5). Interpolating them would
+      // mint a new permanent counter+histogram per Discovery run.
+      label: `apify ${method} ${templatePath(path)}`,
       attempts: d.attempts,
       timeoutMs: d.timeoutMs,
       logger: d.logger,

--- a/backend/test/hotPathMetrics.test.js
+++ b/backend/test/hotPathMetrics.test.js
@@ -228,3 +228,56 @@ describe('GET /health/metrics', () => {
     }
   });
 });
+
+/**
+ * Round-3 regression: a label carrying an id is a memory leak.
+ *
+ * P3-5 shipped with the Apify client passing `apify GET /actor-runs/${runId}`,
+ * so every Discovery run minted a permanent counter AND a permanent histogram
+ * holding up to 512 samples. The "keep cardinality low" rule was documented and
+ * still broken within hours, so it is enforced in the sink now, not just
+ * written down.
+ */
+describe('metric key cardinality is bounded', () => {
+  beforeEach(() => resetMetrics());
+
+  it('templates ids out of the Apify label instead of interpolating them', async () => {
+    const { makeApifyClient } = await import('../src/services/redeemOps/discovery/apifyClient.js');
+    const client = makeApifyClient({
+      token: 't', baseUrl: 'https://api.test',
+      fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ data: { id: 'r1' } }) }),
+      logger: silent, sleep: async () => {},
+    });
+
+    await client.getRun('run-abcdef123456');
+    await client.getRun('run-zzzzzz999999');
+
+    // Two different runs, ONE metric key.
+    const keys = Object.keys(getDurationsSnapshot()).filter((k) => k.includes('apify'));
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain('/actor-runs/:id');
+    expect(keys[0]).not.toContain('abcdef');
+  });
+
+  it('stops minting new keys past the cap but keeps updating existing ones', () => {
+    for (let i = 0; i < 600; i += 1) incCounter('leaky', 1, { id: `id-${i}` });
+
+    const snap = getCountersSnapshot();
+    // Bounded, not unbounded.
+    expect(Object.keys(snap).length).toBeLessThanOrEqual(501);
+    // The drop is COUNTED, not silent — telemetry going blind unnoticed is its
+    // own outage.
+    expect(snap['observability.keys_dropped']).toBeGreaterThan(0);
+
+    // An already-tracked key must keep working, or the signals that matter go
+    // dead the moment some unrelated caller floods the map.
+    const before = snap['leaky{id=id-0}'];
+    incCounter('leaky', 5, { id: 'id-0' });
+    expect(getCountersSnapshot()['leaky{id=id-0}']).toBe(before + 5);
+  });
+
+  it('caps durations the same way', () => {
+    for (let i = 0; i < 600; i += 1) observeDuration('leaky.duration', 10, { id: `id-${i}` });
+    expect(Object.keys(getDurationsSnapshot()).length).toBeLessThanOrEqual(500);
+  });
+});

--- a/docs/reference/hot-path-metrics.md
+++ b/docs/reference/hot-path-metrics.md
@@ -93,6 +93,19 @@ await timed('thing.duration', () => doIt(), { kind: 'x' });  // records + counts
 ```
 
 Two rules. Keep the label cardinality **low** — never a lead id, a phone or a
-UUID; each distinct combination is a permanent row in memory. And never let an
-observability call fail a request: `observeDuration` ignores nonsense input on
-purpose, and `timed` always re-throws rather than swallowing.
+UUID; each distinct combination is a permanent row in memory, and a duration key
+drags up to 512 samples with it. And never let an observability call fail a
+request: `observeDuration` ignores nonsense input on purpose, and `timed` always
+re-throws rather than swallowing.
+
+The cardinality rule is **enforced**, not just written here: the sink caps
+distinct keys at 500. Past the cap it stops minting new keys while every
+already-tracked key keeps updating, so a flood from one careless caller can't
+blind the signals that matter. Drops are counted under
+`observability.keys_dropped` and logged once.
+
+That backstop exists because the rule alone did not work. This file shipped
+saying "never a UUID", and the Apify client was passing
+`apify GET /actor-runs/${runId}` at the same time — a permanent counter and
+histogram per Discovery run. If you are adding a label, template the ids out
+(`/actor-runs/:id`) rather than trusting yourself to remember.


### PR DESCRIPTION
**Round-3 finding — in my own change from earlier today.**

## The leak

P3-5 added `external.call.duration` / `.retried` / `.failed` at the shared transport, labelled with the caller's `label`. The Apify client passes:

```js
label: `apify ${method} ${path}`
```

and `path` carries `runId` and `datasetId` — unique per run:

```js
call('GET', `/actor-runs/${encodeURIComponent(runId)}`)
call('GET', `/datasets/${encodeURIComponent(datasetId)}/items`)
```

So **every Discovery run minted a new permanent counter and a new permanent histogram**, each holding up to 512 samples, in a long-lived Render process. Unbounded growth.

## Two fixes, because one isn't enough

**1. The caller templates ids out** — `/actor-runs/:id`, not `/actor-runs/abc123`. Two runs share one key instead of minting two.

**2. The sink caps distinct keys at 500.** Past the cap it stops *minting* keys while every already-tracked key keeps updating — so a flood from one careless caller can't blind the signals that matter — and drops are counted under `observability.keys_dropped` and logged once, because telemetry going dead unnoticed is its own outage.

## Why the backstop is the real fix

`docs/reference/hot-path-metrics.md` shipped saying *"never a lead id, a phone or a UUID; each distinct combination is a permanent row in memory"* — **in the same commit that violated it.** A rule that only lives in a doc didn't survive its own afternoon. It's enforced in code now, and the doc explains why it had to be.

## Test proof

3 regression cases, **all failing pre-fix** (verified by reverting both halves):

- the Apify label collapses two different runs to one key
- the cap holds, while an already-tracked key keeps updating
- durations cap the same way

17 metrics tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)