### PR TITLE
fix(prospects): won requires a real assignee, enforced at mutation time (H4)

### DIFF
--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Transaction } from 'sequelize';
+import { Op, Transaction } from 'sequelize';
 import {
   Prospect,
   User,
@@ -866,14 +866,19 @@ export function makeProspectService(overrides = {}) {
       safeUpdates.consumerId = null;
     }
 
-    // Won-transition precondition runs BEFORE any mutation (Codex R1 #5):
-    // a lead may only be marked won while assigned to a real agent (assignment
-    // integrity for down-funnel attribution — the retired commission mint is
-    // gone, the rule stays).
+    // Won-transition precondition (Codex R1 #5, H4): a lead may only be marked
+    // won while assigned to a REAL assignee — an internal agent that isn't the
+    // System Agent, or an external (mktr-leads) agent. A null assignedAgentId
+    // is just as unassigned as the System Agent, so it rejects too. This early
+    // check only shapes the friendly 400 for obvious requests — ENFORCEMENT is
+    // the conditional UPDATE below, which re-checks under the row's write lock.
     const becomingWon = oldStatus !== 'won' && safeUpdates.leadStatus === 'won';
+    let systemAgentId = null;
     if (becomingWon) {
-      const systemId = await d.getSystemAgentId();
-      if (prospect.assignedAgentId && prospect.assignedAgentId === systemId) {
+      systemAgentId = await d.getSystemAgentId();
+      const hasRealInternalAgent =
+        prospect.assignedAgentId && prospect.assignedAgentId !== systemAgentId;
+      if (!hasRealInternalAgent && !prospect.externalAgentId) {
         throw new d.AppError('Lead must be assigned to a real agent before marking as won', 400);
       }
     }
@@ -889,10 +894,43 @@ export function makeProspectService(overrides = {}) {
     // committing fields the enrichment pipeline never hears about.
     const editingDemographics = safeUpdates.demographics !== undefined;
     const updatePayload = becomingWon ? { ...safeUpdates, conversionDate: new Date() } : safeUpdates;
+
+    // H4: a won-transition is enforced AT MUTATION TIME — the UPDATE's WHERE
+    // re-checks the assignment under the row's write lock, so a concurrent
+    // unassignment that commits after our unlocked read above can never
+    // produce a won-and-unassigned row. Zero affected rows = the state moved
+    // under us = reject with the same 400 as the precheck.
+    const applyProspectWrite = async (transaction = null) => {
+      const opts = transaction ? { transaction } : {};
+      if (!becomingWon) {
+        await prospect.update(updatePayload, opts);
+        return;
+      }
+      const [affected] = await m.Prospect.update(updatePayload, {
+        ...opts,
+        where: {
+          id: prospect.id,
+          [Op.or]: [
+            {
+              [Op.and]: [
+                { assignedAgentId: { [Op.not]: null } },
+                { assignedAgentId: { [Op.ne]: systemAgentId } },
+              ],
+            },
+            { externalAgentId: { [Op.not]: null } },
+          ],
+        },
+      });
+      if (affected === 0) {
+        throw new d.AppError('Lead must be assigned to a real agent before marking as won', 400);
+      }
+      await prospect.reload(opts);
+    };
+
     try {
       if (editingDemographics) {
         await d.sequelize.transaction(async (t) => {
-          await prospect.update(updatePayload, { transaction: t });
+          await applyProspectWrite(t);
           const [rows] = await d.sequelize.query(
             `UPDATE prospects
                 SET "enrichmentRevision" = COALESCE("enrichmentRevision", 1) + 1
@@ -916,7 +954,7 @@ export function makeProspectService(overrides = {}) {
           });
         });
       } else {
-        await prospect.update(updatePayload);
+        await applyProspectWrite();
       }
     } catch (err) {
       if (err?.name === 'SequelizeUniqueConstraintError') {

--- a/backend/test/prospectWonGuard.test.js
+++ b/backend/test/prospectWonGuard.test.js
@@ -1,0 +1,109 @@
+/**
+ * H4 (review round 3): only genuinely-assigned leads may be marked won, and
+ * the rule must hold at MUTATION time.
+ *
+ * Pre-fix the guard was `if (assignedAgentId && assignedAgentId === systemId)`
+ * — a held/unassigned row (assignedAgentId=null, externalAgentId=null)
+ * accepted {leadStatus:'won'}, got a conversionDate, and fired the won
+ * outcome hook with no real assignee. And because the precheck read the row
+ * without a lock, a concurrent unassignment committing between the read and
+ * the status write produced the same won-and-unassigned state.
+ *
+ * Post-fix: the precheck rejects null assignees too (external mktr-leads
+ * assignees count as real), and the won-transition write is a CONDITIONAL
+ * UPDATE whose WHERE re-checks the assignment under the row's write lock —
+ * zero affected rows = reject, so the race window is closed.
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { Prospect, ExternalAgent } from '../src/models/index.js'
+import { makeProspectService } from '../src/services/prospectService.js'
+import { getSystemAgentId } from '../src/services/systemAgent.js'
+
+let app, adminToken, adminUser, agentUser, campaign
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminUser = admin.user; adminToken = admin.token
+  const agent = await createTestUser({ role: 'agent' })
+  agentUser = agent.user
+  campaign = await createTestCampaign(adminUser.id, { name: 'Won Guard Campaign' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const putStatus = (id, leadStatus) => request(app)
+  .put(`/api/prospects/${id}`)
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send({ leadStatus })
+
+describe('H4 — won requires a real assignee', () => {
+  it('an UNASSIGNED lead (null agent, null external) cannot be marked won', async () => {
+    const p = await createTestProspect(campaign.id)
+    expect(p.assignedAgentId ?? null).toBeNull()
+
+    const res = await putStatus(p.id, 'won')
+    // Pre-fix: 200 — the null case slipped the truthy-and-equals guard.
+    expect(res.status).toBe(400)
+
+    const row = await Prospect.findByPk(p.id, { raw: true })
+    expect(row.leadStatus).not.toBe('won')
+    expect(row.conversionDate).toBeNull()
+  })
+
+  it('a System-Agent-assigned lead still cannot be marked won', async () => {
+    const systemId = await getSystemAgentId()
+    const p = await createTestProspect(campaign.id, { assignedAgentId: systemId })
+    const res = await putStatus(p.id, 'won')
+    expect(res.status).toBe(400)
+  })
+
+  it('a real-agent-assigned lead CAN be marked won', async () => {
+    const p = await createTestProspect(campaign.id, { assignedAgentId: agentUser.id })
+    const res = await putStatus(p.id, 'won')
+    expect(res.status).toBe(200)
+    const row = await Prospect.findByPk(p.id, { raw: true })
+    expect(row.leadStatus).toBe('won')
+    expect(row.conversionDate).not.toBeNull()
+  })
+
+  it('an EXTERNAL (mktr-leads) assignee counts as a real assignee', async () => {
+    const ext = await ExternalAgent.create({ phone: `65${String(Date.now()).slice(-8)}`, fullName: 'Rival Agent' })
+    const p = await createTestProspect(campaign.id, { externalAgentId: ext.id })
+    expect(p.assignedAgentId ?? null).toBeNull()
+
+    const res = await putStatus(p.id, 'won')
+    expect(res.status).toBe(200)
+    const row = await Prospect.findByPk(p.id, { raw: true })
+    expect(row.leadStatus).toBe('won')
+  })
+
+  it('a concurrent unassignment between precheck and write is rejected at mutation time', async () => {
+    const p = await createTestProspect(campaign.id, { assignedAgentId: agentUser.id })
+    const realSystemId = await getSystemAgentId()
+
+    // Deterministic race: getSystemAgentId is called exactly between the
+    // precheck's unlocked read and the status write on the won path — unassign
+    // the row there, simulating the concurrent reassignment committing first.
+    const svc = makeProspectService({
+      getSystemAgentId: async () => {
+        await Prospect.update({ assignedAgentId: null }, { where: { id: p.id } })
+        return realSystemId
+      },
+    })
+
+    // Pre-fix: the stale instance passed the precheck and the unconditional
+    // UPDATE committed → a won row with NO assignee. Post-fix the conditional
+    // UPDATE matches zero rows and the transition is rejected.
+    await expect(svc.updateProspect(p.id, { leadStatus: 'won' }, adminUser))
+      .rejects.toMatchObject({ statusCode: 400 })
+
+    const row = await Prospect.findByPk(p.id, { raw: true })
+    expect(row.leadStatus).not.toBe('won')
+    expect(row.assignedAgentId).toBeNull()
+    expect(row.conversionDate).toBeNull()
+  })
+})

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -785,6 +785,7 @@ describe('prospectService (unit)', () => {
         assignedAgentId: 'agent-1',
         update: jest.fn().mockResolvedValue(true),
         save: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue(true),
         assignedAgent: { firstName: 'Agent', lastName: 'Smith', email: 'agent@test.com' },
       };
       mocks.models.Prospect.findOne.mockResolvedValue(prospect);
@@ -792,9 +793,13 @@ describe('prospectService (unit)', () => {
 
       await service.updateProspect('prospect-1', { leadStatus: 'won' }, user);
 
-      const [updateArg] = prospect.update.mock.calls[0];
+      // H4: the won transition goes through the CONDITIONAL model update
+      // (assignment re-checked in the WHERE), not the instance update.
+      const [updateArg, updateOpts] = mocks.models.Prospect.update.mock.calls[0];
       expect(updateArg.leadStatus).toBe('won');
       expect(updateArg.conversionDate).toBeInstanceOf(Date);
+      expect(updateOpts.where.id).toBe('prospect-1');
+      expect(prospect.update).not.toHaveBeenCalled();
       expect(mocks.models.Commission.create).not.toHaveBeenCalled();
     });
 
@@ -860,13 +865,14 @@ describe('prospectService (unit)', () => {
       expect(mocks.processLeadOutcome).not.toHaveBeenCalled();
     });
 
-    it('won updates status + conversionDate in one plain update (no transaction needed)', async () => {
+    it('won writes through the conditional model update (assignment re-checked in WHERE)', async () => {
       const prospect = {
         ...mocks.mockProspect,
         leadStatus: 'contacted',
         assignedAgentId: 'agent-1',
         update: jest.fn().mockResolvedValue(true),
         save: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue(true),
         assignedAgent: null,
       };
       mocks.models.Prospect.findOne.mockResolvedValue(prospect);
@@ -874,11 +880,54 @@ describe('prospectService (unit)', () => {
 
       await service.updateProspect('prospect-1', { leadStatus: 'won' }, user);
 
-      const [updateArg, updateOpts] = prospect.update.mock.calls[0];
+      const [updateArg, updateOpts] = mocks.models.Prospect.update.mock.calls[0];
       expect(updateArg.leadStatus).toBe('won');
       expect(updateArg.conversionDate).toBeInstanceOf(Date);
-      expect(updateOpts).toBeUndefined();
+      expect(updateOpts.where.id).toBe('prospect-1');
+      expect(updateOpts.transaction).toBeUndefined(); // still no tx for a plain status edit
+      expect(prospect.update).not.toHaveBeenCalled();
+      expect(prospect.reload).toHaveBeenCalled();
       expect(mocks.models.Commission.create).not.toHaveBeenCalled();
+    });
+
+    it('H4: zero affected rows (concurrent unassignment) rejects with 400 and skips the hook', async () => {
+      const prospect = {
+        ...mocks.mockProspect,
+        leadStatus: 'contacted',
+        assignedAgentId: 'agent-1',
+        update: jest.fn().mockResolvedValue(true),
+        save: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue(true),
+        assignedAgent: null,
+      };
+      mocks.models.Prospect.findOne.mockResolvedValue(prospect);
+      mocks.models.Prospect.update.mockResolvedValue([0]); // the row moved under us
+      mocks.getSystemAgentId.mockResolvedValue('system-agent-id');
+
+      await expect(
+        service.updateProspect('prospect-1', { leadStatus: 'won' }, user)
+      ).rejects.toMatchObject({ statusCode: 400 });
+      expect(mocks.processLeadOutcome).not.toHaveBeenCalled();
+    });
+
+    it('H4: an unassigned lead (null agent, null external) is rejected before any write', async () => {
+      const prospect = {
+        ...mocks.mockProspect,
+        leadStatus: 'contacted',
+        assignedAgentId: null,
+        externalAgentId: null,
+        update: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue(true),
+        assignedAgent: null,
+      };
+      mocks.models.Prospect.findOne.mockResolvedValue(prospect);
+      mocks.getSystemAgentId.mockResolvedValue('system-agent-id');
+
+      await expect(
+        service.updateProspect('prospect-1', { leadStatus: 'won' }, user)
+      ).rejects.toMatchObject({ statusCode: 400 });
+      expect(mocks.models.Prospect.update).not.toHaveBeenCalled();
+      expect(prospect.update).not.toHaveBeenCalled();
     });
 
     // ── admin-recorded down-funnel CAPI hook (Phase 3) ──
@@ -909,6 +958,7 @@ describe('prospectService (unit)', () => {
         assignedAgentId: 'agent-1',
         update: jest.fn().mockResolvedValue(true),
         save: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue(true),
         assignedAgent: null,
       };
       mocks.models.Prospect.findOne.mockResolvedValue(prospect);


### PR DESCRIPTION
## Task

**H4 (HIGH)** — Unassigned leads can be marked won, and assignment can race the precheck.

## Defect (confirmed live; cited lines drifted post-P3-3 — the guard sits in `updateProspect`)

The round-1 guard was written as `if (assignedAgentId && assignedAgentId === systemId)` — truthy-and-equals, so a **null** `assignedAgentId` skipped the check entirely. A held/unassigned row accepted `{leadStatus:'won'}`, received a `conversionDate`, and fired the down-funnel won hook with no real assignee. Separately, the precheck read the row **without a lock**: a concurrent unassignment committing between the read and the status write produced the same won-and-unassigned state even for an assigned row.

## Fix (exactly the task's prescription — the rule is now code, not a comment)

- Precheck rejects when there is **neither** a non-system internal `assignedAgentId` **nor** a non-null `externalAgentId` (an external mktr-leads assignee counts as a real assignee — the old guard ignored that column).
- Enforcement moved to **mutation time**: the won transition is a conditional `Prospect.update` whose WHERE re-checks `(assignedAgentId IS NOT NULL AND != systemAgent) OR externalAgentId IS NOT NULL` under the row's write lock. **Zero affected rows → 400**, the hook never fires. The instance reloads after the model write so the response and follow-on hooks see persisted state.
- Composes with H3: on a demographics-carrying won edit the conditional write runs inside the same transaction as the revision/outbox work.

## Test proof (pre-fix captured on this branch against merged H3 main)

`backend/test/prospectWonGuard.test.js`:

```
unassigned lead PUT won      → 200, row persisted won  (expected 400)
deterministic race test      → promise RESOLVED, row won-and-unassigned
                               (concurrent unassignment injected at the
                                getSystemAgentId seam between read and write)
Tests: 2 failed, 3 passed    (3 = system-agent 400 / real-agent 200 / external 200 controls)
```

**Post-fix: 5/5**, including the race rejecting with 400 and the row staying un-won. Unit suite gains contract cases: won goes through the conditional model update; affected=0 → 400 + no hook; null-assignee rejected before any write.

## Verification

- Unit tier: **2226/2226**
- DB suites (wonGuard, demographicsRevision, prospects, leadOutcomeService, leadQuota): **111/111**
- eslint clean; no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)