### PR TITLE
fix(campaign): one transaction for rail + campaign + agent assignments (H1+H5)

### DIFF
--- a/backend/src/services/campaignService.js
+++ b/backend/src/services/campaignService.js
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import { Campaign, QrTag, Prospect, CampaignAgentAssignment, sequelize } from '../models/index.js';
+import { Campaign, QrTag, Prospect, CampaignAgentAssignment, User, sequelize } from '../models/index.js';
 import { storageService } from './storage.js';
 import { buildCampaignWhere, buildOwnerWhere } from './campaignScope.js';
 import { AppError } from '../middleware/appError.js';
@@ -349,9 +349,19 @@ export async function createCampaign(body, user) {
     });
   }
 
+  // H5: the campaign row and its agent links are ONE create — a ghost or
+  // ineligible assigned_agents id aborts the whole thing with a 422 instead of
+  // committing the campaign and then dying on the join-table FK (an orphan
+  // campaign behind a 500).
   let campaign;
   try {
-    campaign = await Campaign.create(campaignData);
+    campaign = await sequelize.transaction(async (t) => {
+      const row = await Campaign.create(campaignData, { transaction: t });
+      if (assigned_agents && Array.isArray(assigned_agents) && assigned_agents.length > 0) {
+        await syncAgentAssignments(row.id, assigned_agents, t);
+      }
+      return row;
+    });
   } catch (err) {
     if (err?.name === 'SequelizeUniqueConstraintError') {
       throw new AppError('That marketplace slug is already taken by another campaign.', 409);
@@ -387,11 +397,6 @@ export async function createCampaign(body, user) {
     // Born-active draw gets its engine record too — after the doc (stamped
     // rail + pinned terms) is stored. Best-effort; the reconciler retries.
     if (campaignData.is_active) await ensureRecord({ campaignId: campaign.id, user });
-  }
-
-  // Write agent assignments to join table
-  if (assigned_agents && Array.isArray(assigned_agents) && assigned_agents.length > 0) {
-    await syncAgentAssignments(campaign.id, assigned_agents);
   }
 
   // Return with backward-compatible virtual fields for API compatibility
@@ -540,11 +545,8 @@ export async function updateCampaign(id, body, req) {
       }
     }
 
-    if (arming) {
-      const rail = await ensureRail({ campaign, designConfig: nextDoc, user: req.user });
-      const stamped = stampRailActivationId(nextDoc, rail.activationId);
-      if (stamped !== nextDoc) updateData.design_config = stamped;
-    }
+    // The ensureRail call itself rides the write transaction below (H1) so the
+    // rail can never outlive a failed save.
   }
 
   // Draw pass colourway — a NARROW, top-level field rather than a design_config
@@ -591,17 +593,34 @@ export async function updateCampaign(id, body, req) {
     }
   }
 
+  // H1 + H5: the arming rail, the campaign row, and the agent links commit or
+  // fail as ONE transaction. Pre-fix, ensureRail committed independently first
+  // (a slug-conflict 409 then left a live rail + allocated stock on a campaign
+  // that never activated), and syncAgentAssignments committed separately after
+  // (an assignment failure left a half-applied save).
   try {
-    await campaign.update(updateData);
-    // Draw record rides the arming moment, AFTER the doc (with its stamped
-    // rail + pinned terms) is stored — best-effort; the reconciler retries.
-    if (armedDraw) await ensureRecord({ campaignId: campaign.id, user: req.user });
+    await sequelize.transaction(async (t) => {
+      if (armedDraw) {
+        const nextDoc = updateData.design_config !== undefined ? updateData.design_config : campaign.design_config;
+        const rail = await ensureRail({ campaign, designConfig: nextDoc, user: req.user, transaction: t });
+        const stamped = stampRailActivationId(nextDoc, rail.activationId);
+        if (stamped !== nextDoc) updateData.design_config = stamped;
+      }
+      await campaign.update(updateData, { transaction: t });
+      if (assigned_agents !== undefined) {
+        await syncAgentAssignments(id, assigned_agents || [], t);
+      }
+    });
   } catch (err) {
     if (err?.name === 'SequelizeUniqueConstraintError') {
       throw new AppError('That marketplace slug is already taken by another campaign.', 409);
     }
     throw err;
   }
