### PR TITLE
fix(prospects): demographic edits mint revisions transactionally (H3)

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -878,11 +878,45 @@ export function makeProspectService(overrides = {}) {
       }
     }
 
+    // H3: a demographics edit writes the fields, the revision bump, the fact
+    // snapshot, and the outbox row in ONE transaction. The bump is
+    // column-relative with RETURNING — never computed from the possibly-stale
+    // loaded instance — and the snapshot is built from the RETURNED persisted
+    // row. Two concurrent edits serialize on the row lock and mint DISTINCT
+    // revisions, so the map-job unique index can no longer collapse two
+    // different payloads into one revision and publish stale facts. A failed
+    // outbox write now rolls the edit back (all-or-nothing) instead of
+    // committing fields the enrichment pipeline never hears about.
+    const editingDemographics = safeUpdates.demographics !== undefined;
+    const updatePayload = becomingWon ? { ...safeUpdates, conversionDate: new Date() } : safeUpdates;
     try {
-      if (becomingWon) {
-        await prospect.update({ ...safeUpdates, conversionDate: new Date() });
+      if (editingDemographics) {
+        await d.sequelize.transaction(async (t) => {
+          await prospect.update(updatePayload, { transaction: t });
+          const [rows] = await d.sequelize.query(
+            `UPDATE prospects
+                SET "enrichmentRevision" = COALESCE("enrichmentRevision", 1) + 1
+              WHERE id = :id
+              RETURNING "enrichmentRevision", "demographics"`,
+            { replacements: { id: prospect.id }, transaction: t }
+          );
+          const row = rows?.[0];
+          if (!row) throw new d.AppError('Prospect not found or access denied', 404);
+          prospect.enrichmentRevision = row.enrichmentRevision;
+          // FORM section only: quiz/profile artifacts are capture-immutable —
+          // absent sections mean "leave those artifacts alone" (§5.1). Cleared
+          // demographics still supersede (zero-fact snapshots at revision > 1).
+          const snapshot = d.buildFactSnapshot({
+            demographics: row.demographics || {},
+          });
+          await d.enqueueMapJobsTx(t, {
+            prospectId: prospect.id,
+            formRevision: row.enrichmentRevision,
+            snapshot,
+          });
+        });
       } else {
-        await prospect.update(safeUpdates);
+        await prospect.update(updatePayload);
       }
     } catch (err) {
       if (err?.name === 'SequelizeUniqueConstraintError') {
@@ -892,6 +926,7 @@ export function makeProspectService(overrides = {}) {
       }
       throw err;
     }
+    if (editingDemographics) d.drainMapJobs({ limit: 2 }).catch(() => {});
 
     // Consumer-spine projection upkeep: recompute BOTH phones' consumers from
     // rows (assign, never adjust) — this also relinks this row's consumerId.
@@ -902,34 +937,7 @@ export function makeProspectService(overrides = {}) {
     }
 
     // Enrichment choke points (docs/plans/consumer-profile-enrichment.md §5,
-    // §6.3 — Codex R4-era #2). Best-effort: the sweep's repair scan heals.
-    // (a) demographics is a mapped field — a staff edit mints the next form-
-    //     artifact revision + a new map job whose activation supersedes the
-    //     old revision's observations (including a CLEARED DOB — zero-fact
-    //     snapshots at revision > 1 still supersede).
-    if (safeUpdates.demographics !== undefined) {
-      try {
-        await d.sequelize.transaction(async (t) => {
-          const rev = (prospect.enrichmentRevision || 1) + 1;
-          await prospect.update({ enrichmentRevision: rev }, { transaction: t });
-          // FORM section only: quiz/profile artifacts are capture-immutable —
-          // absent sections mean "leave those artifacts alone" (§5.1).
-          const snapshot = d.buildFactSnapshot({
-            demographics: prospect.demographics || {},
-          });
-          await d.enqueueMapJobsTx(t, {
-            prospectId: prospect.id,
-            formRevision: rev,
-            snapshot,
-          });
-        });
-        d.drainMapJobs({ limit: 2 }).catch(() => {});
-      } catch (enrichErr) {
-        d.logger.warn('[enrichment] edit revision/outbox failed (sweep heals)', {
-          error: enrichErr?.message || String(enrichErr),
-        });
-      }
-    }
+    // §6.3). (a) demographics — handled ABOVE inside the edit transaction (H3).
     // (b) prospect lifecycle fields feed the score/DTO — bump the owner's
     //     input version so the profile goes dirty (no observation write here).
     if (safeUpdates.leadStatus !== undefined && safeUpdates.leadStatus !== oldStatus && prospect.consumerId) {

--- a/backend/test/prospectDemographicsRevision.test.js
+++ b/backend/test/prospectDemographicsRevision.test.js
@@ -1,0 +1,112 @@
+/**
+ * H3 (review round 3): concurrent demographic edits must mint DISTINCT
+ * enrichment revisions, each snapshotting the PERSISTED row.
+ *
+ * Pre-fix, updateProspect wrote demographics non-transactionally, then a
+ * separate transaction computed `rev = instance.enrichmentRevision + 1` from
+ * the possibly-stale loaded instance and built the snapshot from in-memory
+ * state. Two concurrent staff edits both computed revision 2; the map-job
+ * unique index + ON CONFLICT DO NOTHING kept only ONE payload — and when the
+ * surviving payload was the LOSER's, the mapper published stale facts with no
+ * higher revision left for the sweep to recover.
+ *
+ * Post-fix the field write, a column-relative bump (UPDATE … RETURNING), the
+ * snapshot (from the returned row), and the outbox insert share one
+ * transaction — concurrent edits serialize on the row lock, so these
+ * invariants hold on EVERY interleave:
+ *   1. two edits → final enrichmentRevision = 3 (1 + one per edit)
+ *   2. two form map jobs, at revisions 2 and 3 (none collapsed)
+ *   3. the HIGHEST-revision job's payload matches the FINAL row demographics
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { Prospect, EnrichmentJob } from '../src/models/index.js'
+import { buildFactSnapshot } from '../src/services/factMapperService.js'
+
+let app, adminToken, campaign
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminToken = admin.token
+  campaign = await createTestCampaign(admin.user.id, { name: 'Demographics Revision Race' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+// Different 5-year birth bands → the two snapshots carry DIFFERENT facts.
+const DEMO_A = { dateOfBirth: '1990-06-15' } // identity.birth_year_band 1990-1994
+const DEMO_B = { dateOfBirth: '1985-03-02' } // identity.birth_year_band 1985-1989
+
+const putDemographics = (id, demographics) => request(app)
+  .put(`/api/prospects/${id}`)
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send({ demographics })
+
+async function formJobsFor(prospectId) {
+  const jobs = await EnrichmentJob.findAll({
+    where: { kind: 'map', subjectProspectId: prospectId },
+    order: [['sourceRevisionId', 'ASC']],
+    raw: true,
+  })
+  // Form-revision jobs only (quiz/profile artifacts are pinned to revision 1
+  // and none exist here anyway — the edits only touch demographics).
+  return jobs.filter((j) => !j.sourceArtifactId || String(j.sourceArtifactId).startsWith('form:'))
+}
+
+function factsOf(payload) {
+  const p = typeof payload === 'string' ? JSON.parse(payload) : payload
+  return (p?.facts || []).map((f) => ({ key: f.key, value: f.value }))
+}
+
+describe('H3 — concurrent demographic edits keep revision/fact integrity', () => {
+  // The race window is load→write; several rounds make the pre-fix collapse
+  // overwhelmingly likely while the post-fix invariants are deterministic.
+  const ROUNDS = 6
+
+  for (let i = 0; i < ROUNDS; i++) {
+    it(`round ${i + 1}: two concurrent edits mint revisions 2 and 3, last one matching the row`, async () => {
+      const prospect = await createTestProspect(campaign.id)
+      expect(prospect.enrichmentRevision).toBe(1)
+
+      const [r1, r2] = await Promise.all([
+        putDemographics(prospect.id, DEMO_A),
+        putDemographics(prospect.id, DEMO_B),
+      ])
+      expect(r1.status).toBe(200)
+      expect(r2.status).toBe(200)
+
+      const row = await Prospect.findByPk(prospect.id, { raw: true })
+      // 1: every edit minted its own revision — none reused a stale number.
+      expect(row.enrichmentRevision).toBe(3)
+
+      const jobs = await formJobsFor(prospect.id)
+      const revisions = jobs.map((j) => Number(j.sourceRevisionId)).sort((a, b) => a - b)
+      // 2: both payloads survived as distinct revisions (no ON CONFLICT collapse).
+      expect(revisions).toEqual([2, 3])
+
+      // 3: the winning (highest) revision snapshots the FINAL persisted row —
+      // the published facts can never diverge from the prospect.
+      const winner = jobs.find((j) => Number(j.sourceRevisionId) === 3)
+      const expected = buildFactSnapshot({ demographics: row.demographics || {} }).sections.form.facts
+      expect(factsOf(winner.payload)).toEqual(expected)
+    })
+  }
+
+  it('a single edit still bumps once and snapshots the new value', async () => {
+    const prospect = await createTestProspect(campaign.id)
+    const res = await putDemographics(prospect.id, DEMO_A)
+    expect(res.status).toBe(200)
+
+    const row = await Prospect.findByPk(prospect.id, { raw: true })
+    expect(row.enrichmentRevision).toBe(2)
+    expect(row.demographics).toMatchObject(DEMO_A)
+
+    const jobs = await formJobsFor(prospect.id)
+    expect(jobs.map((j) => Number(j.sourceRevisionId))).toEqual([2])
+    const expected = buildFactSnapshot({ demographics: row.demographics }).sections.form.facts
+    expect(factsOf(jobs[0].payload)).toEqual(expected)
+  })
+})


### PR DESCRIPTION
## Task

**H3 (HIGH)** — Concurrent demographic edits collapse to one enrichment revision and can publish stale facts.

## Defect (confirmed live; cited lines had drifted to `prospectService.js:910-932` post-P3-3)

`updateProspect` wrote demographics non-transactionally, then a **separate** transaction computed `rev = (instance.enrichmentRevision || 1) + 1` from the possibly-stale loaded instance and built the fact snapshot from **in-memory** state. Two concurrent staff edits both loaded revision 1 → both computed revision 2 → the map-job unique index (`uq_ejobs_map*`) + `ON CONFLICT DO NOTHING` kept only one payload. When the survivor was the **loser's** payload, the mapper published facts diverging from the prospect row permanently — no higher revision left for the sweep to recover.

## Fix (as the task prescribes)

A demographics edit now performs, in **one transaction**:
1. the field write (`prospect.update`, taking the row lock),
2. a **column-relative** bump — `UPDATE … SET "enrichmentRevision" = COALESCE("enrichmentRevision",1)+1 … RETURNING "enrichmentRevision", demographics` — never computed from the instance,
3. the snapshot built **from the RETURNING row** (persisted state, not memory),
4. the outbox insert (`enqueueMapJobsTx`).

Concurrent edits serialize on the row lock and mint **distinct** revisions; on every interleave the highest revision snapshots the final row, so published facts cannot diverge. A revision can no longer be silently reused — the ON CONFLICT guard now only absorbs true idempotent replays. A failed outbox write rolls the edit back (all-or-nothing) instead of the old warn-and-continue, closing the silent-divergence window the old `catch` accepted.

## Test proof

`backend/test/prospectDemographicsRevision.test.js` — 6 rounds of two concurrent `PUT {demographics}` + a single-edit control. **Pre-fix (captured on this branch):**

```
6× rounds: Expected enrichmentRevision 3, Received 2   (both edits reused revision 2)
Tests: 6 failed, 1 passed
```

**Post-fix: 7/7** — invariants asserted every round: final revision = 3; form jobs exist at revisions **[2,3]** (no collapse); the revision-3 payload equals `buildFactSnapshot(final row demographics)`.

## Verification

- Unit tier: **2224/2224**
- DB suites (prospects, consumerEnrichment, leadQuota, leadCapture, leadProfileService + new suite): **142/142**
- eslint clean; no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)