### PR TITLE
fix(redeem-ops): one live primary contact per partner (M7)

### DIFF
--- a/backend/src/database/migrations/109-one-live-primary-contact.js
+++ b/backend/src/database/migrations/109-one-live-primary-contact.js
@@ -1,0 +1,50 @@
+/**
+ * 109 — at most ONE live primary contact per partner (M7).
+ *
+ * addContact/updateContact demoted existing primaries and inserted the new
+ * one inside a transaction, but nothing serialized two concurrent switches
+ * and no index rejected the second primary — both could commit, and the
+ * cadence materializer then silently picked the OLDER primary by createdAt,
+ * sending automated outreach to a different person than the operator chose.
+ *
+ * Reconciliation: the NEWEST live primary per partner keeps the flag (it is
+ * the operator's latest expressed intent — the older one is exactly the row
+ * the drift was mis-selecting); the rest demote. Then the partial unique
+ * index makes a second live primary unstorable. Mirrored on the model
+ * (sync-before-migrations test boot).
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.transaction(async (t) => {
+    const q = (sql) => sequelize.query(sql, { transaction: t });
+
+    await q(`
+      UPDATE partner_contacts SET "isPrimary" = false
+       WHERE id IN (
+         SELECT id FROM (
+           SELECT id, row_number() OVER (
+             PARTITION BY "partnerOrganisationId"
+             ORDER BY "createdAt" DESC, id DESC
+           ) AS rn
+             FROM partner_contacts
+            WHERE "isPrimary" = true AND "archivedAt" IS NULL
+         ) ranked
+         WHERE rn > 1
+       )
+    `);
+
+    await q(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uq_pc_one_live_primary
+        ON partner_contacts ("partnerOrganisationId")
+        WHERE "isPrimary" = true AND "archivedAt" IS NULL
+    `);
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'DROP INDEX IF EXISTS uq_pc_one_live_primary'
+  );
+}

--- a/backend/src/models/PartnerContact.js
+++ b/backend/src/models/PartnerContact.js
@@ -21,7 +21,16 @@ const PartnerContact = sequelize.define('PartnerContact', {
 }, {
   tableName: 'partner_contacts',
   indexes: [
-    { fields: ['partnerOrganisationId'], name: 'idx_pc_partner' }
+    { fields: ['partnerOrganisationId'], name: 'idx_pc_partner' },
+    // M7: at most ONE live primary per partner — concurrent "make primary"
+    // races hit this instead of leaving two primaries for the cadence
+    // materializer to pick between. Mirrored in migration 109 for prod.
+    {
+      unique: true,
+      fields: ['partnerOrganisationId'],
+      name: 'uq_pc_one_live_primary',
+      where: { isPrimary: true, archivedAt: null }
+    }
   ]
 });
 

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -692,6 +692,11 @@ export function makePartnerService(overrides = {}) {
     if (!body.name || !String(body.name).trim()) throw new AppError('Contact name is required', 400);
     return d.sequelize.transaction(async (t) => {
       if (body.isPrimary) {
+        // M7: serialize primary switches on the parent row — two concurrent
+        // "make primary" transactions otherwise both demote zero rows and
+        // both insert a primary. The partial unique index (migration 109) is
+        // the DB backstop; the lock keeps the demote+insert pair atomic.
+        await d.PartnerOrganisation.findByPk(id, { transaction: t, lock: t.LOCK.UPDATE });
         await d.PartnerContact.update(
           { isPrimary: false },
           { where: { partnerOrganisationId: id }, transaction: t }
@@ -725,6 +730,8 @@ export function makePartnerService(overrides = {}) {
     }
     return d.sequelize.transaction(async (t) => {
       if (updates.isPrimary === true) {
+        // M7: same serialization as addContact — lock the parent, then swap.
+        await d.PartnerOrganisation.findByPk(contact.partnerOrganisationId, { transaction: t, lock: t.LOCK.UPDATE });
         await d.PartnerContact.update(
           { isPrimary: false },
           { where: { partnerOrganisationId: contact.partnerOrganisationId }, transaction: t }

--- a/backend/test/partnerPrimaryContact.test.js
+++ b/backend/test/partnerPrimaryContact.test.js
@@ -1,0 +1,104 @@
+/**
+ * M7 (review round 3): at most one live primary contact per partner, even
+ * under concurrency.
+ *
+ * Pre-fix, two concurrent addContact(..., {isPrimary:true}) transactions on a
+ * partner with no contacts both demoted ZERO rows and both inserted a primary
+ * — no lock serialized the switch and no index rejected the second row. The
+ * cadence materializer then silently picked the OLDER primary by createdAt,
+ * so automated outreach could target a different person than the operator's
+ * chosen primary.
+ *
+ * Post-fix the parent partner row is locked for the demote+insert pair, and
+ * the partial unique index uq_pc_one_live_primary (migration 109) makes a
+ * second live primary unstorable outright.
+ */
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import { PartnerContact, PartnerOrganisation, sequelize } from '../src/models/index.js'
+import partnerService from '../src/services/redeemOps/partnerService.js'
+
+let admin
+
+beforeAll(async () => {
+  await getApp()
+  admin = (await createTestUser({ role: 'admin' })).user
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+async function makePartner(name) {
+  return PartnerOrganisation.create({
+    legalName: name,
+    normalizedName: name.toLowerCase(),
+    createdBy: admin.id,
+    ownerUserId: admin.id,
+  })
+}
+
+const livePrimaries = (partnerId) => PartnerContact.count({
+  where: { partnerOrganisationId: partnerId, isPrimary: true, archivedAt: null },
+})
+
+describe('M7 — one live primary per partner', () => {
+  it('two CONCURRENT make-primary adds leave exactly ONE live primary', async () => {
+    const partner = await makePartner('Primary Race Nails')
+
+    const results = await Promise.allSettled([
+      partnerService.addContact(partner.id, { name: 'Alice Tan', isPrimary: true }, admin),
+      partnerService.addContact(partner.id, { name: 'Ben Lim', isPrimary: true }, admin),
+    ])
+
+    // Both requests may succeed (the lock serializes them — the second demotes
+    // the first) — what must NEVER happen is two live primaries.
+    expect(results.some((r) => r.status === 'fulfilled')).toBe(true)
+    expect(await livePrimaries(partner.id)).toBe(1)
+  })
+
+  it('a sequential switch demotes the old primary (operator intent follows the latest set)', async () => {
+    const partner = await makePartner('Primary Switch Spa')
+    const a = await partnerService.addContact(partner.id, { name: 'First Person', isPrimary: true }, admin)
+    const b = await partnerService.addContact(partner.id, { name: 'Second Person', isPrimary: true }, admin)
+
+    expect(await livePrimaries(partner.id)).toBe(1)
+    expect((await PartnerContact.findByPk(a.id)).isPrimary).toBe(false)
+    expect((await PartnerContact.findByPk(b.id)).isPrimary).toBe(true)
+  })
+
+  it('updateContact promotion swaps, never duplicates', async () => {
+    const partner = await makePartner('Primary Update Gym')
+    const a = await partnerService.addContact(partner.id, { name: 'Old Primary', isPrimary: true }, admin)
+    const b = await partnerService.addContact(partner.id, { name: 'New Primary' }, admin)
+
+    await partnerService.updateContact(b.id, { isPrimary: true }, admin)
+    expect(await livePrimaries(partner.id)).toBe(1)
+    expect((await PartnerContact.findByPk(a.id)).isPrimary).toBe(false)
+    expect((await PartnerContact.findByPk(b.id)).isPrimary).toBe(true)
+  })
+
+  it('the DB backstop: a raw second live primary violates uq_pc_one_live_primary', async () => {
+    const partner = await makePartner('Primary Backstop Cafe')
+    await partnerService.addContact(partner.id, { name: 'Held Primary', isPrimary: true }, admin)
+    const rogue = await partnerService.addContact(partner.id, { name: 'Rogue Contact' }, admin)
+
+    await expect(
+      sequelize.query('UPDATE partner_contacts SET "isPrimary" = true WHERE id = :id', {
+        replacements: { id: rogue.id },
+      })
+    ).rejects.toMatchObject({ name: 'SequelizeUniqueConstraintError' })
+  })
+
+  it('an ARCHIVED primary does not block a new live primary', async () => {
+    const partner = await makePartner('Primary Archive Bar')
+    const a = await partnerService.addContact(partner.id, { name: 'Departed Primary', isPrimary: true }, admin)
+    await sequelize.query(
+      'UPDATE partner_contacts SET "archivedAt" = now() WHERE id = :id',
+      { replacements: { id: a.id } }
+    )
+
+    const b = await partnerService.addContact(partner.id, { name: 'Replacement Primary', isPrimary: true }, admin)
+    expect(b.isPrimary).toBe(true)
+    expect(await livePrimaries(partner.id)).toBe(1)
+  })
+})


### PR DESCRIPTION
## Task

**M7 (MED)** — Concurrent contact creation can leave multiple primary contacts.

## Defect (confirmed live)

`addContact`/`updateContact` demoted existing primaries and set the new one inside a transaction, but nothing serialized two concurrent switches and no index rejected the second primary — both committed. Cadence materialization then silently picked the **older** primary by `createdAt`, so automated outreach could target a different person than the operator's intended primary.

## Fix (exactly the prescribed shape)

- **Partial unique index** (migration 109, mirrored on the model): `uq_pc_one_live_primary ON partner_contacts ("partnerOrganisationId") WHERE "isPrimary" = true AND "archivedAt" IS NULL`.
- **Parent-row lock**: both switch paths `SELECT … FOR UPDATE` the partner before the demote+set pair, so concurrent switches serialize (second demotes the first — both requests succeed, one live primary remains).
- **Reconciliation before the index**: all but the **newest** live primary per partner demote — the newest is the operator's latest expressed intent; the older row is exactly what the drift was mis-selecting.
- A conflict that still slips through surfaces as a unique-constraint rejection rather than silent dual-primary state.

## Test proof (pre-fix captured on this branch)

```
concurrent make-primary race → live primaries: Expected 1, Received 2
raw second-primary UPDATE    → resolved (no index to reject it)
Tests: 2 failed, 3 passed
```

**Post-fix: 5/5** — race leaves exactly one live primary; sequential and `updateContact` swaps preserved; an archived primary doesn't block a replacement; the DB backstop rejects rogue writes with `SequelizeUniqueConstraintError`.

## Verification

- Unit tier: **2223/2223**
- DB suites (partnerPrimaryContact, redeemOpsPartners, redeemOpsCadences, migrations validation): **105/105**
- eslint clean. Migration tier runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)