### PR TITLE
fix(qr): one lifecycle truth — status canonical, active mirrored (M1)

### DIFF
--- a/backend/src/database/migrations/106-qr-lifecycle-coherence.js
+++ b/backend/src/database/migrations/106-qr-lifecycle-coherence.js
@@ -1,0 +1,65 @@
+/**
+ * 106 — one QR lifecycle truth: status and active can no longer disagree (M1).
+ *
+ * qr_tags carried TWO independent lifecycle fields: the status enum
+ * ('active'|'inactive'|'archived', written by bulk activate/deactivate/
+ * archive) and the active boolean (written by PUT and read by the PUBLIC slug
+ * resolver + attribution). Bulk-deactivating a printed QR flipped status only
+ * — the tag stayed publicly resolvable and kept recording scans after the
+ * admin saw a successful deactivation. PUT {active:false} flipped the boolean
+ * only — the authenticated /:id/scan path (status-gated) still accepted it.
+ *
+ * status is the canonical column (it alone can say 'archived'); active stays
+ * as its dual-written mirror for API/frontend compatibility. This migration
+ * reconciles the drifted rows and adds the CHECK that makes a future
+ * contradiction unstorable.
+ *
+ * Reconciliation rule: a DEACTIVATION intent always wins. A row that either
+ * side ever marked not-live goes (or stays) not-live — reactivating a QR the
+ * admin believed dead is the one wrong answer.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    // 1. PUT-deactivated rows: boolean said dead while status still said
+    //    active — status follows the deactivation (NULL active counts as
+    //    not-true: fail safe, never fail live).
+    await q(`
+      UPDATE qr_tags SET status = 'inactive'
+       WHERE status = 'active' AND active IS NOT TRUE
+    `);
+
+    // 2. Everything else mirrors the canonical status (covers bulk-deactivated
+    //    /archived rows whose boolean still said true, and legacy NULLs).
+    await q(`
+      UPDATE qr_tags SET active = (status = 'active')
+       WHERE active IS DISTINCT FROM (status = 'active')
+    `);
+
+    // 3. The mirror is now total — no NULL third state.
+    await q(`ALTER TABLE qr_tags ALTER COLUMN active SET NOT NULL`);
+    await q(`ALTER TABLE qr_tags ALTER COLUMN active SET DEFAULT true`);
+
+    // 4. Contradictions become unstorable. NOT VALID → VALIDATE (migration 014
+    //    pattern) — the backfill above guarantees validation passes.
+    await q(`
+      ALTER TABLE qr_tags ADD CONSTRAINT ck_qr_tags_lifecycle_coherent
+      CHECK ((status = 'active') = active) NOT VALID
+    `);
+    await q(`ALTER TABLE qr_tags VALIDATE CONSTRAINT ck_qr_tags_lifecycle_coherent`);
+  });
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+    await q(`ALTER TABLE qr_tags DROP CONSTRAINT IF EXISTS ck_qr_tags_lifecycle_coherent`);
+    await q(`ALTER TABLE qr_tags ALTER COLUMN active DROP NOT NULL`);
+  });
+}

--- a/backend/src/models/QrTag.js
+++ b/backend/src/models/QrTag.js
@@ -75,9 +75,13 @@ const QrTag = sequelize.define('QrTag', {
     type: DataTypes.STRING(16),
     allowNull: true
   },
-  // Active flag (replace status enum usage)
+  // Dual-written MIRROR of `status` (M1, migration 106): true iff
+  // status === 'active'. The CHECK ck_qr_tags_lifecycle_coherent makes a
+  // contradiction unstorable — every lifecycle write must set BOTH fields in
+  // the same statement (see qrCodeService bulk ops + updateQrCode).
   active: {
     type: DataTypes.BOOLEAN,
+    allowNull: false,
     defaultValue: true
   },
   location: {

--- a/backend/src/services/qrCodeService.js
+++ b/backend/src/services/qrCodeService.js
@@ -262,6 +262,19 @@ export async function updateQrCode(id, body, user) {
     Object.entries(rawData).filter(([k]) => QR_UPDATE_FIELDS.includes(k))
   );
 
+  // M1: `active` is a mirror of the canonical status — a PUT flipping the
+  // boolean must move the lifecycle with it, or the status-gated scan path
+  // keeps accepting a "disabled" tag (and the CHECK from migration 106 would
+  // reject the lone write anyway). active:false preserves an archived state;
+  // active:true relaunches, matching the boolean's public effect it always had.
+  if (updateData.active !== undefined) {
+    const nextActive = updateData.active === true || updateData.active === 'true';
+    updateData.active = nextActive;
+    updateData.status = nextActive
+      ? 'active'
+      : (qrTag.status === 'archived' ? 'archived' : 'inactive');
+  }
+
   // Resolve assignedAgentId from phone when phone is being updated (dual-write)
   if (updateData.assignedAgentPhone && !updateData.assignedAgentId) {
     const agent = await User.findOne({
@@ -396,16 +409,19 @@ export async function bulkOperateQrCodes(operation, qrTagIds, data, user) {
 
   let message;
   switch (operation) {
+    // M1: status and active are dual-written in the SAME statement — writing
+    // status alone left the tag publicly resolvable (the slug/attribution
+    // resolvers gate on `active`) after a "successful" deactivation.
     case 'activate':
-      await QrTag.update({ status: 'active' }, { where });
+      await QrTag.update({ status: 'active', active: true }, { where });
       message = `${qrTags.length} QR codes activated`;
       break;
     case 'deactivate':
-      await QrTag.update({ status: 'inactive' }, { where });
+      await QrTag.update({ status: 'inactive', active: false }, { where });
       message = `${qrTags.length} QR codes deactivated`;
       break;
     case 'archive':
-      await QrTag.update({ status: 'archived' }, { where });
+      await QrTag.update({ status: 'archived', active: false }, { where });
       message = `${qrTags.length} QR codes archived`;
       break;
     case 'update': {

--- a/backend/src/services/trackerService.js
+++ b/backend/src/services/trackerService.js
@@ -14,10 +14,12 @@ const IP_HASH_SALT = process.env.IP_HASH_SALT || 'dev-salt';
 const ATTRIB_SECRET = process.env.ATTRIB_SECRET || 'dev-attrib-secret';
 
 /**
- * Resolve a QR tag by slug (active only). Returns null if not found.
+ * Resolve a QR tag by slug (live only). Returns null if not found.
+ * M1: gates on the CANONICAL lifecycle column — a bulk deactivate/archive
+ * (which historically wrote status only) must kill public resolution.
  */
 export async function resolveQrTag(slug) {
-  return QrTag.findOne({ where: { slug, active: true } });
+  return QrTag.findOne({ where: { slug, status: 'active' } });
 }
 
 /**
@@ -152,7 +154,9 @@ export async function resolveSession(sid, atkCookie) {
   if (!attrib) return null;
 
   const qrTag = await QrTag.findByPk(attrib.qrTagId);
-  if (!qrTag || !qrTag.active) return null;
+  // M1: canonical lifecycle gate — a bulk-deactivated tag must stop
+  // attributing scans, not just stop resolving.
+  if (!qrTag || qrTag.status !== 'active') return null;
 
   let campaign = null;
   if (qrTag.campaignId) {

--- a/backend/test/migration106QrLifecycle.test.js
+++ b/backend/test/migration106QrLifecycle.test.js
@@ -1,0 +1,82 @@
+/**
+ * 106 on real Postgres (M1). Self-contained replay: down() strips the
+ * constraint + NOT NULL so drifted pre-106 rows can be seeded, up() must then
+ * reconcile them with DEACTIVATION INTENT WINNING — a row either side ever
+ * marked not-live goes not-live; reactivating a QR the admin believed dead is
+ * the one wrong answer — and afterwards a single-column lifecycle write that
+ * would reintroduce the drift must be unstorable (CHECK).
+ */
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestQrTag } from './helpers.js'
+import { sequelize, QrTag } from '../src/models/index.js'
+import { up, down } from '../src/database/migrations/106-qr-lifecycle-coherence.js'
+
+let admin, campaign
+
+beforeAll(async () => {
+  await getApp()
+  admin = await createTestUser({ role: 'admin' })
+  campaign = await createTestCampaign(admin.user.id, { name: 'Migration 106 Campaign' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const qi = () => sequelize.getQueryInterface()
+
+/** Seed a tag then force a drifted lifecycle pair via raw SQL (the model —
+ *  and post-106 the CHECK — would refuse the contradiction). */
+async function driftedTag({ status, active }) {
+  const tag = await createTestQrTag(campaign.id, admin.user.id)
+  await sequelize.query(
+    `UPDATE qr_tags SET status = :status, active = ${active === null ? 'NULL' : ':active'} WHERE id = :id`,
+    { replacements: { status, active, id: tag.id } }
+  )
+  return tag.id
+}
+
+const rowOf = async (id) => QrTag.findByPk(id, { raw: true })
+
+test('reconciles every drift shape with deactivation intent winning, then locks coherence', async () => {
+  await down(qi())
+
+  const putDeactivated = await driftedTag({ status: 'active', active: false }) // PUT flipped the boolean only
+  const bulkDeactivated = await driftedTag({ status: 'inactive', active: true }) // bulk flipped status only
+  const archivedLive = await driftedTag({ status: 'archived', active: true })
+  const legacyNull = await driftedTag({ status: 'active', active: null })
+  const coherentLive = await driftedTag({ status: 'active', active: true })
+  const coherentDead = await driftedTag({ status: 'inactive', active: false })
+
+  await up(qi())
+
+  // PUT-deactivated: the boolean's intent wins — status follows it down.
+  expect(await rowOf(putDeactivated)).toMatchObject({ status: 'inactive', active: false })
+  // Bulk-deactivated/archived: status wins — the boolean follows it down.
+  expect(await rowOf(bulkDeactivated)).toMatchObject({ status: 'inactive', active: false })
+  expect(await rowOf(archivedLive)).toMatchObject({ status: 'archived', active: false })
+  // Legacy NULL on a live status: fail safe, never fail live.
+  expect(await rowOf(legacyNull)).toMatchObject({ status: 'inactive', active: false })
+  // Coherent rows pass through untouched.
+  expect(await rowOf(coherentLive)).toMatchObject({ status: 'active', active: true })
+  expect(await rowOf(coherentDead)).toMatchObject({ status: 'inactive', active: false })
+
+  // The drift that started this is now unstorable: a lone status flip…
+  await expect(
+    sequelize.query('UPDATE qr_tags SET status = :s WHERE id = :id', {
+      replacements: { s: 'inactive', id: coherentLive },
+    })
+  ).rejects.toThrow(/ck_qr_tags_lifecycle_coherent/)
+  // …and a lone boolean flip both violate the CHECK.
+  await expect(
+    sequelize.query('UPDATE qr_tags SET active = false WHERE id = :id', {
+      replacements: { id: coherentLive },
+    })
+  ).rejects.toThrow(/ck_qr_tags_lifecycle_coherent/)
+
+  // Dual writes (what the services now do) pass.
+  await sequelize.query(
+    "UPDATE qr_tags SET status = 'inactive', active = false WHERE id = :id",
+    { replacements: { id: coherentLive } }
+  )
+  expect(await rowOf(coherentLive)).toMatchObject({ status: 'inactive', active: false })
+})

--- a/backend/test/qrLifecycleCoherence.test.js
+++ b/backend/test/qrLifecycleCoherence.test.js
@@ -1,0 +1,130 @@
+/**
+ * M1 (review round 3): one QR lifecycle truth across both fields.
+ *
+ * qr_tags carried TWO independent lifecycle fields: `status` (written by the
+ * bulk activate/deactivate/archive ops, read by the authenticated scan path)
+ * and `active` (written by PUT, read by the PUBLIC slug resolver and the
+ * attribution resolver). Pre-fix, bulk-deactivating a printed QR flipped
+ * status only — the tag stayed publicly resolvable after the admin saw a
+ * successful deactivation; and PUT {active:false} flipped the boolean only —
+ * the status-gated /:id/scan path still accepted the "disabled" tag.
+ *
+ * Post-fix `status` is canonical, `active` is its dual-written mirror
+ * (migration 106 reconciles + adds the coherence CHECK), and every resolver
+ * gates on the canonical lifecycle.
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestQrTag } from './helpers.js'
+import { QrTag } from '../src/models/index.js'
+import { resolveQrTag } from '../src/services/trackerService.js'
+
+let app, adminToken, adminUser, campaign
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminUser = admin.user; adminToken = admin.token
+  campaign = await createTestCampaign(adminUser.id, { name: 'QR Lifecycle Campaign' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const bulk = (operation, qrTagIds) => request(app)
+  .post('/api/qrcodes/bulk')
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send({ operation, qrTagIds })
+
+const putTag = (id, body) => request(app)
+  .put(`/api/qrcodes/${id}`)
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send(body)
+
+const scan = (id) => request(app)
+  .post(`/api/qrcodes/${id}/scan`)
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send({})
+
+describe('M1 — bulk lifecycle ops kill public resolution', () => {
+  it('bulk deactivate stops the slug resolver, the scan path, and mirrors active=false', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    expect(await resolveQrTag(tag.slug)).not.toBeNull()
+
+    const res = await bulk('deactivate', [tag.id])
+    expect(res.status).toBe(200)
+
+    // Pre-fix: status flipped but active stayed true — the printed QR kept
+    // resolving publicly after a successful deactivation response.
+    expect(await resolveQrTag(tag.slug)).toBeNull()
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.status).toBe('inactive')
+    expect(row.active).toBe(false)
+
+    const scanRes = await scan(tag.id)
+    expect(scanRes.status).toBe(400)
+  })
+
+  it('bulk archive does the same', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    await bulk('archive', [tag.id])
+
+    expect(await resolveQrTag(tag.slug)).toBeNull()
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.status).toBe('archived')
+    expect(row.active).toBe(false)
+  })
+
+  it('bulk activate restores both fields and resolution', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    await bulk('deactivate', [tag.id])
+    await bulk('activate', [tag.id])
+
+    expect(await resolveQrTag(tag.slug)).not.toBeNull()
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.status).toBe('active')
+    expect(row.active).toBe(true)
+    expect((await scan(tag.id)).status).toBe(200)
+  })
+})
+
+describe('M1 — PUT {active} moves the canonical lifecycle too', () => {
+  it('PUT {active:false} disables the status-gated scan path as well', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    const res = await putTag(tag.id, { active: false })
+    expect(res.status).toBe(200)
+
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.active).toBe(false)
+    expect(row.status).toBe('inactive')
+
+    // Pre-fix: status stayed 'active', so the authenticated scan path kept
+    // accepting (and counting) the supposedly disabled QR.
+    expect((await scan(tag.id)).status).toBe(400)
+    expect(await resolveQrTag(tag.slug)).toBeNull()
+  })
+
+  it('PUT {active:false} on an ARCHIVED tag preserves the archived state', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    await bulk('archive', [tag.id])
+
+    const res = await putTag(tag.id, { active: false })
+    expect(res.status).toBe(200)
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.status).toBe('archived')
+    expect(row.active).toBe(false)
+  })
+
+  it('PUT {active:true} relaunches: status follows, scan + resolver reopen', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+    await putTag(tag.id, { active: false })
+    const res = await putTag(tag.id, { active: true })
+    expect(res.status).toBe(200)
+
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.status).toBe('active')
+    expect(row.active).toBe(true)
+    expect(await resolveQrTag(tag.slug)).not.toBeNull()
+    expect((await scan(tag.id)).status).toBe(200)
+  })
+})

--- a/backend/test/unit/qrCodeService.test.js
+++ b/backend/test/unit/qrCodeService.test.js
@@ -345,7 +345,7 @@ describe('qrCodeService (unit)', () => {
       const result = await service.bulkOperateQrCodes('activate', ['qr-1'], {}, adminUser);
 
       expect(mocks.QrTag.update).toHaveBeenCalledWith(
-        { status: 'active' },
+        { status: 'active', active: true },
         expect.any(Object)
       );
       expect(result.message).toContain('activated');
@@ -355,7 +355,7 @@ describe('qrCodeService (unit)', () => {
       const result = await service.bulkOperateQrCodes('deactivate', ['qr-1'], {}, adminUser);
 
       expect(mocks.QrTag.update).toHaveBeenCalledWith(
-        { status: 'inactive' },
+        { status: 'inactive', active: false },
         expect.any(Object)
       );
       expect(result.message).toContain('deactivated');

--- a/backend/test/unit/qrScanFlow.test.js
+++ b/backend/test/unit/qrScanFlow.test.js
@@ -8,6 +8,7 @@ const mockQrTag = {
   id: 'qr-1',
   slug: 'abc123test',
   campaignId: 'camp-1',
+  status: 'active', // M1: canonical lifecycle column
   active: true,
   scanCount: 5,
   uniqueScanCount: 3,
@@ -98,7 +99,7 @@ describe('qrScanFlow (unit)', () => {
     it('resolves active QR tag by slug', async () => {
       const result = await resolveQrTag('abc123test');
 
-      expect(QrTag.findOne).toHaveBeenCalledWith({ where: { slug: 'abc123test', active: true } });
+      expect(QrTag.findOne).toHaveBeenCalledWith({ where: { slug: 'abc123test', status: 'active' } });
       expect(result).toEqual(mockQrTag);
     });
 
@@ -287,7 +288,8 @@ describe('qrScanFlow (unit)', () => {
 
     it('returns null when QR tag is inactive', async () => {
       Attribution.findOne.mockResolvedValue(mockAttribution);
-      QrTag.findByPk.mockResolvedValue({ ...mockQrTag, active: false });
+      // M1: status is the canonical lifecycle column (active mirrors it).
+      QrTag.findByPk.mockResolvedValue({ ...mockQrTag, status: 'inactive', active: false });
 
       const result = await resolveSession('sess-123', null);
 

--- a/backend/test/unit/trackerService.test.js
+++ b/backend/test/unit/trackerService.test.js
@@ -26,7 +26,7 @@ describe('trackerService (unit)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockQrTag = { id: 'qr-1', slug: 'test-slug', active: true, campaignId: 'camp-1' };
+    mockQrTag = { id: 'qr-1', slug: 'test-slug', status: 'active', active: true, campaignId: 'camp-1' };
     mockScan = { id: 'scan-1', qrTagId: 'qr-1', ipHash: 'hash123', ua: 'Mozilla/5.0', ts: new Date() };
     mockAttribution = {
       id: 'attr-1',
@@ -55,7 +55,7 @@ describe('trackerService (unit)', () => {
     it('finds active QR tag by slug', async () => {
       const result = await resolveQrTag('test-slug');
 
-      expect(QrTag.findOne).toHaveBeenCalledWith({ where: { slug: 'test-slug', active: true } });
+      expect(QrTag.findOne).toHaveBeenCalledWith({ where: { slug: 'test-slug', status: 'active' } });
       expect(result).toBe(mockQrTag);
     });
 


### PR DESCRIPTION
## Task

**M1 (MED)** — Two independent QR lifecycle fields make deactivation ineffective.

## Defect (confirmed live)

`qr_tags` carried two independent lifecycle fields:
- Bulk activate/deactivate/archive wrote **`status` only** — but the public slug resolver (`resolveQrTag`) and the attribution resolver gate on **`active`**. A printed QR stayed publicly resolvable and kept recording scans after the admin received a successful deactivation response.
- `PUT {active:false}` wrote **the boolean only** — the status-gated authenticated `/:id/scan` path still accepted the supposedly disabled QR.

## Fix (canonical column + dual-write + data migration + constraint, as prescribed)

- **`status` is canonical** (only it can say `archived`); `active` remains as a dual-written mirror for API/frontend compatibility.
- Bulk ops write both fields **in one statement**. `PUT {active}` moves `status` with it: `false` preserves an archived state; `true` relaunches (matching the boolean's public effect it always had — pre-fix, `active:true` made an archived tag publicly resolvable).
- Both `trackerService` resolvers now gate on the canonical status; `recordScan` already did.
- **Migration 106**: reconciles drifted rows with **deactivation intent winning in both directions** (a row either side ever marked not-live goes not-live; `NULL` counts as not-live — fail safe, never fail live), then `SET NOT NULL` on `active` and `CHECK ck_qr_tags_lifecycle_coherent ((status='active') = active)` via NOT VALID → VALIDATE (migration 014 pattern). Model mirrors `allowNull: false` for the sync-built test schema.

## Test proof

**Pre-fix** (`qrLifecycleCoherence.test.js`, captured on this branch):
```
bulk deactivate → row {status:'inactive', active:TRUE} — still publicly resolvable
bulk archive    → row {status:'archived', active:TRUE} — same leak
PUT active:false → status stayed 'active' — scan path still open
Tests: 3 failed, 3 passed
```
**Post-fix: 6/6** — deactivate/archive kill resolver + scan + mirror; PUT couples both fields; relaunch restores.

**Migration test** (`migration106QrLifecycle.test.js`, self-contained `down() → seed drift → up()`): every drift shape (PUT-deactivated, bulk-deactivated, archived-live, legacy-NULL, coherent-live/dead) reconciles with deactivation winning; the CHECK then rejects lone single-column flips and accepts the dual write.

## Verification

- Unit tier: **2226/2226** (QR unit suites updated to the dual-write/status-gate contract)
- QR-adjacent DB suites (qrRouting, leadCapture, leadCaptureBind, prospects): **98/98**
- `migrations.test.js` static validation green (106 exports up/down, numbering)
- eslint clean. Migration tier runs in CI (tier 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)