### PR TITLE
fix(redeem-ops): reconcile() honours redemption reversals (M4)

### DIFF
--- a/backend/src/services/redeemOps/inventoryService.js
+++ b/backend/src/services/redeemOps/inventoryService.js
@@ -191,7 +191,11 @@ export function makeInventoryService(overrides = {}) {
       committedQuantity: sum(['committed', 'increased']) - sum(['decreased']),
       allocatedQuantity: sum(['allocated']) - sum(['deallocated']),
       issuedQuantity: sum(['issued']) - sum(['expired', 'cancelled', 'issue_reversed']),
-      redeemedQuantity: sum(['redeemed']),
+      // M4: redeem_reversed is redeemed's legitimate undo (agent_handover
+      // reversal — reverseRedeemed above). Deriving from `redeemed` alone made
+      // every reversal permanent reported drift, so each 15-minute sweep
+      // raised a false inconsistency and buried real counter corruption.
+      redeemedQuantity: sum(['redeemed']) - sum(['redeem_reversed']),
     };
     const actual = {
       committedQuantity: offer.committedQuantity,

--- a/backend/test/inventoryReconcileReversal.test.js
+++ b/backend/test/inventoryReconcileReversal.test.js
@@ -1,0 +1,104 @@
+/**
+ * M4 (review round 3): reconcile() must honour legitimate redemption
+ * reversals.
+ *
+ * reverseRedeemed (the agent_handover undo) decrements redeemedQuantity and
+ * writes a `redeem_reversed` ledger event — but reconcile() derived
+ * redeemedQuantity from `redeemed` events alone. Every legitimate reversal
+ * therefore produced PERMANENT reported drift: the 15-minute fulfilment sweep
+ * raised a false inconsistency forever after, and a stream of false alarms is
+ * exactly how real counter corruption goes unnoticed.
+ *
+ * Note on the task's "back-check existing offers": the drift lived only in
+ * reconcile()'s DERIVED output (the stored counters were always correct —
+ * reverseRedeemed moved them properly). Nothing is persisted to clear; the
+ * corrected formula clears every historical false positive on the next sweep.
+ */
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import { PartnerOrganisation, RewardOffer, sequelize } from '../src/models/index.js'
+import { makeInventoryService } from '../src/services/redeemOps/inventoryService.js'
+
+let admin, partner
+
+beforeAll(async () => {
+  await getApp()
+  admin = (await createTestUser({ role: 'admin' })).user
+  partner = await PartnerOrganisation.create({
+    legalName: 'Reconcile Reversal Partner',
+    normalizedName: 'reconcile reversal partner',
+    createdBy: admin.id,
+  })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+const inventory = makeInventoryService()
+
+async function makeOffer() {
+  return RewardOffer.create({
+    partnerOrganisationId: partner.id,
+    title: 'Reconcile Test Reward',
+    rewardType: 'free_service',
+    fundingSource: 'mktr',
+    status: 'active',
+    createdBy: admin.id,
+  })
+}
+
+/** committed → allocated → issued(n) → redeemed(n) through the real service,
+ *  so the ledger and counters move exactly as production does. */
+async function issueAndRedeem(offerId, n) {
+  await inventory.increaseCommitted({ offerId, quantity: n, actorUser: admin, reason: 'test supply' })
+  await inventory.allocate({ offerId, activationId: null, quantity: n, actorUser: admin, reason: 'test allocation' })
+  for (let i = 0; i < n; i++) {
+    await inventory.recordIssued({ offerId, activationId: null, entitlementId: null })
+    await inventory.recordRedeemed({ offerId, activationId: null, entitlementId: null, actorUser: admin })
+  }
+}
+
+describe('M4 — reconcile() subtracts redeem_reversed', () => {
+  it('a full handover reversal leaves the offer CONSISTENT', async () => {
+    const offer = await makeOffer()
+    await issueAndRedeem(offer.id, 1)
+
+    // The agent_handover undo, in the documented order: redeemed side first.
+    await inventory.reverseRedeemed({ offerId: offer.id, actorUser: admin, reason: 'voucher still in pocket' })
+    await inventory.reverseIssued({ offerId: offer.id, type: 'cancelled', reason: 'handover reversed' })
+
+    const { consistent, derived, actual } = await inventory.reconcile(offer.id)
+    // Pre-fix: derived.redeemedQuantity stayed 1 (sum of `redeemed` only)
+    // while the counter correctly read 0 — false drift on every sweep.
+    expect(derived.redeemedQuantity).toBe(0)
+    expect(actual.redeemedQuantity).toBe(0)
+    expect(consistent).toBe(true)
+  })
+
+  it('a partial reversal reconciles to the surviving redemptions', async () => {
+    const offer = await makeOffer()
+    await issueAndRedeem(offer.id, 2)
+    await inventory.reverseRedeemed({ offerId: offer.id, actorUser: admin, reason: 'one handover undone' })
+
+    const { consistent, derived, actual } = await inventory.reconcile(offer.id)
+    expect(derived.redeemedQuantity).toBe(1)
+    expect(actual.redeemedQuantity).toBe(1)
+    expect(consistent).toBe(true)
+  })
+
+  it('REAL counter corruption still surfaces (the alarm keeps its teeth)', async () => {
+    const offer = await makeOffer()
+    await issueAndRedeem(offer.id, 1)
+
+    // Corrupt the counter without a ledger row — the drift reconcile exists for.
+    await sequelize.query(
+      'UPDATE reward_offers SET "redeemedQuantity" = 5 WHERE id = :id',
+      { replacements: { id: offer.id } }
+    )
+
+    const { consistent, derived, actual } = await inventory.reconcile(offer.id)
+    expect(derived.redeemedQuantity).toBe(1)
+    expect(actual.redeemedQuantity).toBe(5)
+    expect(consistent).toBe(false)
+  })
+})


### PR DESCRIPTION
## Task

**M4 (MED)** — Inventory reconciliation ignores legitimate redemption reversals. (Shipped alone, per the queue contract: money invariant, independently revertable.)

## Defect (confirmed live)

`reverseRedeemed` — the agent_handover undo — decrements `redeemedQuantity` and writes a `redeem_reversed` ledger event. `reconcile()` derived `redeemedQuantity` from `redeemed` events **only** (`inventoryService.js:194`), while `issuedQuantity` already subtracted its reversal types. Every legitimate reversal therefore produced permanent reported drift: the 15-minute fulfilment sweep raised a false inconsistency forever after, burying real counter corruption in noise.

## Fix

`redeemedQuantity: sum(['redeemed']) - sum(['redeem_reversed'])` — one line, plus the comment explaining why the undo type belongs in the derivation.

**On the task's "back-check existing offers":** the drift lived only in `reconcile()`'s *derived* output — the stored counters were always correct (`reverseRedeemed` moved them properly in its guarded UPDATE). Nothing is persisted to clear: the corrected formula clears every historical false positive on the very next sweep. Stated here so the reviewer's third ask is answered, not skipped.

## Test proof (pre-fix captured on this branch)

```
full handover reversal   → derived.redeemedQuantity: Expected 0, Received 1  (consistent:false forever)
partial reversal (2→1)   → derived.redeemedQuantity: Expected 1, Received 2
Tests: 2 failed, 1 passed
```

**Post-fix: 3/3** — including the alarm-keeps-its-teeth control: a raw counter edit with no ledger row still reconciles `consistent:false`.

## Verification

- Unit tier: **2223/2223**
- DB suites (inventoryReconcileReversal, redeemOpsFulfilmentDelivery, redeemOpsAllocationRace): **31/31**
- eslint clean; no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)