### PR TITLE
fix(observability): /health/metrics requires an admin JWT (M12)

### DIFF
--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -17,7 +17,7 @@ import { makeLimiter } from './middleware/rateLimiters.js';
 
 // Non-autodiscoverable middleware
 import leadCaptureBind from './routes/leadCaptureBind.js';
-import { optionalAuth } from './middleware/auth.js';
+import { optionalAuth, authenticateToken, requireAdmin } from './middleware/auth.js';
 import { blockRedeemForInternalRoutes } from './middleware/internalRouteHostGuard.js';
 import { logger } from './utils/logger.js';
 import { maskTokenUrl } from './utils/redactTokens.js';
@@ -215,10 +215,13 @@ export const init = async (app) => {
   });
 
   // Hot-path metrics (P3-5). Counters + latency percentiles for lead capture,
-  // webhook delivery and every external call, since this instance came up. No
-  // secrets, no PII — names and numbers only — so it sits with /health rather
-  // than behind admin auth, matching how the other diagnostics here work.
-  app.get('/health/metrics', async (req, res) => {
+  // webhook delivery and every external call, since this instance came up.
+  // M12: ADMIN-GATED. "No PII" was never "no business data" — the counters
+  // are lead volume by channel, how many leads MKTR currently cannot service
+  // (lead.held{reason=no_funded_agent}), and delivery reliability; anyone
+  // polling the bare URL could trend MKTR's lead flow. Plain /health stays
+  // open for Render health checks — only the metrics need the gate.
+  app.get('/health/metrics', authenticateToken, requireAdmin, async (req, res) => {
     const { getMetricsSnapshot } = await import('./services/observability.js');
     res.status(200).json(getMetricsSnapshot());
   });

--- a/backend/test/hotPathMetrics.test.js
+++ b/backend/test/hotPathMetrics.test.js
@@ -207,12 +207,28 @@ describe('external calls are measured at the shared transport', () => {
 });
 
 describe('GET /health/metrics', () => {
-  it('serves the snapshot with uptime, counters and durations', async () => {
+  it('M12: an unauthenticated request gets 401 — the counters ARE the business', async () => {
+    const res = await request(app).get('/health/metrics');
+    expect(res.status).toBe(401);
+  });
+
+  it('M12: a non-admin authenticated request is refused', async () => {
+    const agent = await createTestUser({ role: 'agent' });
+    const res = await request(app)
+      .get('/health/metrics')
+      .set('Authorization', `Bearer ${agent.token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('serves the snapshot to an ADMIN with uptime, counters and durations', async () => {
     resetMetrics();
     incCounter('lead.captured', 3, { source: 'website' });
     observeDuration('webhook.delivery.duration', 42, { event: 'lead.created' });
 
-    const res = await request(app).get('/health/metrics');
+    const adminUser = await createTestUser({ role: 'admin' });
+    const res = await request(app)
+      .get('/health/metrics')
+      .set('Authorization', `Bearer ${adminUser.token}`);
 
     expect(res.status).toBe(200);
     expect(res.body.uptimeSeconds).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Task

**M12 (MED)** — `/health/metrics` publishes lead volume to anyone. Live production information disclosure.

## Defect (confirmed live in production)

The P3-5 metrics endpoint sat with `/health`, unauthenticated, on the reasoning "no secrets, no PII". The counters ARE the business: `lead.captured{source=…}` is lead volume by channel, `lead.held{reason=no_funded_agent}` is how many leads MKTR currently cannot service, `webhook.delivery.failed` is delivery reliability. Anyone who knew the URL could poll `https://api.mktr.sg/health/metrics` and trend MKTR's lead flow over time.

## Fix (the task's first option, stated)

`GET /health/metrics` now requires `authenticateToken` + `requireAdmin` — the same gate as the other operator surfaces, and no new secret to deploy or rotate. Plain `/health` (and the other diagnostics) stay unauthenticated for Render health checks; only the metrics carry the gate. If a headless scrape token is wanted later for monitoring, that's a follow-up — the disclosure closes now.

## Test proof (pre-fix captured on this branch)

```
anonymous GET /health/metrics → Expected 401, Received 200 (full counter snapshot)
agent-token GET               → Expected 403, Received 200
Tests: 2 failed
```

**Post-fix: 19/19** — anonymous 401, non-admin 403, admin receives the snapshot with uptime, counters, and duration percentiles.

## Verification

- Unit tier: **2231/2231**
- DB suites (hotPathMetrics, config, middleware): **70/70**
- eslint clean; no migration. Deploying this closes the live disclosure — no env change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)