### PR TITLE
fix(screening): alert throttle claims its window atomically (M6)

### DIFF
--- a/backend/src/services/screeningAlerts.js
+++ b/backend/src/services/screeningAlerts.js
@@ -16,9 +16,9 @@ import { logger } from '../utils/logger.js';
  * Two channels, both idempotent:
  *  - ONE ProspectActivity per lead ("fund a package"), so the admin drawer
  *    shows WHY the lead is stuck without log access.
- *  - ONE ops email per campaign per 24h (throttled via idempotency_keys —
- *    `key` is the table's PRIMARY KEY, so the throttle key embeds the scope
- *    prefix and an expired row is refreshed in place, never insert-raced).
+ *  - ONE ops email per campaign per 24h. Both are gated by ONE atomic
+ *    idempotency claim (INSERT … ON CONFLICT DO UPDATE WHERE expired …
+ *    RETURNING) — exactly one concurrent sweep call wins the window (M6).
  *
  * Only alarms holds older than MIN_HOLD_ALERT_MS: a capture-time transient
  * (subscriber briefly disabled, race with funding) must not page anyone —
@@ -29,6 +29,39 @@ const MIN_HOLD_ALERT_MS = 30 * 60 * 1000; // 30 min held-and-qualified before al
 const EMAIL_THROTTLE_MS = 24 * 60 * 60 * 1000; // one ops email per campaign per day
 const ACTIVITY_ALERT_TAG = 'screening_undeliverable';
 const THROTTLE_SCOPE = 'screening:undeliverable-alert';
