### PR TITLE
fix(prospects): DOB age gate is strict-calendar and Singapore-time (M8)

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -181,7 +181,10 @@ export const schemas = {
     budget: Joi.object().optional(),
     location: Joi.object().optional(),
     // Added optional fields for Lead Capture
-    date_of_birth: Joi.alternatives().try(Joi.string(), Joi.date()).optional(),
+    // M8: strict calendar date only — the SGT age gate refuses Date-parser
+    // ambiguity (TZ-bearing strings shifted the birth day on a UTC host).
+    date_of_birth: Joi.string().pattern(/^\d{4}-\d{2}-\d{2}$/).optional()
+      .messages({ 'string.pattern.base': 'date_of_birth must be YYYY-MM-DD' }),
     postal_code: Joi.string().optional(),
     education_level: Joi.string().optional(),
     monthly_income: Joi.string().optional(),

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -63,7 +63,7 @@ import {
   getProspectOutcomes,
 } from './leadProfileService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
-import { sgtDayEndExclusiveMs } from '../utils/sgtTime.js';
+import { sgtDayEndExclusiveMs, cleanYmd, sgtAgeFromDob } from '../utils/sgtTime.js';
 
 // Redeem Ops capture hook (docs/redeem-ops/MKTR_INTEGRATION.md §2): a
 // dependency-INVERTED callback — this module never imports Redeem Ops code.
@@ -624,20 +624,24 @@ export function makeProspectService(overrides = {}) {
     // leave dob optional keep behaving exactly as before, so this can never
     // start rejecting entrants on a live funnel that was set up to allow them.
     const dobRequired = sourceDesign.requiredFields?.dob === true;
-    const parsedDob = safeBody.date_of_birth ? new Date(safeBody.date_of_birth) : null;
-    const dobUsable = !!parsedDob && !isNaN(parsedDob.getTime());
-    if (dobRequired && !dobUsable) {
+    // M8: STRICT calendar date, evaluated on the SINGAPORE calendar. The old
+    // gate parsed arbitrary strings with new Date() and compared server-LOCAL
+    // Y/M/D — on the UTC prod host an applicant whose birthday began at 00:00
+    // SGT stayed "yesterday" until 08:00 SGT and was rejected as underage by
+    // the Singapore-facing form; timezone-bearing inputs shifted the DOB day;
+    // and garbage strings silently SKIPPED the gate (no age stored at all).
+    const dobRaw = safeBody.date_of_birth;
+    const dobProvided = dobRaw !== undefined && dobRaw !== null && String(dobRaw).trim() !== '';
+    const dobCanonical = dobProvided ? cleanYmd(String(dobRaw)) : undefined;
+    if (dobProvided && !dobCanonical) {
+      throw new d.AppError('Date of birth must be a real calendar date (YYYY-MM-DD).', 422);
+    }
+    if (dobRequired && !dobCanonical) {
       throw new d.AppError('Date of birth is required for this campaign.', 422);
     }
-    if (dobUsable) {
-      const dob = parsedDob;
+    if (dobCanonical) {
       {
-        const today = new Date();
-        let age = today.getFullYear() - dob.getFullYear();
-        const m_ = today.getMonth() - dob.getMonth();
-        if (m_ < 0 || (m_ === 0 && today.getDate() < dob.getDate())) {
-          age--;
-        }
+        const age = sgtAgeFromDob(dobCanonical);
 
         // sourceCampaign is already loaded above (same row, full attributes) —
         // the old second findByPk here was a redundant query.
@@ -659,7 +663,7 @@ export function makeProspectService(overrides = {}) {
         incoming.demographics = {
           ...(incoming.demographics || {}),
           age: age,
-          dateOfBirth: safeBody.date_of_birth,
+          dateOfBirth: dobCanonical,
         };
       }
     }

--- a/backend/src/utils/sgtTime.js
+++ b/backend/src/utils/sgtTime.js
@@ -79,3 +79,21 @@ export function sgtDayWindow(now = new Date()) {
   const startUtcMs = Date.UTC(sgt.getUTCFullYear(), sgt.getUTCMonth(), sgt.getUTCDate()) - SGT_OFFSET_MS;
   return { start: new Date(startUtcMs), end: new Date(startUtcMs + 24 * 60 * 60 * 1000) };
 }
+
+/**
+ * Completed years between a YYYY-MM-DD birth date and "today" on the
+ * SINGAPORE calendar (M8). The old age gate compared server-LOCAL
+ * getFullYear/getMonth/getDate — on the UTC prod host an applicant whose
+ * birthday began at 00:00 SGT stayed "yesterday" until 08:00 SGT and was
+ * rejected as underage by the Singapore-facing form. Returns null for
+ * anything cleanYmd rejects.
+ */
+export function sgtAgeFromDob(ymd, now = new Date()) {
+  const s = cleanYmd(ymd);
+  if (!s) return null;
+  const [by, bm, bd] = s.split('-').map(Number);
+  const [ty, tm, td] = sgDateKey(now).split('-').map(Number);
+  let age = ty - by;
+  if (tm < bm || (tm === bm && td < bd)) age--;
+  return age;
+}

--- a/backend/test/prospectDobSgtGate.test.js
+++ b/backend/test/prospectDobSgtGate.test.js
@@ -1,0 +1,81 @@
+/**
+ * M8 (review round 3): the DOB age gate is strict-calendar and Singapore-time.
+ *
+ * Pre-fix the API accepted arbitrary date strings, parsed them with
+ * new Date(), and compared server-LOCAL date parts: garbage formats silently
+ * SKIPPED the gate (lead created with no age at all), timezone-bearing
+ * strings could shift the birth day, and on the UTC prod host a birthday
+ * starting at 00:00 SGT was still "yesterday" until 08:00 SGT.
+ *
+ * Post-fix: strict YYYY-MM-DD at the Joi door, real-calendar validation via
+ * cleanYmd (2012-02-31 dies), age computed on the SGT calendar
+ * (sgtAgeFromDob — unit-proven in test/unit/sgtAge.test.js), and the
+ * canonical date string stored on demographics.
+ */
+import request from 'supertest'
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js'
+import { Prospect } from '../src/models/index.js'
+
+let app, adminToken, campaign
+
+beforeAll(async () => {
+  app = await getApp()
+  const admin = await createTestUser({ role: 'admin' })
+  adminToken = admin.token
+  campaign = await createTestCampaign(admin.user.id, { name: 'SGT DOB Gate', min_age: 21, max_age: 65 })
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+let n = 0
+const post = (extra) => request(app)
+  .post('/api/prospects')
+  .set('Authorization', `Bearer ${adminToken}`)
+  .send({
+    firstName: 'Dob',
+    lastName: `Gate${++n}`,
+    email: `dob-gate-${n}-${Date.now()}@test.com`,
+    phone: `+65${String(Date.now() + n).slice(-8)}`,
+    leadSource: 'website',
+    campaignId: campaign.id,
+    ...extra,
+  })
+
+describe('M8 — strict SGT date-of-birth gate', () => {
+  it('a non-calendar format is rejected, never silently skipped', async () => {
+    const res = await post({ date_of_birth: '15/06/1990' })
+    // Pre-fix: new Date('15/06/1990') was Invalid → the gate silently skipped
+    // and the lead was CREATED with no age stored at all.
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
+  })
+
+  it('a timezone-bearing string is rejected (it could shift the birth day)', async () => {
+    const res = await post({ date_of_birth: '1990-06-15T23:00:00-11:00' })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
+  })
+
+  it('an impossible calendar date is rejected', async () => {
+    const res = await post({ date_of_birth: '2012-02-31' })
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
+  })
+
+  it('a valid date stores the canonical string and the SGT-computed age', async () => {
+    const res = await post({ date_of_birth: '1990-06-15' })
+    expect(res.status).toBe(201)
+    const row = await Prospect.findByPk(res.body.data.prospect.id, { raw: true })
+    expect(row.demographics.dateOfBirth).toBe('1990-06-15')
+    expect(typeof row.demographics.age).toBe('number')
+    expect(row.demographics.age).toBeGreaterThanOrEqual(35)
+  })
+
+  it('the campaign age gate still rejects an underage applicant', async () => {
+    const res = await post({ date_of_birth: '2015-01-01' })
+    expect(res.status).toBe(422)
+    expect(res.body.message).toContain('21')
+  })
+})

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -376,7 +376,10 @@ describe('DOB and postal code mapping', () => {
       campaignId: gated.id,
       date_of_birth: 'not-a-date',
     })
-    expect(res.status).toBe(422)
+    // M8: garbage now dies at the Joi door (400, strict YYYY-MM-DD) — one
+    // gate earlier than the service's 422, same protection.
+    expect(res.status).toBeGreaterThanOrEqual(400)
+    expect(res.status).toBeLessThan(500)
   })
 
   it('maps postal_code to location.postalCode', async () => {

--- a/backend/test/unit/sgtAge.test.js
+++ b/backend/test/unit/sgtAge.test.js
@@ -1,0 +1,41 @@
+/**
+ * sgtAgeFromDob (M8): age on the SINGAPORE calendar, independent of server TZ.
+ * The old gate compared server-LOCAL date parts — on a UTC host an applicant
+ * whose birthday began at 00:00 SGT stayed underage until 08:00 SGT.
+ */
+import { sgtAgeFromDob } from '../../src/utils/sgtTime.js';
+
+describe('sgtAgeFromDob', () => {
+  // 2026-08-02T17:00:00Z = 2026-08-03 01:00 SGT — the UTC calendar still says
+  // Aug 2, the Singapore calendar already says Aug 3.
+  const SGT_PAST_MIDNIGHT = new Date('2026-08-02T17:00:00Z');
+
+  it('counts a birthday from 00:00 SGT even while the UTC date lags behind', () => {
+    // 21st birthday on 2026-08-03 (SGT): already 21 at 01:00 SGT.
+    expect(sgtAgeFromDob('2005-08-03', SGT_PAST_MIDNIGHT)).toBe(21);
+    // The pre-fix local-calendar math on a UTC host said 20 here — the exact
+    // 00:00–08:00 SGT rejection window the review flagged.
+    const utcLocal = new Date('2026-08-02T17:00:00Z');
+    let preFixAge = utcLocal.getUTCFullYear() - 2005;
+    const m = utcLocal.getUTCMonth() - (8 - 1);
+    if (m < 0 || (m === 0 && utcLocal.getUTCDate() < 3)) preFixAge--;
+    expect(preFixAge).toBe(20); // documents the divergence this fix removes
+  });
+
+  it('is not yet a birthday the SGT day before', () => {
+    const beforeMidnightSgt = new Date('2026-08-02T15:00:00Z'); // 23:00 SGT Aug 2
+    expect(sgtAgeFromDob('2005-08-03', beforeMidnightSgt)).toBe(20);
+  });
+
+  it('handles ordinary mid-year dates', () => {
+    expect(sgtAgeFromDob('1990-06-15', new Date('2026-08-02T12:00:00Z'))).toBe(36);
+    expect(sgtAgeFromDob('1990-12-31', new Date('2026-08-02T12:00:00Z'))).toBe(35);
+  });
+
+  it('rejects garbage, TZ-bearing strings, and impossible calendar dates', () => {
+    expect(sgtAgeFromDob('15/06/1990')).toBeNull();
+    expect(sgtAgeFromDob('1990-06-15T23:00:00-11:00')).toBeNull();
+    expect(sgtAgeFromDob('2012-02-31')).toBeNull();
+    expect(sgtAgeFromDob(19900615)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Task

**M8 (MED)** — DOB age gate uses server-local calendar instead of Singapore time.

## Defect (confirmed live)

`date_of_birth` was `Joi.alternatives().try(Joi.string(), Joi.date())` — any string. The service parsed with `new Date()` and compared **server-local** `getFullYear/getMonth/getDate`. Consequences on the UTC prod host: an applicant whose birthday began at 00:00 SGT was still evaluated against the previous UTC date until 08:00 SGT and rejected as underage; TZ-bearing strings could shift the birth calendar day; and unparseable strings silently **skipped the gate entirely** — the lead was created with no age at all (later unmarketable under the 18+ cohort floor).

## Fix (exactly the prescribed shape)

- **Joi door**: strict `YYYY-MM-DD` pattern only.
- **Real-calendar validation** via the shared `cleanYmd` (already the house strict validator — `2012-02-31` dies instead of rolling over), no Date string-parser anywhere.
- **SGT age**: new `sgtAgeFromDob(ymd, now)` in `utils/sgtTime.js` compares year/month/day tuples against today's **Singapore** date (`sgDateKey`, fixed +08:00, no DST).
- Present-but-garbage DOB → **422**, never a silent skip. The **canonical date string** is stored on `demographics.dateOfBirth`.
- Campaign min/max gates unchanged in semantics — only the calendar they reference moved to SGT.

## Test proof

**Deterministic boundary (unit)**: at `2026-08-02T17:00:00Z` — 01:00 SGT on a 21st birthday — `sgtAgeFromDob` returns **21** while the old local-calendar math on a UTC host returns **20** (the 00:00–08:00 SGT rejection window, asserted side-by-side in the test).

**Pre-fix API capture (this branch)**:
```
'15/06/1990'  → 201 CREATED (gate silently skipped, no age stored)   expected 4xx
'2012-02-31'  → 201 CREATED (same silent skip)                        expected 4xx
Tests: 2 failed, 3 passed
```
**Post-fix: 9/9** — strict rejections, canonical storage + SGT age on the row, underage still 422.

## Verification

- Unit tier: **2227/2227** (new sgtAge suite included)
- DB suites (prospectDobSgtGate, prospects, leadCapture, leadCaptureBind): **87/87** — one legacy assertion updated (`not-a-date` now dies at the Joi door with 400 rather than the service 422; same protection, one gate earlier)
- eslint clean; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)