### PR TITLE
fix(test): one jest process per database, enforced at boot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,13 @@ psql -h 127.0.0.1 -p 55432 -U postgres -c "CREATE ROLE ci LOGIN SUPERUSER"
 psql -h 127.0.0.1 -p 55432 -U postgres -c "CREATE DATABASE ci OWNER ci"
 ```
 
+**One jest process per database, enforced.** Test boot takes a `mktr_test_run`
+advisory lock (`backend/src/database/testRunLock.js`) before `sync({force:true})`;
+a second overlapping run fails fast with an explanation instead of dropping the
+first run's tables mid-flight (the old "suite hangs forever / Parse Error" local
+flake). If a run says the lock is held, wait, kill the other jest, or use a
+different `DB_NAME`.
+
 Then CI's own four steps (`cd backend`, prefix each with `NODE_ENV=test JWT_SECRET=x DB_HOST=127.0.0.1 DB_PORT=55432 DB_NAME=ci DB_USER=ci DB_PASSWORD=""`):
 
 ```

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -5,6 +5,7 @@ import { validateEnv } from '../config/envValidation.js';
 import { DEFAULT_CAMPAIGN_TYPE } from '../utils/campaignTypes.js';
 import { validateGoogleOAuthConfig } from '../controllers/authController.js';
 import { runMigrations } from './runMigrations.js';
+import { acquireTestRunLock } from './testRunLock.js';
 import { logger } from '../utils/logger.js';
 import { WebhookSubscriber, Campaign, IdempotencyKey } from '../models/index.js';
 import { adapterRegistry } from '../integrations/AdapterRegistry.js';
