### PR TITLE
fix(discovery): paid run history survives operator deletion (M11)

### DIFF
--- a/backend/src/database/migrations/110-discovery-history-survives-user-deletion.js
+++ b/backend/src/database/migrations/110-discovery-history-survives-user-deletion.js
@@ -1,0 +1,53 @@
+/**
+ * 110 — paid discovery history survives operator deletion (M11).
+ *
+ * discovery_runs.createdBy was NOT NULL + ON DELETE CASCADE (053), and
+ * candidates cascade from each run — permanently deleting a former operator
+ * erased provider run ids, actual/estimated costs, raw results, candidate
+ * provenance, and the per-user quota history rows. Operational/audit history
+ * has to outlive the account that produced it (same policy as 102/105/108).
+ *
+ * createdBy becomes nullable with ON DELETE SET NULL, and createdByEmail is
+ * added as the immutable creator-identity snapshot (backfilled from users,
+ * stamped by the service on every new run).
+ */
+
+export async function up(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+
+  await sequelize.query('ALTER TABLE discovery_runs ADD COLUMN IF NOT EXISTS "createdByEmail" VARCHAR(160)');
+  await sequelize.query(`
+    UPDATE discovery_runs r SET "createdByEmail" = u.email
+      FROM users u
+     WHERE u.id = r."createdBy" AND r."createdByEmail" IS NULL
+  `);
+
+  await sequelize.query('ALTER TABLE discovery_runs ALTER COLUMN "createdBy" DROP NOT NULL');
+
+  // resetFK pattern (014): whatever the current constraint is, re-assert SET NULL.
+  const name = 'discovery_runs_createdBy_fkey';
+  await queryInterface.removeConstraint('discovery_runs', name).catch(() => {});
+  await queryInterface.removeConstraint('discovery_runs', 'discovery_runs_createdBy_users_fk').catch(() => {});
+  await sequelize.query(`
+    ALTER TABLE discovery_runs ADD CONSTRAINT "${name}"
+    FOREIGN KEY ("createdBy") REFERENCES users(id)
+    ON DELETE SET NULL NOT VALID
+  `);
+  await sequelize.query(`ALTER TABLE discovery_runs VALIDATE CONSTRAINT "${name}"`);
+}
+
+export async function down(queryInterface) {
+  const sequelize = queryInterface.sequelize;
+  // Orphaned history cannot re-acquire a NOT NULL owner — remove it before
+  // restoring the old shape.
+  await sequelize.query('DELETE FROM discovery_runs WHERE "createdBy" IS NULL');
+  await sequelize.query('ALTER TABLE discovery_runs ALTER COLUMN "createdBy" SET NOT NULL');
+  const name = 'discovery_runs_createdBy_fkey';
+  await queryInterface.removeConstraint('discovery_runs', name).catch(() => {});
+  await sequelize.query(`
+    ALTER TABLE discovery_runs ADD CONSTRAINT "${name}"
+    FOREIGN KEY ("createdBy") REFERENCES users(id)
+    ON DELETE CASCADE
+  `);
+  await sequelize.query('ALTER TABLE discovery_runs DROP COLUMN IF EXISTS "createdByEmail"');
+}

