### PR TITLE
fix(qr): scan dedup is per-scanner and atomic (M2)

### DIFF
--- a/backend/src/database/migrations/107-qr-scan-dedup-index.js
+++ b/backend/src/database/migrations/107-qr-scan-dedup-index.js
@@ -1,0 +1,24 @@
+/**
+ * 107 — supporting index for the per-scanner QR scan dedup window (M2).
+ *
+ * trackerService.recordScan now decides "duplicate?" with a windowed query on
+ * (qrTagId, ipHash, ts) under a per-(tag, scanner) advisory lock — pre-fix it
+ * compared only the tag's single most recent scan, so interleaved scanners
+ * inflated uniqueScanCount and concurrent same-client scans raced past the
+ * check. This index keeps that windowed lookup from scanning a hot tag's
+ * whole history. Mirrored on the QrScan model (sync-before-migrations test
+ * boot).
+ */
+
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS idx_qr_scans_dedup_window
+      ON qr_scans ("qrTagId", "ipHash", "ts")
+  `);
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'DROP INDEX IF EXISTS idx_qr_scans_dedup_window'
+  );
+}

--- a/backend/src/models/QrScan.js
+++ b/backend/src/models/QrScan.js
@@ -51,7 +51,10 @@ const QrScan = sequelize.define('QrScan', {
   tableName: 'qr_scans',
   indexes: [
     { fields: ['qrTagId', 'ts'] },
-    { fields: ['botFlag'] }
+    { fields: ['botFlag'] },
+    // M2: supports the per-scanner dedup window in trackerService.recordScan
+    // (qrTagId + ipHash + ts range). Mirrored in migration 107 for prod.
+    { fields: ['qrTagId', 'ipHash', 'ts'], name: 'idx_qr_scans_dedup_window' }
   ]
 });
 

--- a/backend/src/services/trackerService.js
+++ b/backend/src/services/trackerService.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
-import { QrTag, QrScan, Attribution, Campaign } from '../models/index.js';
+import { Op } from 'sequelize';
+import { QrTag, QrScan, Attribution, Campaign, sequelize } from '../models/index.js';
 import { buildPublicDesignConfig } from '../utils/publicDesignConfig.js';
 import { publicScreeningCallback } from '../utils/screeningEnv.js';
 
@@ -32,36 +33,51 @@ export async function recordScan(qrTag, { userAgent, referer, ip }) {
   const device = /Mobile|Android|iPhone|iPad/.test(ua) ? 'mobile' : 'desktop';
   const botFlag = /(bot|spider|crawler)/i.test(ua);
 
-  // De-dup within 2 minutes for same (slug, ipHash, ua)
-  const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
-  const recentScan = await QrScan.findOne({ where: { qrTagId: qrTag.id }, order: [['ts', 'DESC']] });
-  let isDuplicate = false;
-  if (recentScan && recentScan.ts > twoMinutesAgo && recentScan.ipHash === ipHash && recentScan.ua === ua) {
-    isDuplicate = true;
-  }
+  // M2: the duplicate decision is scoped to THIS scanner and made atomic.
+  // Pre-fix it compared only the tag's single most recent scan (client A was
+  // "unique" again whenever client B scanned in between) and raced: two
+  // simultaneous same-client requests both read no-prior-dup, both counted
+  // unique. A per-(tag, scanner) advisory xact lock serializes the claim;
+  // the windowed EXISTS query then decides, and the scan row + counters
+  // commit together — uniqueScanCount only increments for the request that
+  // wins the claim.
+  return sequelize.transaction(async (t) => {
+    await sequelize.query('SELECT pg_advisory_xact_lock(hashtext(:k))', {
+      replacements: { k: `qr-scan-dedup:${qrTag.id}:${ipHash}:${ua ?? ''}` },
+      transaction: t,
+    });
 
-  const scan = await QrScan.create({
-    qrTagId: qrTag.id,
-    ipHash,
-    ua,
-    referer,
-    device,
-    geoCity: null,
-    botFlag,
-    isDuplicate
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000);
+    const prior = await QrScan.findOne({
+      where: { qrTagId: qrTag.id, ipHash, ua, ts: { [Op.gt]: twoMinutesAgo } },
+      attributes: ['id'],
+      transaction: t,
+    });
+    const isDuplicate = !!prior;
+
+    const scan = await QrScan.create({
+      qrTagId: qrTag.id,
+      ipHash,
+      ua,
+      referer,
+      device,
+      geoCity: null,
+      botFlag,
+      isDuplicate
+    }, { transaction: t });
+
+    // Bump the denormalized counters on the QR tag so the admin UI's
+    // "Scans" / "Unique" columns reflect activity. The analytics row above
+    // is the source of truth for reporting; these counters exist to avoid
+    // an N+1 count(*) in the QR list. Unique only counts non-duplicate,
+    // non-bot hits.
+    const counters = { scanCount: 1 };
+    if (!isDuplicate && !botFlag) counters.uniqueScanCount = 1;
+    await QrTag.increment(counters, { where: { id: qrTag.id }, transaction: t });
+    await QrTag.update({ lastScanned: new Date() }, { where: { id: qrTag.id }, transaction: t });
+
+    return scan;
   });
-
-  // Bump the denormalized counters on the QR tag so the admin UI's
-  // "Scans" / "Unique" columns reflect activity. The analytics row above
-  // is the source of truth for reporting; these counters exist to avoid
-  // an N+1 count(*) in the QR list. Unique only counts non-duplicate,
-  // non-bot hits.
-  const counters = { scanCount: 1 };
-  if (!isDuplicate && !botFlag) counters.uniqueScanCount = 1;
-  await QrTag.increment(counters, { where: { id: qrTag.id } });
-  await QrTag.update({ lastScanned: new Date() }, { where: { id: qrTag.id } });
-
-  return scan;
 }
 
 /**

--- a/backend/test/qrScanDedup.test.js
+++ b/backend/test/qrScanDedup.test.js
@@ -1,0 +1,101 @@
+/**
+ * M2 (review round 3): QR scan dedup is per-scanner and atomic.
+ *
+ * Pre-fix, recordScan fetched only the tag's single MOST RECENT scan and
+ * compared client fields against it — for client A, then B, then A again
+ * within the 2-minute window, A's second scan was compared with B's and
+ * counted unique again. And nothing serialized concurrent requests: two
+ * simultaneous same-client scans both read the same prior state, both wrote
+ * isDuplicate=false, and both incremented uniqueScanCount.
+ *
+ * Post-fix the window query is scoped to (qrTagId, ipHash, ua), the claim is
+ * serialized by a per-(tag, scanner) advisory xact lock, and the scan row +
+ * counters commit in one transaction — only the winning request counts.
+ */
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestQrTag } from './helpers.js'
+import { QrTag, sequelize } from '../src/models/index.js'
+import { recordScan } from '../src/services/trackerService.js'
+
+let adminUser, campaign
+
+const CLIENT_A = { userAgent: 'Mozilla/5.0 (iPhone; client A)', referer: null, ip: '10.0.0.1' }
+const CLIENT_B = { userAgent: 'Mozilla/5.0 (Macintosh; client B)', referer: null, ip: '10.0.0.2' }
+
+beforeAll(async () => {
+  await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminUser = admin.user
+  campaign = await createTestCampaign(adminUser.id, { name: 'Scan Dedup Campaign' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const freshTag = () => createTestQrTag(campaign.id, adminUser.id)
+const tagRow = async (id) => QrTag.findByPk(id, { raw: true })
+
+describe('M2 — per-scanner dedup window', () => {
+  it('A, then B, then A again: the third scan is a DUPLICATE', async () => {
+    const tag = await freshTag()
+
+    const first = await recordScan(tag, CLIENT_A)
+    const second = await recordScan(tag, CLIENT_B)
+    const third = await recordScan(tag, CLIENT_A)
+
+    expect(first.isDuplicate).toBe(false)
+    expect(second.isDuplicate).toBe(false)
+    // Pre-fix: compared only with B (the tag's latest scan) → counted unique.
+    expect(third.isDuplicate).toBe(true)
+
+    const row = await tagRow(tag.id)
+    expect(row.scanCount).toBe(3)
+    expect(row.uniqueScanCount).toBe(2)
+  })
+
+  it('a re-scan OUTSIDE the 2-minute window is unique again', async () => {
+    const tag = await freshTag()
+    const first = await recordScan(tag, CLIENT_A)
+    await sequelize.query('UPDATE qr_scans SET ts = :ts WHERE id = :id', {
+      replacements: { ts: new Date(Date.now() - 3 * 60 * 1000), id: first.id },
+    })
+
+    const again = await recordScan(tag, CLIENT_A)
+    expect(again.isDuplicate).toBe(false)
+    expect((await tagRow(tag.id)).uniqueScanCount).toBe(2)
+  })
+})
+
+describe('M2 — the unique claim is atomic under concurrency', () => {
+  it('4 simultaneous same-client scans → exactly ONE unique', async () => {
+    const tag = await freshTag()
+
+    const scans = await Promise.all(
+      Array.from({ length: 4 }, () => recordScan(tag, CLIENT_A))
+    )
+
+    const uniques = scans.filter((s) => !s.isDuplicate)
+    // Pre-fix: every request read "no prior duplicate" and all counted unique.
+    expect(uniques).toHaveLength(1)
+
+    const row = await tagRow(tag.id)
+    expect(row.scanCount).toBe(4)
+    expect(row.uniqueScanCount).toBe(1)
+  })
+
+  it('distinct clients scanning concurrently all stay unique (no over-dedup)', async () => {
+    const tag = await freshTag()
+    const clients = [
+      CLIENT_A,
+      CLIENT_B,
+      { userAgent: 'Mozilla/5.0 (Linux; client C)', referer: null, ip: '10.0.0.3' },
+    ]
+
+    const scans = await Promise.all(clients.map((c) => recordScan(tag, c)))
+    expect(scans.every((s) => !s.isDuplicate)).toBe(true)
+
+    const row = await tagRow(tag.id)
+    expect(row.scanCount).toBe(3)
+    expect(row.uniqueScanCount).toBe(3)
+  })
+})

--- a/backend/test/unit/qrScanFlow.test.js
+++ b/backend/test/unit/qrScanFlow.test.js
@@ -62,11 +62,19 @@ const Campaign = {
   findByPk: jest.fn().mockResolvedValue(mockCampaign),
 };
 
+// M2: recordScan runs in a managed transaction under a per-scanner advisory
+// lock — the mock executes the callback and absorbs the lock query.
+const sequelize = {
+  transaction: jest.fn(async (cb) => cb({ id: 'tx' })),
+  query: jest.fn(async () => [[]]),
+};
+
 jest.unstable_mockModule('../../src/models/index.js', () => ({
   QrTag,
   QrScan,
   Attribution,
   Campaign,
+  sequelize,
 }));
 
 const {
@@ -129,7 +137,8 @@ describe('qrScanFlow (unit)', () => {
           qrTagId: 'qr-1',
           device: 'mobile',
           botFlag: false,
-        })
+        }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
     });
 
@@ -166,13 +175,8 @@ describe('qrScanFlow (unit)', () => {
       expect(createArg.botFlag).toBe(true);
     });
 
-    it('marks duplicate scan within 2 minutes', async () => {
-      const recentScan = {
-        ts: new Date(), // just now
-        ipHash: crypto.createHash('sha256').update('1.2.3.4:dev-salt').digest('hex'),
-        ua: 'Mozilla/5.0',
-      };
-      QrScan.findOne.mockResolvedValue(recentScan);
+    it('marks duplicate when a windowed same-scanner row exists (M2)', async () => {
+      QrScan.findOne.mockResolvedValue({ id: 'prior-scan' });
 
       await recordScan(mockQrTag, {
         userAgent: 'Mozilla/5.0',
@@ -184,19 +188,22 @@ describe('qrScanFlow (unit)', () => {
       expect(createArg.isDuplicate).toBe(true);
     });
 
-    it('does not mark as duplicate when IP differs', async () => {
-      const recentScan = {
-        ts: new Date(),
-        ipHash: 'different-hash',
-        ua: 'Mozilla/5.0',
-      };
-      QrScan.findOne.mockResolvedValue(recentScan);
+    it('scopes the dedup query to this scanner — other IPs cannot shadow it (M2)', async () => {
+      QrScan.findOne.mockResolvedValue(null); // no row for THIS (tag, ip, ua) window
 
       await recordScan(mockQrTag, {
         userAgent: 'Mozilla/5.0',
         referer: '',
         ip: '1.2.3.4',
       });
+
+      // Pre-M2 the query fetched the tag's single latest scan (any scanner)
+      // and compared in JS — an interleaved other-client scan made the same
+      // client "unique" again. The WHERE now carries the scanner identity.
+      const findArg = QrScan.findOne.mock.calls[0][0];
+      const expectedHash = crypto.createHash('sha256').update('1.2.3.4:dev-salt').digest('hex');
+      expect(findArg.where.ipHash).toBe(expectedHash);
+      expect(findArg.where.ua).toBe('Mozilla/5.0');
 
       const createArg = QrScan.create.mock.calls[0][0];
       expect(createArg.isDuplicate).toBe(false);
@@ -349,19 +356,19 @@ describe('qrScanFlow (unit)', () => {
   // ────────────────────────────────────────────────
 
   describe('recordScan (edge cases)', () => {
-    it('does not mark as duplicate when scan is older than 2 minutes', async () => {
-      const oldScan = {
-        ts: new Date(Date.now() - 3 * 60 * 1000), // 3 minutes ago
-        ipHash: crypto.createHash('sha256').update('1.2.3.4:dev-salt').digest('hex'),
-        ua: 'Mozilla/5.0',
-      };
-      QrScan.findOne.mockResolvedValue(oldScan);
+    it('bounds the dedup window in the query itself — stale rows never match (M2)', async () => {
+      // The 2-minute cutoff moved INTO the WHERE (ts > now-2min): a 3-minute-old
+      // row is excluded by the database, so the scoped lookup returns null.
+      QrScan.findOne.mockResolvedValue(null);
 
       await recordScan(mockQrTag, {
         userAgent: 'Mozilla/5.0',
         referer: '',
         ip: '1.2.3.4',
       });
+
+      const findArg = QrScan.findOne.mock.calls[0][0];
+      expect(findArg.where.ts).toBeDefined();
 
       const createArg = QrScan.create.mock.calls[0][0];
       expect(createArg.isDuplicate).toBe(false);

--- a/backend/test/unit/trackerService.test.js
+++ b/backend/test/unit/trackerService.test.js
@@ -13,7 +13,14 @@ const QrScan = { findOne: jest.fn(), create: jest.fn() };
 const Attribution = { create: jest.fn(), findOne: jest.fn(), findByPk: jest.fn() };
 const Campaign = { findByPk: jest.fn() };
 
-jest.unstable_mockModule('../../src/models/index.js', () => ({ QrTag, QrScan, Attribution, Campaign }));
+// M2: recordScan runs in a managed transaction under a per-scanner advisory
+// lock — the mock executes the callback and absorbs the lock query.
+const sequelize = {
+  transaction: jest.fn(async (cb) => cb({ id: 'tx' })),
+  query: jest.fn(async () => [[]]),
+};
+
+jest.unstable_mockModule('../../src/models/index.js', () => ({ QrTag, QrScan, Attribution, Campaign, sequelize }));
 
 const { resolveQrTag, recordScan, createAttribution, buildRedirectParams, resolveSession, generateSessionId } =
   await import('../../src/services/trackerService.js');
@@ -83,7 +90,8 @@ describe('trackerService (unit)', () => {
           device: 'mobile',
           botFlag: false,
           isDuplicate: false,
-        })
+        }),
+        expect.objectContaining({ transaction: expect.anything() })
       );
     });
 
@@ -109,19 +117,23 @@ describe('trackerService (unit)', () => {
       expect(createArg.botFlag).toBe(true);
     });
 
-    it('marks scan as duplicate within 2-minute window', async () => {
+    it('marks scan as duplicate when a windowed same-scanner row exists (M2)', async () => {
       const expectedHash = crypto.createHash('sha256').update('1.2.3.4:test-salt').digest('hex');
-      QrScan.findOne.mockResolvedValue({
-        ts: new Date(),
-        ipHash: expectedHash,
-        ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS)',
-      });
+      QrScan.findOne.mockResolvedValue({ id: 'prior-scan' });
 
       await recordScan(mockQrTag, {
         userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS)',
         referer: null,
         ip: '1.2.3.4',
       });
+
+      // The dedup decision is scoped to THIS scanner in the query itself —
+      // not compared in JS against whatever the tag's latest scan was.
+      const findArg = QrScan.findOne.mock.calls[0][0];
+      expect(findArg.where.qrTagId).toBe('qr-1');
+      expect(findArg.where.ipHash).toBe(expectedHash);
+      expect(findArg.where.ua).toBe('Mozilla/5.0 (iPhone; CPU iPhone OS)');
+      expect(findArg.where.ts).toBeDefined();
 
       const createArg = QrScan.create.mock.calls[0][0];
       expect(createArg.isDuplicate).toBe(true);


### PR DESCRIPTION
## Task

**M2 (MED)** — QR uniqueness dedup checks only the most recent scanner and races.

## Defect (confirmed live)

`trackerService.recordScan` fetched the tag's single most recent scan (any scanner) and compared client fields in JS. Client A → B → A within the 2-minute window: A's re-scan was compared against **B's** row and counted unique again. And with no lock or DB-backed claim, simultaneous same-client requests all read the same prior state and **all** incremented `uniqueScanCount`.

## Fix (as prescribed: scoped window + atomic claim + supporting index)

- The window query is scoped to `(qrTagId, ipHash, ua, ts > now-2min)` — the scanner identity lives in the WHERE, not a JS comparison against whoever scanned last.
- A per-`(tag, scanner)` `pg_advisory_xact_lock` serializes concurrent claims; the scan row and the `scanCount`/`uniqueScanCount` increments commit in **one transaction**, so only the winning request counts unique.
- **Migration 107** adds `idx_qr_scans_dedup_window (qrTagId, ipHash, ts)` so the windowed lookup doesn't scan a hot tag's history; mirrored on the QrScan model (sync-before-migrations test schema).

## Test proof (pre-fix captured on this branch)

```
A, then B, then A again → third scan isDuplicate: Expected true, Received false
4 concurrent same-client scans → uniques: Expected length 1, Received length 4
Tests: 2 failed, 2 passed   (controls: distinct clients stay unique; window expiry)
```

**Post-fix: 4/4** — invariants are deterministic (the lock serializes, so exactly one unique per client-window on every interleave).

## Verification

- Unit tier: **2226/2226** (tracker unit suites updated to the scoped-WHERE + transactional contract — the 2-minute cutoff and scanner scoping are asserted as query contract now that they live in SQL)
- DB suites (qrScanDedup, qrLifecycleCoherence, qrRouting, leadCapture, migrations validation): **57/57**
- eslint clean. Migration 107 is index-only (`IF NOT EXISTS` / `IF EXISTS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)