### PR TITLE
fix(webhooks): subscriber deletion works — history survives via SET NULL (M5)

### DIFF
--- a/backend/src/database/migrations/108-webhook-delivery-set-null.js
+++ b/backend/src/database/migrations/108-webhook-delivery-set-null.js
@@ -1,0 +1,49 @@
+/**
+ * 108 — webhook delivery history survives subscriber deletion (M5).
+ *
+ * Migration 014 set webhook_deliveries.subscriberId to ON DELETE SET NULL,
+ * but the column itself stayed NOT NULL — a contradiction Postgres resolves
+ * by REJECTING the parent delete. Deleting any subscriber that ever received
+ * a delivery therefore 500ed, and a used subscriber could not be retired.
+ *
+ * Policy (one truth across model, column, and FK): history SURVIVES — the
+ * column becomes nullable and the FK is re-asserted as SET NULL so the test
+ * schema (sync-built, then migration-replayed) carries the same rule as prod.
+ * Admin listings LEFT JOIN the subscriber and retryDelivery already rejects
+ * a delivery whose subscriber is gone.
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.query(
+    'ALTER TABLE webhook_deliveries ALTER COLUMN "subscriberId" DROP NOT NULL'
+  );
+
+  // Re-assert the SET NULL rule idempotently (014's resetFK pattern) — the
+  // sync-built test schema may carry a different generated constraint.
+  const name = 'webhook_deliveries_subscriberId_fkey';
+  await queryInterface.removeConstraint('webhook_deliveries', name).catch(() => {});
+  await queryInterface
+    .removeConstraint('webhook_deliveries', 'webhook_deliveries_subscriberId_webhook_subscribers_fk')
+    .catch(() => {});
+  await sequelize.query(`
+    ALTER TABLE webhook_deliveries ADD CONSTRAINT "${name}"
+    FOREIGN KEY ("subscriberId") REFERENCES webhook_subscribers(id)
+    ON DELETE SET NULL NOT VALID
+  `);
+  await sequelize.query(
+    `ALTER TABLE webhook_deliveries VALIDATE CONSTRAINT "${name}"`
+  );
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  // Restore NOT NULL only after clearing orphans — the rows SET NULL created.
+  await sequelize.query(
+    'DELETE FROM webhook_deliveries WHERE "subscriberId" IS NULL'
+  );
+  await sequelize.query(
+    'ALTER TABLE webhook_deliveries ALTER COLUMN "subscriberId" SET NOT NULL'
+  );
+}

--- a/backend/src/models/WebhookDelivery.js
+++ b/backend/src/models/WebhookDelivery.js
@@ -9,7 +9,14 @@ const WebhookDelivery = sequelize.define('WebhookDelivery', {
   },
   subscriberId: {
     type: DataTypes.UUID,
-    allowNull: false,
+    // M5: nullable — the FK is ON DELETE SET NULL (migrations 014 + 108), so
+    // delivery history SURVIVES subscriber deletion as an audit record.
+    // Pre-fix this said allowNull:false while the FK said SET NULL: deleting
+    // any subscriber with history made Postgres null a NOT NULL column and
+    // reject the delete (admin 500). Consumers tolerate the null: listings
+    // LEFT JOIN the subscriber, and retryDelivery rejects cleanly when the
+    // subscriber is gone.
+    allowNull: true,
     references: {
       model: 'webhook_subscribers',
       key: 'id'

--- a/backend/test/unit/models.test.js
+++ b/backend/test/unit/models.test.js
@@ -251,9 +251,11 @@ describe('Sequelize Models (definitions & validations)', () => {
       expect(attrs(WebhookDelivery).attempts.defaultValue).toBe(0);
     });
 
-    it('has subscriberId foreign key', () => {
+    it('has subscriberId foreign key (nullable — history survives SET NULL, M5)', () => {
       expect(attrs(WebhookDelivery).subscriberId.references.model).toBe('webhook_subscribers');
-      expect(attrs(WebhookDelivery).subscriberId.allowNull).toBe(false);
+      // ON DELETE SET NULL (migrations 014+108) requires the column nullable —
+      // the old allowNull:false made every used-subscriber delete a 500.
+      expect(attrs(WebhookDelivery).subscriberId.allowNull).toBe(true);
     });
   });
 });

--- a/backend/test/webhookSubscriberDeletion.test.js
+++ b/backend/test/webhookSubscriberDeletion.test.js
@@ -1,0 +1,72 @@
+/**
+ * M5 (review round 3): a used webhook subscriber can actually be deleted.
+ *
+ * Pre-fix, webhook_deliveries.subscriberId was NOT NULL while its FK said
+ * ON DELETE SET NULL (migration 014) — a contradiction Postgres resolves by
+ * rejecting the parent delete. Any subscriber with delivery history 500ed on
+ * DELETE, so a retired integration could never be removed as advertised.
+ *
+ * Policy (one truth across model + column + FK, migration 108): history
+ * SURVIVES — the delete succeeds, deliveries keep their audit row with
+ * subscriberId NULL, listings LEFT JOIN, and a retry of an orphaned delivery
+ * rejects cleanly instead of dying on a missing parent.
+ */
+import { getApp, closeDb } from './helpers.js'
+import { WebhookSubscriber, WebhookDelivery } from '../src/models/index.js'
+import { deleteSubscriber, listDeliveries } from '../src/services/webhookAdminService.js'
+import { makeWebhookService } from '../src/services/webhookService.js'
+
+beforeAll(async () => {
+  await getApp()
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+async function subscriberWithDelivery() {
+  const subscriber = await WebhookSubscriber.create({
+    name: `Retired Integration ${Date.now()}`,
+    url: 'https://example.invalid/hook',
+    secret: 'shh',
+    events: ['lead.created'],
+    enabled: false,
+  })
+  const delivery = await WebhookDelivery.create({
+    subscriberId: subscriber.id,
+    eventType: 'lead.created',
+    payload: { hello: 'world' },
+    status: 'failed',
+    attempts: 3,
+  })
+  return { subscriber, delivery }
+}
+
+describe('M5 — deleting a subscriber with delivery history', () => {
+  it('succeeds, and the delivery survives as an orphaned audit row', async () => {
+    const { subscriber, delivery } = await subscriberWithDelivery()
+
+    // Pre-fix: Postgres tried to SET NULL a NOT NULL column and rejected the
+    // delete — the admin DELETE path surfaced a database error.
+    await expect(deleteSubscriber(subscriber.id)).resolves.toBeUndefined()
+
+    expect(await WebhookSubscriber.findByPk(subscriber.id)).toBeNull()
+    const survivor = await WebhookDelivery.findByPk(delivery.id)
+    expect(survivor).not.toBeNull()
+    expect(survivor.subscriberId).toBeNull()
+    expect(survivor.eventType).toBe('lead.created')
+  })
+
+  it('orphaned deliveries still list (LEFT JOIN) and retry rejects cleanly', async () => {
+    const { subscriber, delivery } = await subscriberWithDelivery()
+    await deleteSubscriber(subscriber.id)
+
+    const { deliveries } = await listDeliveries({ status: 'failed', limit: 100 })
+    const row = deliveries.find((d) => d.id === delivery.id)
+    expect(row).toBeDefined()
+    expect(row.subscriber).toBeNull()
+
+    const svc = makeWebhookService()
+    await expect(svc.retryDelivery(delivery.id)).rejects.toThrow('Subscriber not found for delivery')
+  })
+})


### PR DESCRIPTION
## Task

**M5 (MED)** — Webhook subscriber deletion conflicts with its NOT NULL delivery history.

## Defect (confirmed live)

`webhook_deliveries.subscriberId` was `allowNull: false` while its FK — reset by migration 014 — said `ON DELETE SET NULL`. Postgres resolves that contradiction by **rejecting the parent delete**: any subscriber with delivery history 500ed on the admin DELETE path (`null value in column "subscriberId" violates not-null constraint`), so a used subscriber could not be retired.

## Fix — one policy across model, column, and FK: history survives

- Model: `subscriberId` becomes nullable (with the policy documented at the column).
- **Migration 108**: `DROP NOT NULL`, then re-asserts the `SET NULL` FK idempotently (014's `resetFK` NOT VALID → VALIDATE pattern) so the sync-built test schema carries the same rule as prod. `down()` restores NOT NULL only after deleting the orphans SET NULL created.
- No consumer changes needed — verified: `listDeliveries`/`getDeliveryById` LEFT JOIN the subscriber, and `retryDelivery` already rejects `'Subscriber not found for delivery'` when the parent is gone.

Chosen over RESTRICT/disable-only: the association, migration 014, and the admin UX all already declared the SET NULL intent — the column was the one part that never caught up. Delivery rows are the audit/dead-letter record and should outlive the endpoint they were sent to (same policy as migrations 102/105).

## Test proof (pre-fix captured on this branch)

```
deleteSubscriber(used subscriber) → rejected:
  SequelizeDatabaseError: null value in column "subscriberId" of relation
  "webhook_deliveries" violates not-null constraint
Tests: 2 failed
```

**Post-fix: 2/2** — delete succeeds; the delivery survives with `subscriberId NULL`; it still lists (subscriber: null); retrying it rejects cleanly.

## Verification

- Unit tier: **2223/2223** (`models.test.js` updated to the nullable contract)
- Webhook DB suites + migrations validation: **25/25**
- eslint clean. Migration tier runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)