+// Effectively-forever claim for the once-per-lead activity: the hourly
+// idempotency cleanup only purges expiresAt < now, so this row never dies.
+const ACTIVITY_CLAIM_TTL_MS = 100 * 365 * 24 * 60 * 60 * 1000;
+
+/**
+ * Atomically claim (scope, key) for ttlMs — exactly ONE concurrent caller
+ * wins. The INSERT takes a fresh row; when the stored claim has EXPIRED the
+ * conditional DO UPDATE revives it for a single winner; a live claim returns
+ * no row. (M6: the old select-then-insert/update raced — concurrent sweep
+ * calls both saw no throttle row, the loser's caught unique error was
+ * DISCARDED and both continued to sendEmail; an expired row was update-raced
+ * by both callers the same way.)
+ */
+async function claimIdempotencyWindow(d, { scope, key, ttlMs, meta = null }) {
+  const [rows] = await d.sequelize.query(
+    `INSERT INTO idempotency_keys
+       (scope, key, "responseBody", "responseCode", "expiresAt", "createdAt", "updatedAt")
+     VALUES (:scope, :key, CAST(:body AS json), 200, :expiresAt, now(), now())
+     ON CONFLICT (scope, key) DO UPDATE
+       SET "expiresAt" = EXCLUDED."expiresAt", "updatedAt" = now()
+       WHERE idempotency_keys."expiresAt" <= now()
+     RETURNING key`,
+    {
+      replacements: {
+        scope,
+        key,
+        body: meta ? JSON.stringify(meta) : null,
+        expiresAt: new Date(d.now() + ttlMs),
+      },
+    }
+  );
+  return Array.isArray(rows) && rows.length > 0;
+}
 
 function alertRecipient() {
   return process.env.SCREENING_ALERT_EMAIL || process.env.SMS_ALERT_EMAIL || null;
@@ -55,15 +88,23 @@ export async function notifyUndeliverableHold({ prospect, reason, campaign = nul
       return { alerted: false, reason: 'too_fresh' };
     }
 
-    // Once-per-lead activity. metadata->>'alert' is the dedup tag — checked
-    // with a raw indexed-enough probe (small per-prospect activity sets).
+    // Once-per-lead activity. The atomic claim is the RACE gate (exactly one
+    // concurrent sweep call wins); the probe keeps claim-era calls from
+    // double-writing next to historical rows created before the claim existed.
+    const activityClaimed = await claimIdempotencyWindow(d, {
+      scope: THROTTLE_SCOPE,
+      key: `${ACTIVITY_ALERT_TAG}:${prospect.id}`,
+      ttlMs: ACTIVITY_CLAIM_TTL_MS,
+      meta: { prospectId: prospect.id },
+    });
     const [rows] = await d.sequelize.query(
       `SELECT 1 FROM prospect_activities
         WHERE "prospectId" = :id AND metadata->>'alert' = :tag LIMIT 1`,
       { replacements: { id: prospect.id, tag: ACTIVITY_ALERT_TAG } }
     );
     const activityExists = Array.isArray(rows) && rows.length > 0;
-    if (!activityExists) {
+    const activityCreated = activityClaimed && !activityExists;
+    if (activityCreated) {
       await d.ProspectActivity.create({
         prospectId: prospect.id,
         type: 'updated',
@@ -74,32 +115,22 @@ export async function notifyUndeliverableHold({ prospect, reason, campaign = nul
       });
     }
 
-    // Per-campaign 24h email throttle. `key` is the PK — no row expiry job
-    // exists, so an expired throttle row is UPDATEd back to life rather than
-    // re-created (insert would PK-collide forever after the first day).
+    // Per-campaign 24h email throttle — the SAME atomic claim: absent row →
+    // insert wins; expired row → one winner revives it; live row → throttled.
+    // Send ONLY when the claim returned a row (M6).
     const to = alertRecipient();
-    if (!to) return { alerted: !activityExists, email: 'unconfigured' };
+    if (!to) return { alerted: activityCreated, email: 'unconfigured' };
 
     const throttleKey = `${THROTTLE_SCOPE}:${prospect.campaignId || 'none'}`;
     const nowMs = d.now();
-    const existing = await d.IdempotencyKey.findOne({ where: { key: throttleKey } });
-    if (existing && new Date(existing.expiresAt).getTime() > nowMs) {
-      return { alerted: !activityExists, email: 'throttled' };
-    }
-    if (existing) {
-      await existing.update({ expiresAt: new Date(nowMs + EMAIL_THROTTLE_MS) });
-    } else {
-      await d.IdempotencyKey.create({
-        key: throttleKey,
-        scope: THROTTLE_SCOPE,
-        responseBody: { campaignId: prospect.campaignId || null },
-        responseCode: 200,
-        expiresAt: new Date(nowMs + EMAIL_THROTTLE_MS),
-      }).catch((err) => {
-        // Lost a same-instant race — the winner sends; treat as throttled.
-        if (err?.name === 'SequelizeUniqueConstraintError') return null;
-        throw err;
-      });
+    const emailClaimed = await claimIdempotencyWindow(d, {
+      scope: THROTTLE_SCOPE,
+      key: throttleKey,
+      ttlMs: EMAIL_THROTTLE_MS,
+      meta: { campaignId: prospect.campaignId || null },
+    });
+    if (!emailClaimed) {
+      return { alerted: activityCreated, email: 'throttled' };
     }
 
     const campaignName = campaign?.name || prospect.campaignId || 'unknown campaign';

--- a/backend/test/screeningAlertThrottle.test.js
+++ b/backend/test/screeningAlertThrottle.test.js
@@ -1,0 +1,94 @@
+/**
+ * M6 (review round 3): the screening-alert throttle holds under concurrency,
+ * on real Postgres.
+ *
+ * Pre-fix, the throttle was select-then-insert/update: concurrent sweep calls
+ * for the same campaign both observed no live row; one insert won, the
+ * loser's caught unique error was DISCARDED and both continued to
+ * sendEmail(). An EXPIRED row was update-raced the same way, and the
+ * per-lead activity's select-then-create could double-write the alert.
+ *
+ * Post-fix both windows are ONE atomic claim (INSERT … ON CONFLICT
+ * (scope,key) DO UPDATE … WHERE expired … RETURNING) — exactly one concurrent
+ * caller wins; the revive path after expiry has exactly one winner too.
+ */
+import { jest } from '@jest/globals'
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js'
+import { sequelize } from '../src/models/index.js'
+import { notifyUndeliverableHold } from '../src/services/screeningAlerts.js'
+
+let campaign, prospect
+
+const envBackup = {}
+beforeAll(async () => {
+  envBackup.SCREENING_ALERT_EMAIL = process.env.SCREENING_ALERT_EMAIL
+  process.env.SCREENING_ALERT_EMAIL = 'ops@throttle.test'
+  await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  campaign = await createTestCampaign(admin.user.id, { name: 'Throttle Race Campaign' })
+  prospect = await createTestProspect(campaign.id, {
+    quarantinedAt: new Date(Date.now() - 45 * 60 * 1000), // stale enough to alarm
+  })
+})
+
+afterAll(async () => {
+  if (envBackup.SCREENING_ALERT_EMAIL === undefined) delete process.env.SCREENING_ALERT_EMAIL
+  else process.env.SCREENING_ALERT_EMAIL = envBackup.SCREENING_ALERT_EMAIL
+  await closeDb()
+})
+
+const activityCount = async () => {
+  const [rows] = await sequelize.query(
+    `SELECT count(*)::int AS n FROM prospect_activities
+      WHERE "prospectId" = :id AND metadata->>'alert' = 'screening_undeliverable'`,
+    { replacements: { id: prospect.id } }
+  )
+  return rows[0].n
+}
+
+test('4 concurrent sweep calls → exactly ONE email and ONE activity; expiry revives for ONE winner', async () => {
+  const sendEmail = jest.fn().mockResolvedValue({})
+
+  const wave1 = await Promise.all(
+    Array.from({ length: 4 }, () =>
+      notifyUndeliverableHold(
+        { prospect, reason: 'no_intended_agent', campaign },
+        { sendEmail }
+      )
+    )
+  )
+
+  // Pre-fix: every loser fell through its caught unique error and sent too.
+  expect(sendEmail).toHaveBeenCalledTimes(1)
+  expect(wave1.filter((r) => r.email === 'sent')).toHaveLength(1)
+  expect(wave1.filter((r) => r.email === 'throttled')).toHaveLength(3)
+  expect(await activityCount()).toBe(1)
+
+  // A second wave inside the 24h window stays silent.
+  const inside = await notifyUndeliverableHold(
+    { prospect, reason: 'no_intended_agent', campaign },
+    { sendEmail }
+  )
+  expect(inside.email).toBe('throttled')
+  expect(sendEmail).toHaveBeenCalledTimes(1)
+
+  // Expire the throttle row, then race again: the conditional DO UPDATE
+  // revive has exactly ONE winner (pre-fix both callers updated and sent).
+  await sequelize.query(
+    `UPDATE idempotency_keys SET "expiresAt" = now() - interval '1 hour'
+      WHERE scope = 'screening:undeliverable-alert'
+        AND key = 'screening:undeliverable-alert:' || :campaignId`,
+    { replacements: { campaignId: campaign.id } }
+  )
+  const wave2 = await Promise.all(
+    Array.from({ length: 3 }, () =>
+      notifyUndeliverableHold(
+        { prospect, reason: 'no_intended_agent', campaign },
+        { sendEmail }
+      )
+    )
+  )
+  expect(sendEmail).toHaveBeenCalledTimes(2)
+  expect(wave2.filter((r) => r.email === 'sent')).toHaveLength(1)
+  expect(await activityCount()).toBe(1) // the once-per-lead claim held throughout
+})

--- a/backend/test/unit/screeningAlerts.test.js
+++ b/backend/test/unit/screeningAlerts.test.js
@@ -2,10 +2,13 @@
  * screeningAlerts unit tests (PR-1, draw-launch-integrity §2.2) — the
  * loud-failure surfacing for undeliverable qualified holds. Pure DI, no live
  * Postgres, no module mocks. Covers the 30-min freshness fence, the
- * once-per-lead activity guard, and the per-campaign 24h email throttle
- * (including the expired-PK-row refresh — idempotency_keys.key is a PRIMARY
- * KEY with no cleanup job, so a stale row must be UPDATEd back to life, never
- * insert-raced into a permanent PK collision).
+ * once-per-lead activity guard, and the per-campaign 24h email throttle.
+ *
+ * M6: both guards are now ONE atomic idempotency claim
+ * (INSERT … ON CONFLICT (scope,key) DO UPDATE … WHERE expired … RETURNING) —
+ * a caller acts only when the claim returns a row. These tests pin that
+ * contract at the query boundary; the real-Postgres race (two sweeps, one
+ * email) is proven in test/screeningAlertThrottle.test.js.
  */
 import { jest } from '@jest/globals';
 import { notifyUndeliverableHold } from '../../src/services/screeningAlerts.js';
@@ -14,6 +17,8 @@ const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: (
 
 const T0 = Date.parse('2026-07-24T12:00:00Z');
 const HELD_45M_AGO = new Date(T0 - 45 * 60 * 1000).toISOString();
+
+const ACTIVITY_KEY_PREFIX = 'screening_undeliverable:';
 
 function prospectRow(over = {}) {
   return {
@@ -24,20 +29,33 @@ function prospectRow(over = {}) {
   };
 }
 
-function deps(over = {}) {
+/**
+ * Routes the service's three query shapes:
+ *  - claim INSERT for the once-per-lead activity (key 'screening_undeliverable:<id>')
+ *  - probe SELECT on prospect_activities
+ *  - claim INSERT for the per-campaign email throttle
+ */
+function deps({ activityClaim = true, emailClaim = true, priorActivity = false, ...over } = {}) {
+  const query = jest.fn(async (sql, options) => {
+    if (/INSERT INTO idempotency_keys/.test(sql)) {
+      const key = options?.replacements?.key || '';
+      const wins = key.startsWith(ACTIVITY_KEY_PREFIX) ? activityClaim : emailClaim;
+      return [wins ? [{ key }] : []];
+    }
+    return [priorActivity ? [{ 1: 1 }] : []];
+  });
   return {
-    sequelize: { query: jest.fn().mockResolvedValue([[]]) }, // no prior alert activity
+    sequelize: { query },
     ProspectActivity: { create: jest.fn().mockResolvedValue({}) },
-    IdempotencyKey: {
-      findOne: jest.fn().mockResolvedValue(null),
-      create: jest.fn().mockResolvedValue({}),
-    },
     sendEmail: jest.fn().mockResolvedValue({}),
     logger: silentLogger,
     now: () => T0,
     ...over,
   };
 }
+
+const claimCalls = (d) =>
+  d.sequelize.query.mock.calls.filter(([sql]) => /INSERT INTO idempotency_keys/.test(sql));
 
 const ENV_KEYS = ['SCREENING_ALERT_EMAIL', 'SMS_ALERT_EMAIL'];
 const envBackup = {};
@@ -61,7 +79,7 @@ describe('notifyUndeliverableHold', () => {
     expect(d.sendEmail).not.toHaveBeenCalled();
   });
 
-  it('stale hold → writes the activity ONCE and emails with campaign context', async () => {
+  it('stale hold → claims both windows atomically, writes the activity ONCE and emails', async () => {
     const d = deps();
     const out = await notifyUndeliverableHold(
       { prospect: prospectRow(), reason: 'no_intended_agent', campaign: { name: 'iPhone Draw' } },
@@ -70,7 +88,16 @@ describe('notifyUndeliverableHold', () => {
     expect(out).toMatchObject({ alerted: true, email: 'sent' });
     expect(d.ProspectActivity.create).toHaveBeenCalledTimes(1);
     expect(d.ProspectActivity.create.mock.calls[0][0].metadata).toMatchObject({ alert: 'screening_undeliverable' });
-    expect(d.IdempotencyKey.create).toHaveBeenCalledTimes(1);
+
+    // The M6 contract: the send is gated by the atomic claim, and the claim
+    // statement carries the conditional-revive shape (never a blind upsert).
+    const claims = claimCalls(d);
+    expect(claims).toHaveLength(2); // once-per-lead activity + email throttle
+    for (const [sql] of claims) {
+      expect(sql).toMatch(/ON CONFLICT \(scope, key\) DO UPDATE/);
+      expect(sql).toMatch(/WHERE idempotency_keys\."expiresAt" <= now\(\)/);
+      expect(sql).toMatch(/RETURNING key/);
+    }
     const mail = d.sendEmail.mock.calls[0][0];
     expect(mail.to).toBe('ops@test.local');
     expect(mail.subject).toContain('iPhone Draw');
@@ -78,38 +105,24 @@ describe('notifyUndeliverableHold', () => {
   });
 
   it('activity already written for this lead → not duplicated (email logic still runs)', async () => {
-    const d = deps({ sequelize: { query: jest.fn().mockResolvedValue([[{ 1: 1 }]]) } });
+    const d = deps({ priorActivity: true });
     await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
     expect(d.ProspectActivity.create).not.toHaveBeenCalled();
     expect(d.sendEmail).toHaveBeenCalledTimes(1);
   });
 
-  it('live throttle row for the campaign → email suppressed', async () => {
-    const d = deps({
-      IdempotencyKey: {
-        findOne: jest.fn().mockResolvedValue({ expiresAt: new Date(T0 + 60 * 60 * 1000) }),
-        create: jest.fn(),
-      },
-    });
+  it('LOST activity claim (a concurrent sweep is writing) → no duplicate activity', async () => {
+    const d = deps({ activityClaim: false });
+    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
+    expect(d.ProspectActivity.create).not.toHaveBeenCalled();
+    expect(out.email).toBe('sent'); // the email window is claimed independently
+  });
+
+  it('live/lost email claim → throttled, NOTHING sent (the loser no longer falls through)', async () => {
+    const d = deps({ emailClaim: false });
     const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
     expect(out.email).toBe('throttled');
     expect(d.sendEmail).not.toHaveBeenCalled();
-    expect(d.IdempotencyKey.create).not.toHaveBeenCalled();
-  });
-
-  it('EXPIRED throttle row → refreshed in place (PK has no cleanup job) and the email re-sends', async () => {
-    const update = jest.fn().mockResolvedValue({});
-    const d = deps({
-      IdempotencyKey: {
-        findOne: jest.fn().mockResolvedValue({ expiresAt: new Date(T0 - 1000), update }),
-        create: jest.fn(),
-      },
-    });
-    const out = await notifyUndeliverableHold({ prospect: prospectRow(), reason: 'no_subscriber' }, d);
-    expect(out.email).toBe('sent');
-    expect(update).toHaveBeenCalledTimes(1); // UPDATEd, never re-created
-    expect(d.IdempotencyKey.create).not.toHaveBeenCalled();
-    expect(d.sendEmail).toHaveBeenCalledTimes(1);
   });
 
   it('no recipient configured → activity still lands, email marked unconfigured', async () => {
@@ -119,6 +132,7 @@ describe('notifyUndeliverableHold', () => {
     expect(out.email).toBe('unconfigured');
     expect(d.ProspectActivity.create).toHaveBeenCalledTimes(1);
     expect(d.sendEmail).not.toHaveBeenCalled();
+    expect(claimCalls(d)).toHaveLength(1); // no email claim without a recipient
   });
 
   it('SMS_ALERT_EMAIL is the fallback recipient', async () => {


### PR DESCRIPTION
## Task

**M6 (MED)** — Screening alert throttle still sends duplicate emails under concurrency.

## Defect (confirmed live)

The 24h per-campaign email throttle was select-then-insert/update (`screeningAlerts.js`): concurrent sweep calls both observed no live row; one insert won and **the loser's caught `SequelizeUniqueConstraintError` was discarded** — the code fell through and both called `sendEmail()`. An **expired** row was update-raced by both callers the same way. The once-per-lead activity's select-then-create had the same race.

## Fix (exactly the prescribed single-statement lease)

One atomic claim for both windows:

```sql
INSERT INTO idempotency_keys (scope, key, …) VALUES (…)
ON CONFLICT (scope, key) DO UPDATE SET "expiresAt" = EXCLUDED."expiresAt"
  WHERE idempotency_keys."expiresAt" <= now()
RETURNING key
```

- Absent row → the INSERT wins. Expired row → the conditional DO UPDATE revives it for **exactly one** winner. Live row → no row returned.
- The email sends **only when the claim returns a row**; losers return `throttled`.
- The per-lead activity tag is backed by the same claim (`ON CONFLICT` target is the composite PK `(scope, key)` from migration 104) with an effectively-forever TTL — the hourly cleanup only purges expired keys — while the existing probe still respects pre-claim-era historical activity rows.

## Test proof (pre-fix captured on this branch, real Postgres)

```
4 concurrent sweep calls → sendEmail: Expected number of calls: 1, Received: 4
Tests: 1 failed
```

**Post-fix:** exactly one send + one `screening_undeliverable` activity across the wave; an in-window caller is `throttled`; after force-expiring the row, a 3-way race sends exactly one more (single revive winner) and the activity count stays 1.

## Verification

- Unit tier: **2223/2223** — the DI suite is rewritten to the claim contract (9 cases: claim shape pinned to `ON CONFLICT (scope, key) … WHERE expired … RETURNING`, lost-claim paths for both windows, recipient fallbacks, never-throws)
- DB suites (screeningAlertThrottle, idempotencyCompositeKey): green
- eslint clean; no migration (uses the existing composite-PK table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)