### PR TITLE
fix(redeem-ops): scope partner onboarding to row ownership (H2)

### DIFF
--- a/backend/src/controllers/redeemOps/rewardsController.js
+++ b/backend/src/controllers/redeemOps/rewardsController.js
@@ -102,11 +102,13 @@ export const getLedger = asyncHandler(async (req, res) => {
 // ── Onboarding checklist (brief §22) ───────────────────────────────────────
 
 export const getOnboarding = asyncHandler(async (req, res) => {
-  let items = await onboardingService.getChecklist(req.params.id);
+  // getChecklist enforces row ownership (H2) — the lazy seed below is only
+  // reachable once the caller may act on this partner.
+  let items = await onboardingService.getChecklist(req.params.id, req.user);
   if (items.length === 0) {
     // Lazily seed for partners that hit PARTNERED before Phase 4 shipped
     await onboardingService.seedChecklist(req.params.id);
-    items = await onboardingService.getChecklist(req.params.id);
+    items = await onboardingService.getChecklist(req.params.id, req.user);
   }
   res.json({ success: true, data: { items } });
 });

--- a/backend/src/services/redeemOps/onboardingService.js
+++ b/backend/src/services/redeemOps/onboardingService.js
@@ -1,6 +1,7 @@
-import { PartnerOnboardingItem, PartnerOrganisation, sequelize } from '../../models/index.js';
+import { PartnerOnboardingItem, PartnerOrganisation, User, sequelize } from '../../models/index.js';
 import { AppError } from '../../middleware/appError.js';
 import { logger } from '../../utils/logger.js';
+import { canActOnPartnerRow, isRedeemOpsUser } from './permissions.js';
 
 /**
  * Partner onboarding checklist (brief §22). Seeded when a partner hits
@@ -24,7 +25,30 @@ export const ONBOARDING_TEMPLATE = [
 const ITEM_STATUSES = ['pending', 'in_progress', 'done', 'na'];
 
 export function makeOnboardingService(overrides = {}) {
-  const d = { PartnerOnboardingItem, PartnerOrganisation, sequelize, logger, ...overrides };
+  const d = {
+    PartnerOnboardingItem, PartnerOrganisation, User, sequelize, logger,
+    canActOnPartnerRow, isRedeemOpsUser, ...overrides,
+  };
+
+  /**
+   * H2: onboarding.manage is a CAPABILITY, not row access — an outreach_exec
+   * holds it yet may only act on partners they own. Every read/write below
+   * loads the parent row and applies the same ownership gate as stage moves
+   * and detail edits (canActOnPartnerRow: owner, ops_admin+, platform admin).
+   */
+  async function assertPartnerActionable(partnerOrganisationId, user) {
+    const partner = await d.PartnerOrganisation.findByPk(partnerOrganisationId);
+    if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
+    if (!d.canActOnPartnerRow(user, partner)) {
+      throw new AppError(
+        partner.ownerUserId
+          ? 'You can only manage onboarding for businesses you own'
+          : 'Claim this business first, then you can manage its onboarding',
+        403
+      );
+    }
+    return partner;
+  }
 
   /** Idempotent template seed — safe to call on every PARTNERED transition. */
   async function seedChecklist(partnerOrganisationId, transaction = null) {
@@ -37,7 +61,8 @@ export function makeOnboardingService(overrides = {}) {
     }
   }
 
-  async function getChecklist(partnerOrganisationId) {
+  async function getChecklist(partnerOrganisationId, user) {
+    await assertPartnerActionable(partnerOrganisationId, user);
     return d.PartnerOnboardingItem.findAll({
       where: { partnerOrganisationId },
       order: [['sortOrder', 'ASC']],
@@ -47,13 +72,26 @@ export function makeOnboardingService(overrides = {}) {
   async function updateItem(itemId, body, user) {
     const item = await d.PartnerOnboardingItem.findByPk(itemId);
     if (!item) throw new AppError('Checklist item not found', 404);
+    // The item's parent decides who may touch it — knowing another partner's
+    // item UUID must not grant writes across the ownership boundary (H2).
+    await assertPartnerActionable(item.partnerOrganisationId, user);
     const updates = {};
     if (body.status !== undefined) {
       if (!ITEM_STATUSES.includes(body.status)) throw new AppError('Unknown status', 400);
       updates.status = body.status;
       updates.completedAt = body.status === 'done' ? new Date() : null;
     }
-    if (body.assigneeUserId !== undefined) updates.assigneeUserId = body.assigneeUserId;
+    if (body.assigneeUserId !== undefined) {
+      if (body.assigneeUserId === null || body.assigneeUserId === '') {
+        updates.assigneeUserId = null;
+      } else {
+        const assignee = await d.User.findByPk(body.assigneeUserId);
+        if (!assignee || assignee.isActive !== true || !d.isRedeemOpsUser(assignee)) {
+          throw new AppError('assigneeUserId must be an active Redeem Ops user', 422);
+        }
+        updates.assigneeUserId = assignee.id;
+      }
+    }
     if (body.notes !== undefined) updates.notes = body.notes;
     await item.update(updates);
     return item;

--- a/backend/test/redeemOpsOnboardingOwnership.test.js
+++ b/backend/test/redeemOpsOnboardingOwnership.test.js
@@ -1,0 +1,186 @@
+/**
+ * H2 (review round 3): partner onboarding endpoints must honour row-level
+ * ownership. onboarding.manage is a CAPABILITY — an outreach_exec holds it,
+ * yet may only act on partners they own. Pre-fix, GET
+ * /partners/:id/onboarding queried (and lazily SEEDED) solely by the supplied
+ * partner UUID, and PATCH /onboarding/:itemId loaded solely by item PK — so
+ * knowing another partner/item UUID exposed its notes and permitted writing
+ * status/assignee/notes/completedAt across the ownership boundary.
+ * assigneeUserId was also written unvalidated (ghost ids died on the FK as a
+ * 500; any known user id — redeem-ops or not — was accepted).
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+
+import request from 'supertest'
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import { PartnerOnboardingItem } from '../src/models/index.js'
+
+let app, admin, execA, execB, agent
+
+beforeAll(async () => {
+  app = await getApp()
+  admin = await createTestUser({ role: 'admin' })
+  execA = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' })
+  execB = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' })
+  agent = await createTestUser({ role: 'agent' }) // active, but NOT a Redeem Ops principal
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` })
+
+/** Partner owned by execA, walked to PARTNERED so its checklist is seeded. */
+async function makeOwnedPartner(name) {
+  const created = await request(app)
+    .post('/api/redeem-ops/partners')
+    .set(auth(execA.token))
+    .send({ tradingName: name })
+  const partner = created.body.data.partner
+  await request(app).post(`/api/redeem-ops/partners/${partner.id}/claim`).set(auth(execA.token))
+  await request(app)
+    .post(`/api/redeem-ops/partners/${partner.id}/contacts`)
+    .set(auth(execA.token))
+    .send({ name: 'Deal Signer', mobile: '+6598765432' })
+  // Ownership stays with execA (claim above); the stage force is admin-only,
+  // and admin's row override lets it ride without touching the owner.
+  const staged = await request(app)
+    .patch(`/api/redeem-ops/partners/${partner.id}/stage`)
+    .set(auth(admin.token))
+    .send({ toStage: 'PARTNERED', reason: 'closed for fixtures' })
+  if (staged.status !== 200) throw new Error(`fixture close failed: ${staged.status} ${JSON.stringify(staged.body)}`)
+  return partner
+}
+
+describe('H2 — onboarding endpoints enforce partner row ownership', () => {
+  let partner, item
+
+  beforeAll(async () => {
+    partner = await makeOwnedPartner('Ownership Boundary Nails')
+    item = await PartnerOnboardingItem.findOne({
+      where: { partnerOrganisationId: partner.id, itemKey: 'partnership_confirmed' },
+    })
+    expect(item).not.toBeNull()
+  })
+
+  it("GET another owner's checklist is 403", async () => {
+    const res = await request(app)
+      .get(`/api/redeem-ops/partners/${partner.id}/onboarding`)
+      .set(auth(execB.token))
+    expect(res.status).toBe(403)
+  })
+
+  it("PATCH another owner's item is 403 and writes NOTHING", async () => {
+    const res = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execB.token))
+      .send({ status: 'done', notes: 'crossed the boundary' })
+    expect(res.status).toBe(403)
+
+    await item.reload()
+    expect(item.status).toBe('pending')
+    expect(item.notes).toBeNull()
+    expect(item.completedAt).toBeNull()
+  })
+
+  it('the owner still reads and writes their checklist', async () => {
+    const list = await request(app)
+      .get(`/api/redeem-ops/partners/${partner.id}/onboarding`)
+      .set(auth(execA.token))
+    expect(list.status).toBe(200)
+    expect(list.body.data.items.length).toBeGreaterThan(0)
+
+    const res = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execA.token))
+      .send({ status: 'in_progress', notes: 'owner note' })
+    expect(res.status).toBe(200)
+    await item.reload()
+    expect(item.status).toBe('in_progress')
+    expect(item.notes).toBe('owner note')
+  })
+
+  it('platform admin overrides the row gate (ops backstop)', async () => {
+    const list = await request(app)
+      .get(`/api/redeem-ops/partners/${partner.id}/onboarding`)
+      .set(auth(admin.token))
+    expect(list.status).toBe(200)
+
+    const res = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(admin.token))
+      .send({ status: 'na' })
+    expect(res.status).toBe(200)
+  })
+
+  it('an UNOWNED partner belongs to nobody until claimed — no cross-owner lazy seed', async () => {
+    const created = await request(app)
+      .post('/api/redeem-ops/partners')
+      .set(auth(admin.token))
+      .send({ tradingName: 'Unclaimed Onboarding Lead' })
+    const unowned = created.body.data.partner
+
+    const res = await request(app)
+      .get(`/api/redeem-ops/partners/${unowned.id}/onboarding`)
+      .set(auth(execB.token))
+    expect(res.status).toBe(403)
+    // Pre-fix the GET lazily seeded 11 items for a partner execB cannot act on.
+    const seeded = await PartnerOnboardingItem.count({ where: { partnerOrganisationId: unowned.id } })
+    expect(seeded).toBe(0)
+  })
+
+  it('a ghost partner id is a clean 404, not a failed lazy seed', async () => {
+    const res = await request(app)
+      .get('/api/redeem-ops/partners/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/onboarding')
+      .set(auth(admin.token))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('H2 — assigneeUserId must be an active Redeem Ops user', () => {
+  let partner, item
+
+  beforeAll(async () => {
+    partner = await makeOwnedPartner('Assignee Validation Nails')
+    item = await PartnerOnboardingItem.findOne({
+      where: { partnerOrganisationId: partner.id, itemKey: 'primary_contact_verified' },
+    })
+  })
+
+  it('a ghost user id is a 422, not an FK 500', async () => {
+    const res = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execA.token))
+      .send({ assigneeUserId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' })
+    expect(res.status).toBe(422)
+  })
+
+  it('an active user who is NOT a Redeem Ops principal is rejected', async () => {
+    const res = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execA.token))
+      .send({ assigneeUserId: agent.user.id })
+    expect(res.status).toBe(422)
+    await item.reload()
+    expect(item.assigneeUserId).toBeNull()
+  })
+
+  it('an active Redeem Ops colleague is assignable; null clears', async () => {
+    const set = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execA.token))
+      .send({ assigneeUserId: execB.user.id })
+    expect(set.status).toBe(200)
+    await item.reload()
+    expect(item.assigneeUserId).toBe(execB.user.id)
+
+    const clear = await request(app)
+      .patch(`/api/redeem-ops/onboarding/${item.id}`)
+      .set(auth(execA.token))
+      .send({ assigneeUserId: null })
+    expect(clear.status).toBe(200)
+    await item.reload()
+    expect(item.assigneeUserId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Task

**H2 (HIGH)** — Partner onboarding endpoints bypass row-level ownership.

## Defect (confirmed live)

`onboarding.manage` is a capability, not row access — an `outreach_exec` holds it yet is supposed to act only on partners they own. Pre-fix:

- `GET /api/redeem-ops/partners/:id/onboarding` queried solely by the supplied partner UUID — and **lazily seeded** a checklist for any partner id, including ones the caller cannot act on.
- `PATCH /api/redeem-ops/onboarding/:itemId` loaded the item by PK and ignored the user entirely — status, assignee, notes, and completedAt were writable across the ownership boundary by anyone knowing an item UUID.
- `assigneeUserId` was written unvalidated: a ghost id died on the users FK as a 500; any known user id (redeem-ops or not) was accepted.

## Fix

Both operations load the parent `PartnerOrganisation` and apply `canActOnPartnerRow` — the same row gate as stage moves and detail edits (owner; `ops_admin`/`super_admin`; platform admin). A merged or missing partner is a clean 404. The lazy seed is only reachable after the gate passes. `assigneeUserId` must resolve to an **active Redeem Ops principal** (422 otherwise); `null` still clears the assignee.

**Stated posture (per the task prompt):** the gate applies to the GET as well, so a BDM or exec viewing a colleague's partner no longer sees its onboarding checklist — the PartnerDetail Onboarding tab shows its error state for non-owners. Admin/ops_admin retain full access as the ops backstop.

## Test proof (pre-fix failures captured on this branch)

`backend/test/redeemOpsOnboardingOwnership.test.js` against the pre-fix code:

```
cross-owner GET        → 200 (expected 403)
cross-owner PATCH      → 200 (expected 403, and the write landed)
cross-owner lazy seed  → 200 + 11 rows seeded (expected 403, 0 rows)
ghost partner GET      → 500 (expected 404)
ghost assigneeUserId   → 500 FK (expected 422)
non-redeem-ops assignee→ 200 accepted (expected 422)
Tests: 6 failed, 3 passed (the 3 = owner/admin positive controls)
```

Post-fix: **9/9 green** — including owner read/write, admin override, retained behavior for the rewards suite's admin-driven onboarding test.

## Verification

- Unit tier: **2224/2224**
- `redeemOpsOnboardingOwnership` + `redeemOpsPartners`: **50/50** on this branch atop merged main
- `redeemOpsRewards`'s onboarding test acts as admin (row override) — compatible by design; CI is the authority for that suite (it flakes/hangs locally at the transport level)
- `npx eslint src/ --quiet` clean; no migration, no schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)