--- a/backend/src/models/DiscoveryRun.js
+++ b/backend/src/models/DiscoveryRun.js
@@ -11,7 +11,12 @@ import { sequelize } from '../database/connection.js';
  */
 const DiscoveryRun = sequelize.define('DiscoveryRun', {
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
-  createdBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  // M11: nullable + ON DELETE SET NULL (migration 110) — paid discovery
+  // history (provider run ids, costs, raw results, quota rows) must OUTLIVE
+  // the operator who fired it. createdByEmail is the immutable identity
+  // snapshot stamped at run creation.
+  createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  createdByEmail: { type: DataTypes.STRING(160), allowNull: true },
   provider: { type: DataTypes.STRING(32), allowNull: false, defaultValue: 'apify_google_maps' },
   category: { type: DataTypes.STRING(64), allowNull: true },
   area: { type: DataTypes.STRING(120), allowNull: true },

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -310,7 +310,8 @@ function defineAssociations() {
 
   // Discover tool (migration 053)
   const { DiscoveryRun, DiscoveryCandidate, DiscoveryPlaceMemory } = models;
-  DiscoveryRun.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'CASCADE' });
+  // M11: history survives operator deletion (SET NULL; snapshot on the row).
+  DiscoveryRun.belongsTo(User, { foreignKey: 'createdBy', as: 'creator', onDelete: 'SET NULL' });
   DiscoveryRun.hasMany(DiscoveryCandidate, { foreignKey: 'discoveryRunId', as: 'candidates', onDelete: 'CASCADE' });
   DiscoveryCandidate.belongsTo(DiscoveryRun, { foreignKey: 'discoveryRunId', as: 'run' });
   DiscoveryCandidate.belongsTo(PartnerOrganisation, { foreignKey: 'matchedPartnerId', as: 'matchedPartner', onDelete: 'SET NULL' });

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -267,7 +267,10 @@ export function makeDiscoveryService(overrides = {}) {
       : Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length));
 
     const runValues = {
-      createdBy: user.id, provider: isInstagram ? 'apify_instagram_hashtag' : 'apify_google_maps',
+      // createdByEmail: immutable identity snapshot — survives the operator's
+      // deletion (M11: createdBy goes SET NULL, the history row stays).
+      createdBy: user.id, createdByEmail: user.email || null,
+      provider: isInstagram ? 'apify_instagram_hashtag' : 'apify_google_maps',
       category: canonicalCategory, area: String(area).trim(),
       requestedLimit, status: 'pending',
       estimatedCostUsd: Number((requestedLimit * c.costPerResultUsd).toFixed(4)),

--- a/backend/test/discoveryHistorySurvival.test.js
+++ b/backend/test/discoveryHistorySurvival.test.js
@@ -1,0 +1,63 @@
+/**
+ * M11 (review round 3): paid discovery history survives operator deletion.
+ *
+ * Pre-fix, discovery_runs.createdBy was NOT NULL + ON DELETE CASCADE and
+ * candidates cascade from each run: permanentlyDeleteUser on a former
+ * operator (no campaign/commission/wallet blockers) silently erased provider
+ * run ids, actual costs, raw results, and candidate provenance — the rows
+ * quota history and cost audits are built from.
+ *
+ * Post-fix (migration 110): createdBy is nullable with SET NULL, and
+ * createdByEmail keeps the immutable creator-identity snapshot on the row.
+ */
+import { getApp, closeDb, createTestUser } from './helpers.js'
+import { DiscoveryRun, DiscoveryCandidate, User } from '../src/models/index.js'
+import { permanentlyDeleteUser } from '../src/services/userService.js'
+
+let admin
+
+beforeAll(async () => {
+  await getApp()
+  admin = (await createTestUser({ role: 'admin' })).user
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+test('deleting a former operator preserves runs, candidates, and the identity snapshot', async () => {
+  const { user: operator } = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' })
+
+  const run = await DiscoveryRun.create({
+    createdBy: operator.id,
+    createdByEmail: operator.email,
+    provider: 'apify_google_maps',
+    category: 'nail_salon',
+    area: 'Tampines',
+    requestedLimit: 60,
+    status: 'completed',
+    providerRunId: `apify-${Date.now()}`,
+    actualCostUsd: 1.234,
+    resultCount: 1,
+  })
+  const candidate = await DiscoveryCandidate.create({
+    discoveryRunId: run.id,
+    name: 'Polished Nails Tampines',
+    externalPlaceId: `place-${Date.now()}`,
+  })
+
+  await permanentlyDeleteUser(operator.id, admin.id)
+  expect(await User.findByPk(operator.id)).toBeNull()
+
+  // Pre-fix: the CASCADE took the run — and its candidates — with the user.
+  const survivingRun = await DiscoveryRun.findByPk(run.id, { raw: true })
+  expect(survivingRun).not.toBeNull()
+  expect(survivingRun.createdBy).toBeNull()
+  expect(survivingRun.createdByEmail).toBe(operator.email)
+  expect(survivingRun.providerRunId).toBe(run.providerRunId)
+  expect(Number(survivingRun.actualCostUsd)).toBeCloseTo(1.234)
+
+  const survivingCandidate = await DiscoveryCandidate.findByPk(candidate.id, { raw: true })
+  expect(survivingCandidate).not.toBeNull()
+  expect(survivingCandidate.discoveryRunId).toBe(run.id)
+})


### PR DESCRIPTION
## Task

**M11 (MED)** — Hard-deleting a user cascades away paid discovery history.

## Defect (confirmed live)

`discovery_runs.createdBy` was `NOT NULL` + `ON DELETE CASCADE` (migration 053), with candidates cascading from each run. `permanentlyDeleteUser` blocks on campaigns/commissions/wallet — but not discovery — so deleting a former operator silently erased provider run ids, actual/estimated costs, raw payloads, candidate provenance, and the per-user quota history rows.

## Fix (exactly the prescribed shape)

- `createdBy` → **nullable + ON DELETE SET NULL** (migration 110, 014's resetFK NOT VALID → VALIDATE pattern); association in `models/index.js` and the model migrated consistently (sync-built test schema parity).
- **Immutable creator-identity snapshot**: new `createdByEmail`, backfilled from `users` in the migration and stamped by `discoveryService` on every new run — the history stays attributable after the FK nulls.
- Same history-outlives-its-subject policy as migrations 102/105/108. `down()` deletes orphaned rows before restoring NOT NULL + CASCADE.

## Test proof (pre-fix captured on this branch)

```
after permanentlyDeleteUser: survivingRun → Received: null
  (the CASCADE erased the paid run and its candidates with the account)
Tests: 1 failed
```

**Post-fix: 1/1** — the run and its candidate survive; `createdBy` is NULL; `createdByEmail`, `providerRunId`, and `actualCostUsd` intact.

## Verification

- Unit tier: **2231/2231**
- DB suites (discoveryHistorySurvival, redeemOpsDiscovery, discoveryPermissions, userDeletion, migrations validation): **92/92**
- eslint clean. Migration tier runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)