### PR TITLE
fix(routing): round-robin queue map actually drains (M9)

### DIFF
--- a/backend/src/services/systemAgent.js
+++ b/backend/src/services/systemAgent.js
@@ -6,16 +6,25 @@ import { pickFromRing } from './leadRing.js';
 
 // In-process queue to serialize round-robin updates per campaign (prevents race conditions)
 const rrQueues = new Map();
-function enqueueCampaign(campaignId, task) {
-  const chain = (rrQueues.get(campaignId) || Promise.resolve())
-    .then(task)
-    .finally(() => {
-      // Clear queue when this task finishes if it's still the last one
-      if (rrQueues.get(campaignId) === chain) rrQueues.delete(campaignId);
-    });
-  rrQueues.set(campaignId, chain.catch(() => { }));
+export function enqueueCampaign(campaignId, task) {
+  const prior = rrQueues.get(campaignId) || Promise.resolve();
+  // The caller sees the task's real outcome (rejections propagate)…
+  const chain = prior.then(task);
+  // …the STORED tail swallows them so the next enqueue still runs…
+  const tail = chain.catch(() => { });
+  // …and cleanup compares the EXACT object stored. M9: the old code stored
+  // chain.catch(...) while finally compared against `chain` — two different
+  // Promise objects, so the equality was ALWAYS false and every campaign ever
+  // routed left a settled entry in this process-global Map until restart.
+  const entry = tail.finally(() => {
+    if (rrQueues.get(campaignId) === entry) rrQueues.delete(campaignId);
+  });
+  rrQueues.set(campaignId, entry);
   return chain;
 }
+
+/** Test seam (M9): the queue map must drain back to empty once tasks settle. */
+export const rrQueueSize = () => rrQueues.size;
 
 dotenv.config();
 

--- a/backend/test/unit/rrQueueCleanup.test.js
+++ b/backend/test/unit/rrQueueCleanup.test.js
@@ -1,0 +1,59 @@
+/**
+ * M9 (review round 3): the per-campaign round-robin queue map drains.
+ *
+ * enqueueCampaign's cleanup ran `if (rrQueues.get(id) === chain) delete` —
+ * but the map stored `chain.catch(...)`, a DIFFERENT Promise object, so the
+ * identity check was always false. Every distinct campaign ever routed left a
+ * settled promise in the process-global Map forever: campaign churn grew the
+ * heap until restart.
+ *
+ * Post-fix the map stores the exact object the cleanup compares (rejection
+ * swallowing is attached WITHOUT replacing the stored identity), so the last
+ * settled task removes its entry.
+ */
+import { enqueueCampaign, rrQueueSize } from '../../src/services/systemAgent.js';
+
+const drainMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('enqueueCampaign map hygiene', () => {
+  it('a successful task removes its campaign entry once settled', async () => {
+    const before = rrQueueSize();
+    await expect(enqueueCampaign('m9-camp-ok', async () => 42)).resolves.toBe(42);
+    await drainMicrotasks();
+    // Pre-fix this stayed at before+1 forever — the leak.
+    expect(rrQueueSize()).toBe(before);
+  });
+
+  it('a FAILED task still rejects to the caller AND removes its entry', async () => {
+    const before = rrQueueSize();
+    await expect(
+      enqueueCampaign('m9-camp-fail', async () => { throw new Error('routing blew up'); })
+    ).rejects.toThrow('routing blew up');
+    await drainMicrotasks();
+    expect(rrQueueSize()).toBe(before);
+  });
+
+  it('serialization survives: same-campaign tasks run strictly in order, then drain', async () => {
+    const order = [];
+    const slow = enqueueCampaign('m9-camp-serial', async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      order.push('first');
+    });
+    const fast = enqueueCampaign('m9-camp-serial', async () => {
+      order.push('second');
+    });
+    await Promise.all([slow, fast]);
+    expect(order).toEqual(['first', 'second']);
+    await drainMicrotasks();
+    expect(rrQueueSize()).toBe(0);
+  });
+
+  it('a task enqueued after a failure still runs (the stored tail swallows rejections)', async () => {
+    await expect(
+      enqueueCampaign('m9-camp-recover', async () => { throw new Error('boom'); })
+    ).rejects.toThrow('boom');
+    await expect(enqueueCampaign('m9-camp-recover', async () => 'recovered')).resolves.toBe('recovered');
+    await drainMicrotasks();
+    expect(rrQueueSize()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Task

**M9 (MED)** — Round-robin queue cleanup can never remove completed campaigns.

## Defect (confirmed live)

`enqueueCampaign` (systemAgent.js) cleaned up with `if (rrQueues.get(campaignId) === chain) rrQueues.delete(...)` — but the map stored **`chain.catch(() => {})`**, a different Promise object. The identity check was always false, so every distinct campaign ever routed left a settled promise in the process-global Map until restart. Campaign churn = unbounded heap growth.

## Fix (exactly the prescribed shape)

The map stores the **exact object the cleanup compares**:

- the caller still receives the task's real promise (rejections propagate to the router),
- the stored tail attaches rejection-swallowing **without replacing the stored identity** (a failed task never wedges the next enqueue),
- the last settled task deletes its own entry; an entry replaced by a newer enqueue is left alone.

`rrQueueSize()` is exported as the test seam.

## Test proof (pre-fix captured on this branch — old logic with the seam grafted on)

```
map size after settled tasks: Expected 0/1/0/0 — Received 1, 2, 3, 4 (monotonic growth)
Tests: 4 failed
```

**Post-fix: 4/4** — success and failure paths drain to empty; same-campaign tasks still run strictly in order; a task enqueued after a failure still runs.

## Verification

- Unit tier: **2231/2231**
- Routing DB suites (agentAssignment, leadPackageConcurrency, pipelineE2E): **17/17**
- eslint clean; no migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)