@@ -26,6 +27,9 @@ export async function bootstrapDatabase() {
   // 2b. In test mode, sync all model definitions to create base tables first.
   //     Migrations then layer on indexes, column tweaks, and data migrations.
   if (process.env.NODE_ENV === 'test') {
+    // Refuse to run beside another jest process on this database — its
+    // sync({force:true}) would drop our tables mid-run (see testRunLock.js).
+    await acquireTestRunLock();
     await sequelize.sync({ force: true });
     logger.info('Test DB: tables synced (force: true).');
   }

--- a/backend/src/database/testRunLock.js
+++ b/backend/src/database/testRunLock.js
@@ -1,0 +1,80 @@
+import pg from 'pg';
+import { sequelize } from './connection.js';
+
+/**
+ * One jest process per test database, enforced.
+ *
+ * Test boot runs sequelize.sync({ force: true }) — it DROPS every table. When
+ * a second jest process overlaps on the same database (a backgrounded run, an
+ * orphaned child of a killed run, two terminals), its sync drops the tables
+ * under the first run's open transactions and the two wedge on each other's
+ * locks: the suite "hangs forever" or dies with transport-level noise
+ * ("Parse Error: Expected HTTP/"). CI never overlaps runs, which is why the
+ * flake family was local-only.
+ *
+ * The lock is a Postgres session advisory lock held on a DEDICATED client
+ * (the pool's own connections are idle-evicted after ~10s, which would
+ * silently release it). Process exit — including jest's forceExit and
+ * SIGKILL — closes the connection and frees the lock.
+ *
+ * Same-process re-entry is detected THROUGH the database, not process memory:
+ * jest's ESM mode gives every test file its own vm context, so module state,
+ * globalThis, and even process properties do not reliably cross suite files.
+ * The holder's connection carries application_name "mktr-test-lock:<pid>" — a
+ * refused acquirer whose own pid matches the holder is a later suite of the
+ * SAME run and proceeds; anything else is a rival process and fails fast.
+ */
+const LOCK_KEY = 'mktr_test_run';
+const appName = () => `mktr-test-lock:${process.pid}`;
+
+function clientConfig() {
+  const { database, username, password, host, port } = sequelize.config;
+  return { host, port, database, user: username, password, application_name: appName() };
+}
+
+async function tryLock(client) {
+  const { rows } = await client.query(
+    'SELECT pg_try_advisory_lock(hashtext($1)) AS locked',
+    [LOCK_KEY]
+  );
+  return rows[0]?.locked === true;
+}
+
+async function lockHolderAppName(client) {
+  const { rows } = await client.query(
+    `SELECT a.application_name
+       FROM pg_locks l JOIN pg_stat_activity a ON a.pid = l.pid
+      WHERE l.locktype = 'advisory' AND a.application_name LIKE 'mktr-test-lock:%'
+      LIMIT 1`
+  );
+  return rows[0]?.application_name || null;
+}
+
+export async function acquireTestRunLock() {
+  const client = new pg.Client(clientConfig());
+  await client.connect();
+
+  if (await tryLock(client)) {
+    // First suite of this run: hold the client (and the lock) until the
+    // process exits. jest's forceExit closes it; Postgres then frees the lock.
+    return;
+  }
+
+  const holder = await lockHolderAppName(client);
+  if (holder === appName()) {
+    // A later suite of the SAME jest process — the run already owns the lock.
+    await client.end();
+    return;
+  }
+
+  // The previous holder may have exited between the try and the check.
+  if (await tryLock(client)) return;
+
+  const { database } = sequelize.config;
+  await client.end();
+  throw new Error(
+    `Another test run (${holder || 'unknown holder'}) holds the "${LOCK_KEY}" advisory lock on database "${database}". ` +
+    'Starting a second jest process would drop its tables mid-run (sync({force:true})) and wedge both. ' +
+    'Wait for the other run, kill it (check `ps -eo pid,command | grep jest`), or point DB_NAME at a different database.'
+  );
+}

--- a/backend/test/testRunLock.test.js
+++ b/backend/test/testRunLock.test.js
@@ -1,0 +1,49 @@
+/**
+ * The one-jest-per-database guard (testRunLock.js). Test boot drops every
+ * table via sync({force:true}); overlapping runs used to wedge each other
+ * into the local "suite hangs forever / Parse Error" flake family. This
+ * process acquired the advisory lock during getApp() bootstrap — these tests
+ * prove the lock is genuinely held, contended, and idempotent.
+ */
+import pg from 'pg'
+import { getApp, closeDb } from './helpers.js'
+import { sequelize } from '../src/models/index.js'
+import { acquireTestRunLock } from '../src/database/testRunLock.js'
+
+beforeAll(async () => {
+  await getApp()
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+test('this run holds the lock: a rival connection cannot take it', async () => {
+  const { database, username, password, host, port } = sequelize.config
+  const rival = new pg.Client({ host, port, database, user: username, password })
+  await rival.connect()
+  try {
+    const { rows } = await rival.query(
+      "SELECT pg_try_advisory_lock(hashtext('mktr_test_run')) AS locked"
+    )
+    // A second jest process would see exactly this false and fail fast at
+    // boot instead of dropping our tables mid-run.
+    expect(rows[0].locked).toBe(false)
+
+    // The holder identifies itself as THIS process — the basis for
+    // same-run re-entry across jest's per-file vm contexts.
+    const { rows: holders } = await rival.query(
+      `SELECT a.application_name
+         FROM pg_locks l JOIN pg_stat_activity a ON a.pid = l.pid
+        WHERE l.locktype = 'advisory' AND a.application_name LIKE 'mktr-test-lock:%'`
+    )
+    expect(holders.map((h) => h.application_name)).toContain(`mktr-test-lock:${process.pid}`)
+  } finally {
+    await rival.end()
+  }
+})
+
+test('re-acquiring from the same process resolves (later suites of one run)', async () => {
+  await expect(acquireTestRunLock()).resolves.toBeUndefined()
+  await expect(acquireTestRunLock()).resolves.toBeUndefined()
+})


### PR DESCRIPTION
## What this fixes

The "hanging test suites" from the codebase grading (`redeemOpsRewards`, `emailBroadcastService` locally wedging 10+ minutes while green in CI). Root cause found this session: **overlapping jest processes on the shared test database**. Test boot runs `sync({force:true})` — a second process drops the first one's tables mid-run and both wedge on each other's locks. CI never overlaps runs, hence local-only.

## The fix

Boot acquires a `mktr_test_run` session advisory lock on a **dedicated** pg client (pool connections idle-evict after ~10s and would silently release it), with `application_name = mktr-test-lock:<pid>`.

- **Rival process** → refused **fast** with an actionable message (wait / kill the other jest / use another DB_NAME) instead of a silent wedge.
- **Later suites of the same run** — jest's ESM vm contexts share neither module state, `globalThis`, nor `process` properties across files (all three verified empirically) — are recognized **through the database**: the refused acquirer matches the holder's `application_name` pid against its own.
- Process exit (including jest `forceExit` and SIGKILL) closes the client; Postgres frees the lock. No teardown hooks to forget.

## Proof

```
external holder → suite fails in ~2s: "Another test run (unknown holder) holds the
  mktr_test_run advisory lock…"            (was: 10+ minute wedge, killed by hand)
4-suite in-band slice (incl. both former hangers): 107/107
same-process re-entry + holder identity: test/testRunLock.test.js (2 tests)
unit tier: 2231/2231 · eslint clean
```

CI impact: none — its four jest steps run sequentially in one job (lock acquired/released per step), and the coverage job uses its own service database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)