### PR TITLE
fix(qr): retire the cross-owner authenticated scan endpoint (M3)

### DIFF
--- a/backend/src/controllers/qrCodeController.js
+++ b/backend/src/controllers/qrCodeController.js
@@ -35,11 +35,6 @@ export const deleteQrCode = asyncHandler(async (req, res) => {
   res.json({ success: true, message: 'QR code deleted successfully' });
 });
 
-export const recordScan = asyncHandler(async (req, res) => {
-  const data = await qrCodeService.recordScan(req.params.id, req.body.metadata);
-  res.json({ success: true, message: 'Scan recorded successfully', data });
-});
-
 export const getAnalytics = asyncHandler(async (req, res) => {
   const analytics = await qrCodeService.getAnalytics(req.params.id, req.user);
   res.json({ success: true, data: { analytics } });

--- a/backend/src/routes/qrcodes.js
+++ b/backend/src/routes/qrcodes.js
@@ -27,8 +27,11 @@ router.put('/:id', authenticateToken, requireAdmin, qrCodeController.updateQrCod
 // Delete QR code
 router.delete('/:id', authenticateToken, requireAdmin, qrCodeController.deleteQrCode);
 
-// Record scan
-router.post('/:id/scan', authenticateToken, qrCodeController.recordScan);
+// (M3) The authenticated POST /:id/scan endpoint is RETIRED. It duplicated
+// the public tracker path (/t/:slug) with no owner scoping — any logged-in
+// user holding another owner's QR UUID could inflate that tag's scanCount and
+// dailyScans analytics. The tracker flow is the one real scan recorder; no
+// frontend surface ever called this route (dead client method removed with it).
 
 // Get analytics
 router.get('/:id/analytics', authenticateToken, qrCodeController.getAnalytics);

--- a/backend/src/services/qrCodeService.js
+++ b/backend/src/services/qrCodeService.js
@@ -3,7 +3,7 @@ import QRCode from 'qrcode';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { QrTag, Campaign, QrScan, Attribution, Prospect, SessionVisit, User, AgentGroupMember, sequelize } from '../models/index.js';
+import { QrTag, Campaign, QrScan, Attribution, Prospect, SessionVisit, User, AgentGroupMember } from '../models/index.js';
 import { storageService } from './storage.js';
 import { AppError } from '../middleware/appError.js';
 import { normalizeCustomerHostChoice, customerHostOrigin } from '../utils/customerHost.js';
@@ -327,29 +327,6 @@ export async function deleteQrCode(id, user) {
   await QrScan.destroy({ where: { qrTagId: qrTag.id } });
 
   await qrTag.destroy();
-}
-
-export async function recordScan(id, metadata = {}) {
-  const qrTag = await QrTag.findByPk(id);
-  if (!qrTag) throw new AppError('QR code not found', 404);
-  if (qrTag.status !== 'active') throw new AppError('QR code is not active', 400);
-
-  // today is derived from Date, not user input — safe to interpolate
-  const today = new Date().toISOString().split('T')[0];
-
-  await qrTag.update({
-    scanCount: sequelize.literal('"scanCount" + 1'),
-    lastScanned: new Date(),
-    analytics: sequelize.literal(`
-      jsonb_set(
-        COALESCE(analytics::jsonb, '{"dailyScans":{}}'),
-        ARRAY['dailyScans', '${today}'],
-        to_jsonb(COALESCE((analytics->'dailyScans'->>'${today}')::int, 0) + 1)
-      )
-    `)
-  });
-
-  return { scanCount: (qrTag.scanCount || 0) + 1, destinationUrl: qrTag.destinationUrl };
 }
 
 export async function getAnalytics(id, user) {

--- a/backend/test/qrLifecycleCoherence.test.js
+++ b/backend/test/qrLifecycleCoherence.test.js
@@ -41,11 +41,6 @@ const putTag = (id, body) => request(app)
   .set('Authorization', `Bearer ${adminToken}`)
   .send(body)
 
-const scan = (id) => request(app)
-  .post(`/api/qrcodes/${id}/scan`)
-  .set('Authorization', `Bearer ${adminToken}`)
-  .send({})
-
 describe('M1 — bulk lifecycle ops kill public resolution', () => {
   it('bulk deactivate stops the slug resolver, the scan path, and mirrors active=false', async () => {
     const tag = await createTestQrTag(campaign.id, adminUser.id)
@@ -61,8 +56,6 @@ describe('M1 — bulk lifecycle ops kill public resolution', () => {
     expect(row.status).toBe('inactive')
     expect(row.active).toBe(false)
 
-    const scanRes = await scan(tag.id)
-    expect(scanRes.status).toBe(400)
   })
 
   it('bulk archive does the same', async () => {
@@ -84,7 +77,6 @@ describe('M1 — bulk lifecycle ops kill public resolution', () => {
     const row = await QrTag.findByPk(tag.id, { raw: true })
     expect(row.status).toBe('active')
     expect(row.active).toBe(true)
-    expect((await scan(tag.id)).status).toBe(200)
   })
 })
 
@@ -98,9 +90,8 @@ describe('M1 — PUT {active} moves the canonical lifecycle too', () => {
     expect(row.active).toBe(false)
     expect(row.status).toBe('inactive')
 
-    // Pre-fix: status stayed 'active', so the authenticated scan path kept
-    // accepting (and counting) the supposedly disabled QR.
-    expect((await scan(tag.id)).status).toBe(400)
+    // (The authenticated scan path this used to leak through was retired in
+    // M3 — the resolver + row state above are the surviving lifecycle gates.)
     expect(await resolveQrTag(tag.slug)).toBeNull()
   })
 
@@ -125,6 +116,5 @@ describe('M1 — PUT {active} moves the canonical lifecycle too', () => {
     expect(row.status).toBe('active')
     expect(row.active).toBe(true)
     expect(await resolveQrTag(tag.slug)).not.toBeNull()
-    expect((await scan(tag.id)).status).toBe(200)
   })
 })

--- a/backend/test/qrScanEndpointRetired.test.js
+++ b/backend/test/qrScanEndpointRetired.test.js
@@ -1,0 +1,60 @@
+/**
+ * M3 (review round 3): the authenticated scan endpoint is retired.
+ *
+ * POST /api/qrcodes/:id/scan required only ANY valid login and loaded the tag
+ * by PK with no buildOwnerWhere or admin check — any customer/agent who
+ * obtained another owner's QR UUID could repeatedly inflate that tag's
+ * scanCount and dailyScans analytics. The endpoint duplicated the public
+ * tracker path (/t/:slug — the one real scan recorder, which M2 made
+ * per-scanner and atomic) and no frontend surface ever called it, so per the
+ * task's first option it is retired outright rather than scoped.
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestQrTag } from './helpers.js'
+import { QrTag } from '../src/models/index.js'
+
+let app, adminUser, adminToken, agentToken, campaign
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminUser = admin.user; adminToken = admin.token
+  const agent = await createTestUser({ role: 'agent' })
+  agentToken = agent.token
+  campaign = await createTestCampaign(adminUser.id, { name: 'Scan Endpoint Retired' })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+describe('M3 — POST /api/qrcodes/:id/scan no longer exists', () => {
+  it("an agent can no longer inflate another owner's counters", async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+
+    const res = await request(app)
+      .post(`/api/qrcodes/${tag.id}/scan`)
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send({})
+
+    // Pre-fix: 200 "Scan recorded successfully" — scanCount and dailyScans
+    // of the admin's tag moved on a rival agent's request.
+    expect(res.status).toBe(404)
+
+    const row = await QrTag.findByPk(tag.id, { raw: true })
+    expect(row.scanCount).toBe(0)
+    expect(row.lastScanned).toBeNull()
+  })
+
+  it('the route is gone for admins too — the public tracker path is the recorder', async () => {
+    const tag = await createTestQrTag(campaign.id, adminUser.id)
+
+    const res = await request(app)
+      .post(`/api/qrcodes/${tag.id}/scan`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({})
+
+    expect(res.status).toBe(404)
+    expect((await QrTag.findByPk(tag.id, { raw: true })).scanCount).toBe(0)
+  })
+})

--- a/backend/test/unit/qrCodeService.test.js
+++ b/backend/test/unit/qrCodeService.test.js
@@ -289,32 +289,8 @@ describe('qrCodeService (unit)', () => {
     });
   });
 
-  // ── recordScan ──
-
-  describe('recordScan', () => {
-    it('increments scan count and returns new count', async () => {
-      const result = await service.recordScan('qr-1', {});
-
-      expect(mocks.mockQrTag.update).toHaveBeenCalledWith(
-        expect.objectContaining({ scanCount: expect.anything() })
-      );
-      expect(result.scanCount).toBe(11); // 10 + 1
-    });
-
-    it('throws 404 when QR code not found', async () => {
-      mocks.QrTag.findByPk.mockResolvedValue(null);
-
-      await expect(service.recordScan('bad-id', {}))
-        .rejects.toThrow('QR code not found');
-    });
-
-    it('throws 400 when QR code is not active', async () => {
-      mocks.QrTag.findByPk.mockResolvedValue({ ...mocks.mockQrTag, status: 'inactive' });
-
-      await expect(service.recordScan('qr-1', {}))
-        .rejects.toThrow('QR code is not active');
-    });
-  });
+  // (recordScan retired — M3: the authenticated scan endpoint duplicated the
+  // public tracker path with no owner scoping.)
 
   // ── getAnalytics ──
 

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -528,11 +528,6 @@ class QrTagEntity extends BaseEntity {
  super('/qrcodes', 'qrTags', 'qrTag');
  }
 
- async recordScan(id, metadata = {}) {
- const response = await apiClient.post(`${this.endpoint}/${id}/scan`, { metadata });
- return response.data;
- }
-
  async getAnalytics(id, period = '30d') {
  const response = await apiClient.get(`${this.endpoint}/${id}/analytics`, { period });
  return response.data;


### PR DESCRIPTION
## Task

**M3 (MED)** — Authenticated QR scan endpoint permits cross-owner counter tampering.

## Defect (confirmed live)

`POST /api/qrcodes/:id/scan` required only `authenticateToken` — any valid login. The service loaded the tag with `QrTag.findByPk(id)`, no `buildOwnerWhere`, no admin check. Any customer/agent holding another owner's QR UUID could repeatedly inflate that tag's `scanCount` and `dailyScans` analytics.

## Fix — the task's FIRST option: retire the duplicate endpoint

Chosen over scoping, and stated here per the queue contract:
- The endpoint **duplicated the public tracker path** (`/t/:slug`), which is the one real scan recorder — and since M2 (#408) that path is per-scanner deduped and atomic. This one had neither dedup nor attribution.
- **No frontend surface ever called it** — the `client.js` method existed but had zero call sites (dead code, removed in this PR).

Removed: the route, the controller handler, `qrCodeService.recordScan`, the dead client method, and their unit tests. The M1 lifecycle test moves off the retired route (the resolver + row-state assertions carry the lifecycle proof).

## Test proof (pre-fix captured on this branch)

```
agent POST /api/qrcodes/<admin-owned-tag>/scan → Expected 404, Received 200
      ("Scan recorded successfully" — the rival's counter moved)
admin POST → also 200 pre-fix
Tests: 2 failed
```

**Post-fix: 2/2** — 404 for everyone, `scanCount`/`lastScanned` untouched.

## Verification

- Unit tier: **2223/2223** (3 retired recordScan unit tests removed)
- DB suites (qrScanEndpointRetired, qrLifecycleCoherence, qrScanDedup, campaigns): green
- Backend + frontend eslint clean; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)