+  // Draw record rides the arming moment, AFTER the committed doc (with its
+  // stamped rail + pinned terms) is durable — best-effort by contract
+  // (ensureRecord never throws); the reconciler retries.
+  if (armedDraw) await ensureRecord({ campaignId: campaign.id, user: req.user });
   // Audit AFTER the row actually changed (Codex diff #4) — a clamp/draw-422 or
   // DB failure above must never leave a success-looking rollback entry.
   if (designRollbackApplied) {
@@ -619,11 +638,6 @@ export async function updateCampaign(id, body, req) {
   // would keep scoring under it for up to a TTL. Cheap and whole-map, like the
   // config writer's own bust.
   if (updateData.targetAudience !== undefined) bustScoringConfigCache();
-
-  // Sync agent assignments to join table when assigned_agents is provided
-  if (assigned_agents !== undefined) {
-    await syncAgentAssignments(id, assigned_agents || []);
-  }
 
   // Return with backward-compatible virtual fields for API compatibility
   const agentRows = await CampaignAgentAssignment.findAll({
@@ -720,22 +734,25 @@ export async function setCampaignLaunchState(id, state, req) {
   // readiness, never this: an armed draw with no rail is the exact silent
   // failure this exists to prevent. The promise-consistency gate (PR-3) rides
   // the same arming moment — a contradiction-carrying draw cannot launch.
-  let stampedDoc = null;
-  if (state === 'active' && drawEnabledIn(campaign.design_config)) {
-    assertDrawPromiseConsistency({
-      minAge: campaign.min_age, maxAge: campaign.max_age, designConfig: campaign.design_config,
-    });
-    const rail = await ensureRail({ campaign, designConfig: campaign.design_config, user: req.user });
-    const stamped = stampRailActivationId(campaign.design_config, rail.activationId);
-    if (stamped !== campaign.design_config) stampedDoc = stamped;
-  }
-
   const isActive = state === 'active';
-  await campaign.update({
-    is_active: isActive,
-    status: isActive ? 'active' : 'paused',
-    ...(stampedDoc ? { design_config: stampedDoc } : {}),
-    ...(isActive && !campaign.firstActivatedAt ? { firstActivatedAt: new Date() } : {}),
+  // H1: rail ensure + launch flip commit as ONE transaction — a failed flip
+  // must never leave the rail's activation + allocated stock behind.
+  await sequelize.transaction(async (t) => {
+    let stampedDoc = null;
+    if (isActive && drawEnabledIn(campaign.design_config)) {
+      assertDrawPromiseConsistency({
+        minAge: campaign.min_age, maxAge: campaign.max_age, designConfig: campaign.design_config,
+      });
+      const rail = await ensureRail({ campaign, designConfig: campaign.design_config, user: req.user, transaction: t });
+      const stamped = stampRailActivationId(campaign.design_config, rail.activationId);
+      if (stamped !== campaign.design_config) stampedDoc = stamped;
+    }
+    await campaign.update({
+      is_active: isActive,
+      status: isActive ? 'active' : 'paused',
+      ...(stampedDoc ? { design_config: stampedDoc } : {}),
+      ...(isActive && !campaign.firstActivatedAt ? { firstActivatedAt: new Date() } : {}),
+    }, { transaction: t });
   });
   // The engine record is born with the launch (best-effort — a record hiccup
   // must never un-launch a campaign; the boot reconciler retries).
@@ -1083,8 +1100,15 @@ async function deleteStorageAssets(campaign) {
  * Sync agent assignments to the join table.
  * Accepts an array of agent IDs (UUIDs) or objects with { id }.
  * Handles both shapes for backward compatibility with the old JSON column.
+ *
+ * H5: Joi checks UUID *syntax* only, so the ids are resolved to real users
+ * here — a ghost id 422s instead of dying on the join-table FK. Newly ADDED
+ * agents must be active; an id already on the campaign may stay through
+ * deactivation, so a routine save that resends the stored list keeps working.
+ * Runs on the caller's transaction when given one (the campaign write and its
+ * agent links must commit or fail together); standalone calls open their own.
  */
-async function syncAgentAssignments(campaignId, agents) {
+async function syncAgentAssignments(campaignId, agents, transaction = null) {
   if (!Array.isArray(agents)) return;
 
   // Normalize: extract UUID from either string or { id } object
@@ -1095,7 +1119,28 @@ async function syncAgentAssignments(campaignId, agents) {
   // Deduplicate
   const uniqueIds = [...new Set(agentIds)];
 
-  await sequelize.transaction(async (t) => {
+  const run = async (t) => {
+    if (uniqueIds.length > 0) {
+      const existingRows = await CampaignAgentAssignment.findAll({
+        where: { campaignId }, attributes: ['agentId'], transaction: t, raw: true,
+      });
+      const alreadyAssigned = new Set(existingRows.map(r => r.agentId));
+      const users = await User.findAll({
+        where: { id: uniqueIds }, attributes: ['id', 'isActive'], transaction: t, raw: true,
+      });
+      const byId = new Map(users.map(u => [u.id, u]));
+      const rejected = uniqueIds.filter(id => {
+        const u = byId.get(id);
+        return !u || (u.isActive !== true && !alreadyAssigned.has(id));
+      });
+      if (rejected.length > 0) {
+        throw new AppError(
+          `assigned_agents contains unknown or inactive users: ${rejected.join(', ')}`,
+          422
+        );
+      }
+    }
+
     await CampaignAgentAssignment.destroy({ where: { campaignId }, transaction: t });
 
     if (uniqueIds.length > 0) {
@@ -1104,7 +1149,9 @@ async function syncAgentAssignments(campaignId, agents) {
         { transaction: t }
       );
     }
-  });
+  };
+
+  return transaction ? run(transaction) : sequelize.transaction(run);
 }
 
 /**

--- a/backend/src/services/redeemOps/drawBoostProvisioningService.js
+++ b/backend/src/services/redeemOps/drawBoostProvisioningService.js
@@ -129,7 +129,7 @@ export function makeDrawBoostProvisioningService(overrides = {}) {
    * { activationId, outcome } — caller stamps luckyDraw.activationId.
    * Throws typed 422s; NEVER partially provisions (single tx).
    */
-  async function ensureDrawBoostRail({ campaign, designConfig = null, user = null }) {
+  async function ensureDrawBoostRail({ campaign, designConfig = null, user = null, transaction = null }) {
     const cfg = provisioningConfig();
     if (!cfg.enabled) {
       d.logger.warn('[DrawBoost] auto-provision disabled by kill switch — rail not ensured', { campaignId: campaign.id });
@@ -145,7 +145,7 @@ export function makeDrawBoostProvisioningService(overrides = {}) {
     const doc = designConfig || campaign.design_config;
     const ld = normalizeLuckyDraw(getStoredLuckyDraw(doc));
 
-    return d.sequelize.transaction(async (t) => {
+    const provision = async (t) => {
       await d.sequelize.query(`SELECT pg_advisory_xact_lock(hashtext(:k))`, {
         replacements: { k: `draw-boost:${campaign.id}` },
         transaction: t,
@@ -275,7 +275,15 @@ export function makeDrawBoostProvisioningService(overrides = {}) {
         campaignId: campaign.id, activationId: activation.id, offerId: offer.id, allocation: cfg.defaultAllocation,
       });
       return { activationId: activation.id, outcome: 'provisioned' };
-    });
+    };
+
+    // H1: when the caller passes its transaction, the rail joins it — the rail
+    // must commit WITH the campaign save that arms it, never in a transaction
+    // of its own that survives the save failing (slug 409 → live rail +
+    // allocated stock on a campaign that never activated). The advisory xact
+    // lock then holds until the CALLER commits, which also covers the save.
+    // Standalone callers keep the self-contained transaction.
+    return transaction ? provision(transaction) : d.sequelize.transaction(provision);
   }
 
   /**

--- a/backend/test/campaignTxIntegrity.test.js
+++ b/backend/test/campaignTxIntegrity.test.js
@@ -1,0 +1,206 @@
+/**
+ * H1 + H5 (review round 3): campaign writes must be transactional.
+ *
+ * H1 — the draw boost rail used to commit in its OWN transaction before
+ * campaign.update() ran. A PUT {is_active:true, slug:<taken>} on an inactive
+ * draw campaign provisioned + committed an active activation and allocated
+ * stock, THEN died on the slug unique constraint (409) — leaving a live rail
+ * on a campaign that never activated. The rail must commit WITH the save.
+ *
+ * H5 — assigned_agents was validated as UUID *syntax* only, and
+ * syncAgentAssignments ran in its own transaction after the campaign row
+ * committed. POST with a ghost UUID left an orphan campaign behind a 500;
+ * PUT committed field changes even when the assignment write then failed.
+ * Campaign + assignment writes must land (or fail) together, and ghost ids
+ * must 422 before anything commits.
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import {
+  Campaign, User, Activation, RewardOffer, PartnerOrganisation, CampaignAgentAssignment,
+} from '../src/models/index.js'
+import { buildDrawTermsHtml } from '../src/utils/drawTermsTemplate.js'
+
+let app, adminToken, adminUser, agentUser
+
+const BRIEF = { objective: 'agent_leads', product: 'insurance' }
+const GHOST_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' // well-formed, no such user
+
+const DRAW_FACTS = { prize: 'iPhone 17 Pro', closesAt: '2027-01-31', minAge: 21, maxAge: 55 }
+
+function drawDesignConfig(campaignName) {
+  return {
+    luckyDraw: { enabled: true, closesAt: DRAW_FACTS.closesAt, prize: DRAW_FACTS.prize },
+    termsContent: buildDrawTermsHtml({
+      campaignName,
+      prize: DRAW_FACTS.prize,
+      closesAt: DRAW_FACTS.closesAt,
+      minAge: DRAW_FACTS.minAge,
+      maxAge: DRAW_FACTS.maxAge,
+    }),
+  }
+}
+
+const ENV_KEYS = ['REDEEM_OPS_ENTITLEMENTS_ENABLED', 'DRAW_BOOST_AUTOPROVISION_ENABLED', 'REDEEM_HOUSE_PARTNER_ORG_ID']
+const envBackup = {}
+
+beforeAll(async () => {
+  ENV_KEYS.forEach((k) => { envBackup[k] = process.env[k] })
+  // The rail provisions only with the entitlement engine on + a house partner.
+  process.env.REDEEM_OPS_ENTITLEMENTS_ENABLED = 'true'
+  delete process.env.DRAW_BOOST_AUTOPROVISION_ENABLED
+  delete process.env.REDEEM_HOUSE_PARTNER_ORG_ID
+
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminUser = admin.user; adminToken = admin.token
+  const agent = await createTestUser({ role: 'agent' })
+  agentUser = agent.user
+  await PartnerOrganisation.create({
+    legalName: 'MKTR PTE. LTD.',
+    normalizedName: 'mktr pte. ltd.',
+    createdBy: adminUser.id,
+  })
+})
+
+afterAll(async () => {
+  ENV_KEYS.forEach((k) => {
+    if (envBackup[k] === undefined) delete process.env[k]
+    else process.env[k] = envBackup[k]
+  })
+  await closeDb()
+})
+
+const post = (body) => request(app)
+  .post('/api/campaigns')
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send(body)
+
+const put = (id, body) => request(app)
+  .put(`/api/campaigns/${id}`)
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send(body)
+
+describe('H1 — draw rail commits with the activation save, not before it', () => {
+  let drawId
+
+  beforeAll(async () => {
+    // Holds the slug the activation PUT will collide with.
+    const holder = await post({ name: 'H1 Slug Holder', targetAudience: BRIEF, slug: 'h1-taken-slug' })
+    expect(holder.status).toBe(201)
+
+    const draw = await post({
+      name: 'H1 Draw Campaign',
+      targetAudience: BRIEF,
+      is_active: false,
+      min_age: DRAW_FACTS.minAge,
+      max_age: DRAW_FACTS.maxAge,
+      design_config: drawDesignConfig('H1 Draw Campaign'),
+    })
+    expect(draw.status).toBe(201)
+    drawId = draw.body.data.campaign.id
+  })
+
+  it('a slug-conflict 409 on the arming PUT leaves NO committed rail behind', async () => {
+    const res = await put(drawId, { is_active: true, slug: 'h1-taken-slug' })
+    expect(res.status).toBe(409)
+
+    // Pre-fix: ensureRail's own transaction had already committed an active
+    // activation + allocated offer stock before campaign.update() 409ed.
+    const acts = await Activation.count({ where: { campaignId: drawId } })
+    expect(acts).toBe(0)
+    const offer = await RewardOffer.findOne({ where: { internalRef: `draw-boost:${drawId}` } })
+    expect(offer).toBeNull()
+
+    const campaign = await Campaign.findByPk(drawId)
+    expect(campaign.is_active).toBe(false)
+    expect(campaign.slug).toBeNull()
+  })
+
+  it('control: the same PUT with a free slug provisions the rail AND activates', async () => {
+    const res = await put(drawId, { is_active: true, slug: 'h1-free-slug' })
+    expect(res.status).toBe(200)
+
+    const acts = await Activation.findAll({ where: { campaignId: drawId } })
+    expect(acts).toHaveLength(1)
+    expect(acts[0].status).toBe('active')
+
+    const campaign = await Campaign.findByPk(drawId)
+    expect(campaign.is_active).toBe(true)
+    expect(campaign.design_config?.luckyDraw?.activationId).toBe(acts[0].id)
+  })
+})
+
+describe('H5 — campaign + agent-assignment writes are one transaction', () => {
+  it('POST with a ghost agent id 422s and leaves NO orphan campaign', async () => {
+    const res = await post({
+      name: 'H5 Ghost Agent Campaign',
+      targetAudience: BRIEF,
+      assigned_agents: [GHOST_ID],
+    })
+    // Pre-fix: Campaign.create() committed, then the FK violation surfaced as
+    // a 500 — the campaign row survived its own failed create call.
+    expect(res.status).toBe(422)
+    const orphan = await Campaign.findOne({ where: { name: 'H5 Ghost Agent Campaign' } })
+    expect(orphan).toBeNull()
+  })
+
+  it('POST with a real active agent still creates campaign + assignment', async () => {
+    const res = await post({
+      name: 'H5 Assigned Campaign',
+      targetAudience: BRIEF,
+      assigned_agents: [agentUser.id],
+    })
+    expect(res.status).toBe(201)
+    expect(res.body.data.campaign.assigned_agents).toEqual([agentUser.id])
+    const rows = await CampaignAgentAssignment.findAll({
+      where: { campaignId: res.body.data.campaign.id },
+    })
+    expect(rows.map((r) => r.agentId)).toEqual([agentUser.id])
+  })
+
+  it('PUT that renames AND assigns a ghost id rolls the rename back with the 422', async () => {
+    const created = await post({
+      name: 'H5 Atomic Update',
+      targetAudience: BRIEF,
+      assigned_agents: [agentUser.id],
+    })
+    expect(created.status).toBe(201)
+    const id = created.body.data.campaign.id
+
+    const res = await put(id, { name: 'H5 Atomic Update RENAMED', assigned_agents: [GHOST_ID] })
+    expect(res.status).toBe(422)
+
+    // Pre-fix: the rename committed before syncAgentAssignments failed — the
+    // response was a 500 for a half-applied update.
+    const campaign = await Campaign.findByPk(id)
+    expect(campaign.name).toBe('H5 Atomic Update')
+    const rows = await CampaignAgentAssignment.findAll({ where: { campaignId: id } })
+    expect(rows.map((r) => r.agentId)).toEqual([agentUser.id])
+  })
+
+  it('an agent already on the campaign may stay after deactivation; ADDING an inactive agent 422s', async () => {
+    const { user: retiring } = await createTestUser({ role: 'agent' })
+
+    const created = await post({
+      name: 'H5 Retained Agent',
+      targetAudience: BRIEF,
+      assigned_agents: [retiring.id],
+    })
+    expect(created.status).toBe(201)
+    const id = created.body.data.campaign.id
+
+    await User.update({ isActive: false }, { where: { id: retiring.id } })
+
+    // Routine save resending the stored list must keep working (no regression
+    // for campaigns whose assigned agent later went inactive)…
+    const keep = await put(id, { name: 'H5 Retained Agent v2', assigned_agents: [retiring.id] })
+    expect(keep.status).toBe(200)
+
+    // …but newly ADDING an inactive agent is rejected.
+    const other = await post({ name: 'H5 Add Inactive Target', targetAudience: BRIEF })
+    expect(other.status).toBe(201)
+    const add = await put(other.body.data.campaign.id, { assigned_agents: [retiring.id] })
+    expect(add.status).toBe(422)
+  })
+})

--- a/backend/test/designConfigV1Golden.test.js
+++ b/backend/test/designConfigV1Golden.test.js
@@ -23,6 +23,7 @@ import { Op } from 'sequelize';
 jest.unstable_mockModule('../src/models/index.js', () => ({
   Campaign: {}, QrTag: {}, Prospect: {}, Commission: {}, Device: {},
   CampaignMediaItem: {}, CampaignAgentAssignment: {},
+  User: { findAll: async () => [] }, // H5: assigned_agents id resolution
   sequelize: { transaction: jest.fn() },
   Draw: { findOne: async () => null }, // PR 5: closesAt-lock seam
   DrawTermsVersion: {

--- a/backend/test/designConfigV2.util.test.js
+++ b/backend/test/designConfigV2.util.test.js
@@ -14,7 +14,10 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   QrTag: {}, Prospect: {}, Commission: {}, Device: {},
   CampaignMediaItem: { findAll: jest.fn(async () => []), bulkCreate: jest.fn(async () => []) },
   CampaignAgentAssignment: { findAll: jest.fn(async () => []), bulkCreate: jest.fn(async () => []) },
-  sequelize: { transaction: jest.fn() },
+  User: { findAll: jest.fn(async () => []) }, // H5: assigned_agents id resolution
+  // updateCampaign now writes inside a managed transaction (H1/H5) — run the
+  // callback so campaign.update actually executes.
+  sequelize: { transaction: jest.fn(async (cb) => cb({ LOCK: { UPDATE: 'U' } })) },
   DrawTermsVersion: {
     findOne: jest.fn(async () => null),
     max: jest.fn(async () => null),

--- a/backend/test/unit/campaignService.test.js
+++ b/backend/test/unit/campaignService.test.js
@@ -53,6 +53,13 @@ const CampaignAgentAssignment = {
   bulkCreate: jest.fn(),
 };
 
+// syncAgentAssignments resolves assigned_agents ids to real users (H5); the
+// default mock echoes every requested id back as an active user so tests can
+// assign arbitrary ids.
+const User = {
+  findAll: jest.fn(),
+};
+
 const sequelize = {
   transaction: jest.fn(async (cb) => cb(mockTransaction)),
   fn: jest.fn((fnName, col) => `${fnName}(${col})`),
@@ -78,7 +85,7 @@ class AppError extends Error {
 
 jest.unstable_mockModule('../../src/models/index.js', () => ({
   Campaign, QrTag, Prospect, Commission, Device,
-  CampaignMediaItem, CampaignAgentAssignment, sequelize,
+  CampaignMediaItem, CampaignAgentAssignment, User, sequelize,
   // Draw-terms versioning dep (lucky draw) — inert stub; drawTermsVersioning.test.js
   // covers the real logic through the DI seam.
   Draw: { findOne: async () => null }, // PR 5: closesAt-lock seam
@@ -165,6 +172,11 @@ function resetAllMocks() {
   CampaignAgentAssignment.findAll.mockReset().mockResolvedValue([]);
   CampaignAgentAssignment.destroy.mockReset().mockResolvedValue(0);
   CampaignAgentAssignment.bulkCreate.mockReset().mockResolvedValue([]);
+
+  User.findAll.mockReset().mockImplementation(async ({ where } = {}) => {
+    const ids = Array.isArray(where?.id) ? where.id : where?.id ? [where.id] : [];
+    return ids.map((id) => ({ id, isActive: true }));
+  });
 
   sequelize.transaction.mockReset().mockImplementation(async (cb) => cb(mockTransaction));
 
@@ -566,7 +578,8 @@ describe('campaignService (unit)', () => {
       const result = await campaignService.updateCampaign('camp-1', body, makeReq());
 
       expect(inst.update).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Updated Name', min_age: 25 })
+        expect.objectContaining({ name: 'Updated Name', min_age: 25 }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
       expect(result).toBeDefined();
     });
@@ -1068,7 +1081,10 @@ describe('campaignService (unit)', () => {
 
       await campaignService.updateCampaign('camp-1', { name: DIRTY }, makeReq());
 
-      expect(instance.update).toHaveBeenCalledWith(expect.objectContaining({ name: CLEAN }));
+      expect(instance.update).toHaveBeenCalledWith(
+        expect.objectContaining({ name: CLEAN }),
+        expect.objectContaining({ transaction: expect.anything() })
+      );
     });
 
     it('duplicateCampaign strips an explicit body.name identically', async () => {

--- a/backend/test/unit/drawBoostProvisioning.test.js
+++ b/backend/test/unit/drawBoostProvisioning.test.js
@@ -284,3 +284,31 @@ describe('topUpDrawBoostAllocations', () => {
     await expect(svc.topUpDrawBoostAllocations()).resolves.toEqual({ toppedUp: 0 });
   });
 });
+
+describe('ensureDrawBoostRail — caller-transaction join (H1)', () => {
+  it('joins the given transaction instead of opening its own; every write carries it', async () => {
+    const { d, seq } = deps();
+    const callerTx = { LOCK: { UPDATE: 'U' }, id: 'caller-tx' };
+    const svc = makeDrawBoostProvisioningService(d);
+    const out = await svc.ensureDrawBoostRail({ campaign: CAMPAIGN, user: USER, transaction: callerTx });
+
+    expect(out.outcome).toBe('provisioned');
+    // The rail must commit WITH the caller's save, never in its own tx.
+    expect(seq.transaction).not.toHaveBeenCalled();
+    // Advisory lock + all writes ride the caller transaction.
+    expect(seq.calls[0].sql).toContain('pg_advisory_xact_lock');
+    expect(seq.calls[0].opts.transaction).toBe(callerTx);
+    expect(d.Activation.create.mock.calls[0][1].transaction).toBe(callerTx);
+    expect(d.RewardOffer.create.mock.calls[0][1].transaction).toBe(callerTx);
+    expect(d.inventory.allocate).toHaveBeenCalledWith(expect.objectContaining({ transaction: callerTx }));
+    expect(d.audit.recordAuditEvent).toHaveBeenCalledWith(expect.objectContaining({ transaction: callerTx }));
+  });
+
+  it('without a caller transaction, still opens its own (standalone contract unchanged)', async () => {
+    const { d, seq } = deps();
+    const svc = makeDrawBoostProvisioningService(d);
+    const out = await svc.ensureDrawBoostRail({ campaign: CAMPAIGN, user: USER });
+    expect(out.outcome).toBe('provisioned');
+    expect(seq.transaction).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Tasks

**H1 (HIGH)** — Draw rail commits before the campaign activation save
**H5 (HIGH)** — Campaign writes and agent-assignment writes commit independently

Bundled deliberately (per the round-3 queue contract): both are transaction-boundary defects around the same write block in `campaignService` — H1's transaction wraps the exact writes H5 must join, so shipping them separately would mean rewriting the same lines twice.

## Defects (both confirmed live at the cited lines)

- **H1**: `ensureDrawBoostRail` ran in its OWN committed transaction before `campaign.update()`. On an inactive draw campaign with no locked slug, `PUT {is_active:true, slug:<taken>}` provisioned + committed an active activation and allocated offer stock, then died on `uq_campaigns_slug` → 409. Result: live rail + allocated inventory on a campaign that never activated.
- **H5**: `assigned_agents` was Joi-validated as UUID *syntax* only; `syncAgentAssignments` always opened its own transaction after the campaign row committed. POST with a well-formed ghost UUID committed `Campaign.create()`, then hit the users FK → 500 + orphan campaign. PUT committed field changes before assignment replacement → half-applied update behind a 500.

## Fix

- `ensureDrawBoostRail` accepts an optional caller `transaction` and joins it (standalone callers keep the self-contained transaction — born-active create path unchanged, its documented demote-to-draft compensation stays). The per-campaign advisory xact lock now holds until the caller commits, covering the campaign write too.
- `updateCampaign`: rail ensure + `campaign.update` + `syncAgentAssignments` run in ONE transaction. `setCampaignLaunchState` (same arming pattern) gets the same treatment. `ensureRecord` stays post-commit — best-effort by contract, never throws.
- `createCampaign`: `Campaign.create` + `syncAgentAssignments` in one transaction (agent links now sync before the draw block; a born-active draw whose rail 422s keeps its requested agents on the surviving draft).
- `syncAgentAssignments`: accepts the caller transaction and resolves every requested id to a real user — ghosts 422 with the offending ids listed. **Product choice, stated**: newly ADDED agents must be `isActive`; an id already on the campaign may stay through deactivation, so routine saves that resend the stored list keep working (no regression for campaigns whose agent later went inactive).

## Test proof (regression tests fail pre-fix)

`backend/test/campaignTxIntegrity.test.js`, captured pre-fix on this branch:

```
● H1 › a slug-conflict 409 on the arming PUT leaves NO committed rail behind
    Expected: 0 / Received: 1        (activation had committed)
● H5 › POST with a ghost agent id 422s and leaves NO orphan campaign
    Expected: 422 / Received: 500    (+ orphan row present)
● H5 › PUT that renames AND assigns a ghost id rolls the rename back
    Expected: 422 / Received: 500    (rename had committed)
● H5 › ADDING an inactive agent 422s
    Expected: 422 / Received: 200
Tests: 4 failed, 2 passed
```

Post-fix: 6/6 pass. Unit-level: `drawBoostProvisioning.test.js` gains 2 cases proving the caller-transaction join (no own transaction opened; advisory lock + every write carries the caller tx) and the unchanged standalone contract.

## Verification

- Full unit tier: **2224/2224**
- Campaign-adjacent DB suites (campaigns, previews, detailsAi, drawTermsVersioning, drawRecordAutoCreate, luckyDrawService, marketplace, featuredDrops, idParamGuard, agentAssignment, leadCapture + new suite): **205/205**
- `npx eslint src/ --quiet` clean
- No migration; no schema change (join logic only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)