### PR TITLE
feat(security): default-deny route registration — ungated routes refuse to boot

### DIFF
--- a/backend/src/controllers/externalAdminPackagesController.js
+++ b/backend/src/controllers/externalAdminPackagesController.js
@@ -94,6 +94,7 @@ function verifyExternalHmac(req) {
 }
 
 /** Express middleware form — apply once on the router so every handler is gated. */
+requireExternalHmac.mktrAuthGate = true; // default-deny routing (routeGates.js); fn is hoisted
 export function requireExternalHmac(req, res, next) {
   const authErr = verifyExternalHmac(req);
   if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });

--- a/backend/src/controllers/externalBillingController.js
+++ b/backend/src/controllers/externalBillingController.js
@@ -68,6 +68,7 @@ function verifyExternalHmac(req) {
 }
 
 /** Express middleware — apply on the agent-facing routes (NOT the HitPay webhook). */
+requireExternalHmac.mktrAuthGate = true; // default-deny routing (routeGates.js); fn is hoisted
 export function requireExternalHmac(req, res, next) {
   const authErr = verifyExternalHmac(req);
   if (authErr) return res.status(authErr.code).json({ success: false, error: authErr.error });

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -155,8 +155,10 @@ export const authenticateToken = async (req, res, next) => {
 };
 
 // Check user roles
+authenticateToken.mktrAuthGate = true; // default-deny routing (routeGates.js)
+
 export const requireRole = (...roles) => {
-  return (req, res, next) => {
+  const gate = (req, res, next) => {
     if (!req.user) {
       return res.status(401).json({
         success: false,
@@ -173,6 +175,8 @@ export const requireRole = (...roles) => {
 
     next();
   };
+  gate.mktrAuthGate = true; // default-deny routing (routeGates.js)
+  return gate;
 };
 
 // Admin only middleware

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -3,6 +3,8 @@ import { makeLimiter } from '../middleware/rateLimiters.js';
 import * as ctrl from '../controllers/analyticsController.js';
 
 export const meta = {
+  // Public routes (default-deny routing): browser tracking beacons from the public funnel
+  public: ['POST /events', 'POST /referrals'],
   mounts: [
     { path: '/api/analytics' },
     { path: '/api/adtech/analytics', flag: 'ENABLE_DOMAIN_PREFIXES' },

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -4,7 +4,11 @@ import { authenticateToken } from '../middleware/auth.js';
 import { validate, schemas } from '../middleware/validation.js';
 import * as auth from '../controllers/authController.js';
 
-export const meta = { path: '/api/auth' };
+export const meta = {
+  path: '/api/auth',
+  // Public routes (default-deny routing): login/registration/password/invite flows — public by nature
+  public: ['POST /register', 'POST /login', 'POST /google', 'GET /google/config', 'GET /google/state', 'POST /google/callback', 'GET /verify-email/:token', 'POST /forgot-password', 'POST /reset-password/:token', 'GET /invite-info/:token', 'POST /accept-invite'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/campaignPreviews.js
+++ b/backend/src/routes/campaignPreviews.js
@@ -4,6 +4,8 @@ import * as ctrl from '../controllers/campaignPreviewController.js';
 import { uuidParamGuard } from '../middleware/uuidParam.js';
 
 export const meta = {
+  // Public routes (default-deny routing): public campaign pages
+  public: ['GET /slug/:slug', 'GET /public/:id'],
   mounts: [
     { path: '/api/campaigns' },
     { path: '/api/previews' },

--- a/backend/src/routes/campaigns.js
+++ b/backend/src/routes/campaigns.js
@@ -5,6 +5,8 @@ import * as campaignController from '../controllers/campaignController.js';
 import { uuidParamGuard } from '../middleware/uuidParam.js';
 
 export const meta = {
+  // Public routes (default-deny routing): public marketplace featured drops
+  public: ['GET /featured-drops'],
   mounts: [
     { path: '/api/campaigns' },
     { path: '/api/adtech/campaigns', flag: 'ENABLE_DOMAIN_PREFIXES' },

--- a/backend/src/routes/contact.js
+++ b/backend/src/routes/contact.js
@@ -5,6 +5,8 @@ import { validate } from '../middleware/validation.js';
 import * as contactController from '../controllers/contactController.js';
 
 export const meta = {
+  // Public routes (default-deny routing): public contact form
+  public: ['POST /'],
   mounts: [
     { path: '/api/contact' },
     { path: '/api/admin/contact', flag: 'ENABLE_DOMAIN_PREFIXES' },

--- a/backend/src/routes/dnc.js
+++ b/backend/src/routes/dnc.js
@@ -2,7 +2,11 @@ import express from 'express';
 import { makeLimiter } from '../middleware/rateLimiters.js';
 import * as ctrl from '../controllers/dncController.js';
 
-export const meta = { path: '/api/dnc' };
+export const meta = {
+  path: '/api/dnc',
+  // Public routes (default-deny routing): public capture funnel consent pre-check
+  public: ['POST /check'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/externalAdminLeadOps.js
+++ b/backend/src/routes/externalAdminLeadOps.js
@@ -15,6 +15,8 @@ import { reassignLead, returnToHeld } from '../controllers/externalAdminLeadOpsC
 const router = express.Router();
 
 export const meta = {
+  // Public routes (default-deny routing): mktr-leads HMAC verified inside each handler
+  public: ['POST /reassign', 'POST /return-to-held'],
   path: '/api/external/admin-lead-ops',
   flag: 'ADMIN_LEAD_OPS_EXTERNAL_ENABLED',
   flagDefault: 'false'

--- a/backend/src/routes/externalAgentPackages.js
+++ b/backend/src/routes/externalAgentPackages.js
@@ -15,6 +15,8 @@ import { listAgentPackages } from '../controllers/externalAgentPackagesControlle
 const router = express.Router();
 
 export const meta = {
+  // Public routes (default-deny routing): mktr-leads HMAC verified inside each handler
+  public: ['POST /'],
   path: '/api/external/agent-packages',
   flag: 'AGENT_PACKAGES_EXTERNAL_ENABLED',
   flagDefault: 'false'

--- a/backend/src/routes/externalBilling.js
+++ b/backend/src/routes/externalBilling.js
@@ -24,6 +24,8 @@ import {
 const router = express.Router();
 
 export const meta = {
+  // Public routes (default-deny routing): HitPay webhook — signature verified in the handler
+  public: ['POST /hitpay-webhook'],
   path: '/api/external/billing',
   flag: 'BILLING_ENABLED',
   flagDefault: 'false',

--- a/backend/src/routes/externalHeldLeads.js
+++ b/backend/src/routes/externalHeldLeads.js
@@ -14,7 +14,11 @@ import { listHeldLeads, assignHeldLead } from '../controllers/externalHeldLeadsC
 
 const router = express.Router();
 
-export const meta = { path: '/api/external/held-leads', flag: 'HELD_LEADS_EXTERNAL_ENABLED', flagDefault: 'false' };
+export const meta = {
+  path: '/api/external/held-leads', flag: 'HELD_LEADS_EXTERNAL_ENABLED', flagDefault: 'false',
+  // Public routes (default-deny routing): mktr-leads HMAC verified inside each handler
+  public: ['POST /', 'POST /assign'],
+};
 
 // POST (not GET) so the body carries the signed `timestamp` the HMAC freshness
 // check reads — consistent with /api/external/lead-outcomes.

--- a/backend/src/routes/externalLeadActivities.js
+++ b/backend/src/routes/externalLeadActivities.js
@@ -14,7 +14,11 @@ import { listLeadActivities } from '../controllers/externalLeadActivitiesControl
 
 const router = express.Router();
 
-export const meta = { path: '/api/external/lead-activities', flag: 'LEAD_TIMELINE_EXTERNAL_ENABLED', flagDefault: 'false' };
+export const meta = {
+  path: '/api/external/lead-activities', flag: 'LEAD_TIMELINE_EXTERNAL_ENABLED', flagDefault: 'false',
+  // Public routes (default-deny routing): mktr-leads HMAC verified inside each handler
+  public: ['POST /'],
+};
 
 // POST so the body carries the signed `timestamp` the HMAC freshness check reads.
 router.post('/', listLeadActivities);

--- a/backend/src/routes/externalLeadOutcomes.js
+++ b/backend/src/routes/externalLeadOutcomes.js
@@ -17,7 +17,11 @@
 import express from 'express';
 import { handleExternalLeadOutcome } from '../controllers/externalLeadOutcomeController.js';
 
-export const meta = { path: '/api/external' };
+export const meta = {
+  path: '/api/external',
+  // Public routes (default-deny routing): mktr-leads HMAC verified inside the handler
+  public: ['POST /lead-outcomes'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -2,6 +2,7 @@ import { readdir } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { logger } from '../utils/logger.js';
+import { assertRouterGated } from './routeGates.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -38,6 +39,11 @@ export async function loadRoutes(app) {
   let mounted = 0;
 
   for (const { file, router, meta } of routes) {
+    // Default-deny: an ungated, undeclared route refuses to BOOT — validated
+    // before the flag check so flag-off surfaces are held to the same bar the
+    // moment they are written, not the day their flag flips in prod.
+    assertRouterGated({ router, meta, file });
+
     const mounts = meta.mounts || [{ path: meta.path, flag: meta.flag, flagDefault: meta.flagDefault }];
 
     for (const mount of mounts) {

--- a/backend/src/routes/lyfeEntitlementUnlock.js
+++ b/backend/src/routes/lyfeEntitlementUnlock.js
@@ -22,6 +22,8 @@ import { logger } from '../utils/logger.js';
  * The resolved agent must be the lead's assigned consultant.
  */
 export const meta = {
+  // Public routes (default-deny routing): Lyfe HMAC verified inside the handler
+  public: ['POST /entitlement-unlock'],
   path: '/api/integrations/lyfe',
   flag: 'REDEEM_OPS_ENTITLEMENTS_ENABLED',
   flagDefault: 'false',

--- a/backend/src/routes/lyfeLeadOutcome.js
+++ b/backend/src/routes/lyfeLeadOutcome.js
@@ -15,7 +15,11 @@
 import express from 'express';
 import { handleLyfeLeadOutcome } from '../controllers/lyfeLeadOutcomeController.js';
 
-export const meta = { path: '/api/integrations/lyfe' };
+export const meta = {
+  path: '/api/integrations/lyfe',
+  // Public routes (default-deny routing): Lyfe HMAC verified inside the handler
+  public: ['POST /lead-outcome'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/lyfeUsersWebhook.js
+++ b/backend/src/routes/lyfeUsersWebhook.js
@@ -15,7 +15,11 @@
 import express from 'express';
 import { handleLyfeUsersWebhook } from '../controllers/lyfeUsersWebhookController.js';
 
-export const meta = { path: '/api/integrations/lyfe' };
+export const meta = {
+  path: '/api/integrations/lyfe',
+  // Public routes (default-deny routing): Lyfe HMAC verified inside the handler
+  public: ['POST /users-webhook'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/marketplace.js
+++ b/backend/src/routes/marketplace.js
@@ -11,6 +11,8 @@ import * as marketplaceService from '../services/marketplaceService.js';
  * raw campaign row. Dark-launched behind MARKETPLACE_PUBLIC_API_ENABLED.
  */
 export const meta = {
+  // Public routes (default-deny routing): public redeem.sg marketplace
+  public: ['GET /campaigns', 'GET /campaigns/:slug'],
   path: '/api/marketplace',
   flag: 'MARKETPLACE_PUBLIC_API_ENABLED',
   flagDefault: 'false',

--- a/backend/src/routes/prospects.js
+++ b/backend/src/routes/prospects.js
@@ -5,6 +5,8 @@ import { validate, schemas } from '../middleware/validation.js';
 import * as prospectController from '../controllers/prospectController.js';
 
 export const meta = {
+  // Public routes (default-deny routing): the public lead-capture door itself
+  public: ['POST /'],
   mounts: [{ path: '/api/prospects' }, { path: '/api/leadgen/prospects', flag: 'ENABLE_DOMAIN_PREFIXES' }],
 };
 

--- a/backend/src/routes/redeemOpsDiscovery.js
+++ b/backend/src/routes/redeemOpsDiscovery.js
@@ -11,6 +11,8 @@ import * as ctrl from '../controllers/redeemOps/discoveryController.js';
  * URL secret only (server-to-server, no JWT).
  */
 export const meta = {
+  // Public routes (default-deny routing): Apify webhook — path secret is the credential
+  public: ['POST /discovery/webhook/:secret'],
   path: '/api/redeem-ops',
   flag: 'REDEEM_OPS_ENABLED',
   flagDefault: 'false',

--- a/backend/src/routes/retell.js
+++ b/backend/src/routes/retell.js
@@ -2,7 +2,11 @@ import { Router } from 'express';
 import { authenticateToken, requireAgentOrAdmin } from '../middleware/auth.js';
 import * as retellController from '../controllers/retellController.js';
 
-export const meta = { path: '/api/retell' };
+export const meta = {
+  path: '/api/retell',
+  // Public routes (default-deny routing): Retell webhook — HMAC verified inside the handler
+  public: ['POST /webhook'],
+};
 
 const router = Router();
 

--- a/backend/src/routes/rewardClaim.js
+++ b/backend/src/routes/rewardClaim.js
@@ -23,6 +23,8 @@ import { logger } from '../utils/logger.js';
  * full lead PII (docs/redeem-ops/USER_SURFACES… §4).
  */
 export const meta = {
+  // Public routes (default-deny routing): claim link — the token IS the credential
+  public: ['GET /:token'],
   path: '/api/reward-claim',
   flag: 'REDEEM_OPS_ENTITLEMENTS_ENABLED',
   flagDefault: 'false',

--- a/backend/src/routes/routeGates.js
+++ b/backend/src/routes/routeGates.js
@@ -1,0 +1,80 @@
+/**
+ * Default-deny route registration.
+ *
+ * Every endpoint mounted through loadRoutes must either carry a TAGGED auth
+ * gate in its middleware chain (authenticateToken, requireRole closures,
+ * requireRedeemOps, requireExternalHmac — anything marked mktrAuthGate) or be
+ * explicitly declared in its module's `meta.public` array. An undeclared,
+ * ungated route fails the BOOT, not a review: three audit rounds each found
+ * endpoints that shipped open (H2, M3, M12) because nothing structural made
+ * "gated" the default.
+ *
+ * `meta.public` is the reviewable allowlist: auth flows, the public capture
+ * funnel, token-authenticated claim/callback links, and webhook receivers
+ * that verify signatures INSIDE the handler. Declarations are strict — one
+ * that matches no live route also fails boot, so the list cannot rot.
+ */
+
+/** Mark a middleware (or each element of an array) as an auth gate. */
+export function tagAuthGate(fn) {
+  if (Array.isArray(fn)) { fn.forEach(tagAuthGate); return fn; }
+  fn.mktrAuthGate = true;
+  return fn;
+}
+
+const isGate = (handle) => typeof handle === 'function' && handle.mktrAuthGate === true;
+
+/** Flatten an express router into [{ sig, gated }] — router-level gates
+ *  (router.use(gate)) protect every route registered after them. */
+export function walkRouter(stack, inheritedGate = false, out = []) {
+  let gated = inheritedGate;
+  for (const layer of stack || []) {
+    if (layer.route) {
+      const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
+      const routeGated = gated || layer.route.stack.some((l) => isGate(l.handle));
+      for (const method of Object.keys(layer.route.methods)) {
+        for (const p of paths) out.push({ sig: `${method.toUpperCase()} ${p}`, gated: routeGated });
+      }
+    } else if (layer.handle?.stack) {
+      walkRouter(layer.handle.stack, gated, out); // nested router inherits gates
+    } else if (isGate(layer.handle)) {
+      gated = true;
+    }
+  }
+  return out;
+}
+
+/** Boot-time enforcement — throws with the exact offenders. */
+export function assertRouterGated({ router, meta, file }) {
+  const routes = walkRouter(router.stack);
+  const declared = new Set(meta.public || []);
+
+  const undeclared = routes.filter((r) => !r.gated && !declared.has(r.sig)).map((r) => r.sig);
+  if (undeclared.length > 0) {
+    throw new Error(
+      `Ungated route(s) in ${file} with no meta.public declaration: ${undeclared.join(', ')}. ` +
+      'Add an auth gate (authenticateToken / requireRedeemOps / requireExternalHmac / requireRole) ' +
+      "or declare the route in the module's meta.public with a comment saying why it is public."
+    );
+  }
+
+  const live = new Set(routes.map((r) => r.sig));
+  const stale = [...declared].filter((sig) => !live.has(sig));
+  if (stale.length > 0) {
+    throw new Error(
+      `meta.public in ${file} declares route(s) that do not exist: ${stale.join(', ')}. ` +
+      'Remove the stale declaration.'
+    );
+  }
+
+  // A declaration for a route that is actually gated is a lie waiting to
+  // mislead the next reader — declarations must mean exactly one thing.
+  const gatedSigs = new Set(routes.filter((r) => r.gated).map((r) => r.sig));
+  const redundant = [...declared].filter((sig) => gatedSigs.has(sig));
+  if (redundant.length > 0) {
+    throw new Error(
+      `meta.public in ${file} declares route(s) that carry an auth gate: ${redundant.join(', ')}. ` +
+      'Remove the declaration (the gate governs) or the gate (and keep the declaration).'
+    );
+  }
+}

--- a/backend/src/routes/screeningCallback.js
+++ b/backend/src/routes/screeningCallback.js
@@ -20,6 +20,8 @@ import { readWaCallbackContext, applyWaCallbackRequest } from '../services/retel
  * from the redeem.sg static site (internalRouteHostGuard blocklist).
  */
 export const meta = {
+  // Public routes (default-deny routing): screening callback — the token IS the credential
+  public: ['GET /:token', 'POST /:token'],
   path: '/api/screening-callback',
 };
 

--- a/backend/src/routes/shortlinks.js
+++ b/backend/src/routes/shortlinks.js
@@ -4,6 +4,8 @@ import { authenticateToken, requireAdmin } from '../middleware/auth.js';
 import * as shortlinkController from '../controllers/shortlinkController.js';
 
 export const meta = {
+  // Public routes (default-deny routing): public share/redirect surface
+  public: ['POST /public/share', 'GET /:slug'],
   mounts: [
     { path: '/api/shortlinks' },
     { path: '/share' },

--- a/backend/src/routes/tracker.js
+++ b/backend/src/routes/tracker.js
@@ -3,6 +3,8 @@ import { makeLimiter } from '../middleware/rateLimiters.js';
 import * as trackerController from '../controllers/trackerController.js';
 
 export const meta = {
+  // Public routes (default-deny routing): public QR scan funnel
+  public: ['GET /track/:slug', 'GET /session'],
   priority: -1,
   mounts: [
     { path: '/api/qrcodes' },

--- a/backend/src/routes/unsubscribe.js
+++ b/backend/src/routes/unsubscribe.js
@@ -2,7 +2,11 @@ import express from 'express';
 import { makeLimiter } from '../middleware/rateLimiters.js';
 import { showUnsubscribe, confirmUnsubscribe } from '../controllers/unsubscribeController.js';
 
-export const meta = { path: '/api/unsubscribe' };
+export const meta = {
+  path: '/api/unsubscribe',
+  // Public routes (default-deny routing): one-click unsubscribe must never require login
+  public: ['GET /', 'POST /'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/verify.js
+++ b/backend/src/routes/verify.js
@@ -2,7 +2,11 @@ import express from 'express';
 import * as ctrl from '../controllers/verifyController.js';
 import { makeLimiter } from '../middleware/rateLimiters.js';
 
-export const meta = { path: '/api/verify' };
+export const meta = {
+  path: '/api/verify',
+  // Public routes (default-deny routing): public capture funnel OTP
+  public: ['POST /send', 'POST /check'],
+};
 
 const router = express.Router();
 

--- a/backend/src/routes/waitlist.js
+++ b/backend/src/routes/waitlist.js
@@ -6,6 +6,8 @@ import * as waitlistController from '../controllers/waitlistController.js';
 
 // Auto-discovered + mounted by routes/index.js via this meta export.
 export const meta = {
+  // Public routes (default-deny routing): public waitlist form
+  public: ['POST /'],
   path: '/api/waitlist',
 };
 

--- a/backend/src/routes/whatsappWebhook.js
+++ b/backend/src/routes/whatsappWebhook.js
@@ -23,7 +23,11 @@ import { logger } from '../utils/logger.js';
  * durability story: transient DB failure → 500 → Meta redelivers, and every
  * write in the processor is idempotent).
  */
-export const meta = { path: '/api/whatsapp' };
+export const meta = {
+  path: '/api/whatsapp',
+  // Public routes (default-deny routing): Meta verification + signature in the handler
+  public: ['GET /webhook', 'POST /webhook'],
+};
 
 const router = express.Router();
 

--- a/backend/test/routeGateAudit.test.js
+++ b/backend/test/routeGateAudit.test.js
@@ -1,0 +1,197 @@
+/**
+ * Default-deny routing (routeGates.js): the public API surface is EXPLICIT.
+ *
+ * Every endpoint mounted through loadRoutes must carry a tagged auth gate or
+ * be declared in its module's meta.public — an undeclared open route refuses
+ * to BOOT (three audit rounds each found endpoints that shipped open: H2, M3,
+ * M12). This suite is the RATCHET on top of that boot check: the exact
+ * declared-public surface is snapshotted below, so making a new route public
+ * is a conscious, reviewable edit to this file — never a silent default.
+ */
+import { readdir } from 'fs/promises'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import express from 'express'
+import { getApp, closeDb } from './helpers.js'
+import { walkRouter, assertRouterGated, tagAuthGate } from '../src/routes/routeGates.js'
+
+const routesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/routes')
+
+// The ENTIRE intentionally-public API surface. Adding a route here requires a
+// reason in the module's meta.public comment; removing a gate elsewhere fails
+// boot before it fails this test.
+const PUBLIC_SURFACE = {
+  "analytics.js": [
+    "POST /events",
+    "POST /referrals"
+  ],
+  "auth.js": [
+    "GET /google/config",
+    "GET /google/state",
+    "GET /invite-info/:token",
+    "GET /verify-email/:token",
+    "POST /accept-invite",
+    "POST /forgot-password",
+    "POST /google",
+    "POST /google/callback",
+    "POST /login",
+    "POST /register",
+    "POST /reset-password/:token"
+  ],
+  "campaignPreviews.js": [
+    "GET /public/:id",
+    "GET /slug/:slug"
+  ],
+  "campaigns.js": [
+    "GET /featured-drops"
+  ],
+  "contact.js": [
+    "POST /"
+  ],
+  "dnc.js": [
+    "POST /check"
+  ],
+  "externalAdminLeadOps.js": [
+    "POST /reassign",
+    "POST /return-to-held"
+  ],
+  "externalAgentPackages.js": [
+    "POST /"
+  ],
+  "externalBilling.js": [
+    "POST /hitpay-webhook"
+  ],
+  "externalHeldLeads.js": [
+    "POST /",
+    "POST /assign"
+  ],
+  "externalLeadActivities.js": [
+    "POST /"
+  ],
+  "externalLeadOutcomes.js": [
+    "POST /lead-outcomes"
+  ],
+  "lyfeEntitlementUnlock.js": [
+    "POST /entitlement-unlock"
+  ],
+  "lyfeLeadOutcome.js": [
+    "POST /lead-outcome"
+  ],
+  "lyfeUsersWebhook.js": [
+    "POST /users-webhook"
+  ],
+  "marketplace.js": [
+    "GET /campaigns",
+    "GET /campaigns/:slug"
+  ],
+  "prospects.js": [
+    "POST /"
+  ],
+  "redeemOpsDiscovery.js": [
+    "POST /discovery/webhook/:secret"
+  ],
+  "retell.js": [
+    "POST /webhook"
+  ],
+  "rewardClaim.js": [
+    "GET /:token"
+  ],
+  "screeningCallback.js": [
+    "GET /:token",
+    "POST /:token"
+  ],
+  "shortlinks.js": [
+    "GET /:slug",
+    "POST /public/share"
+  ],
+  "tracker.js": [
+    "GET /session",
+    "GET /track/:slug"
+  ],
+  "unsubscribe.js": [
+    "GET /",
+    "POST /"
+  ],
+  "verify.js": [
+    "POST /check",
+    "POST /send"
+  ],
+  "waitlist.js": [
+    "POST /"
+  ],
+  "whatsappWebhook.js": [
+    "GET /webhook",
+    "POST /webhook"
+  ]
+}
+
+beforeAll(async () => {
+  await getApp() // proves boot-time enforcement passes on the real app
+})
+
+afterAll(async () => {
+  await closeDb()
+})
+
+async function loadRouteModules() {
+  const files = (await readdir(routesDir)).filter(
+    (f) => f.endsWith('.js') && f !== 'index.js' && f !== 'routeGates.js'
+  )
+  const mods = []
+  for (const f of files) {
+    const mod = await import(path.join(routesDir, f))
+    if (mod.meta && mod.default) mods.push({ file: f, meta: mod.meta, router: mod.default })
+  }
+  return mods
+}
+
+describe('default-deny route registration', () => {
+  test('every mounted route is gated or explicitly declared public', async () => {
+    for (const { file, meta, router } of await loadRouteModules()) {
+      expect(() => assertRouterGated({ router, meta, file })).not.toThrow()
+    }
+  })
+
+  test('the declared public surface matches the snapshot exactly', async () => {
+    const actual = {}
+    for (const { file, meta } of await loadRouteModules()) {
+      if (meta.public?.length) actual[file] = [...meta.public].sort()
+    }
+    expect(actual).toEqual(PUBLIC_SURFACE)
+  })
+
+  test('walker: router-level gates protect everything registered after them', () => {
+    const gate = tagAuthGate((req, res, next) => next())
+    const r = express.Router()
+    r.get('/before', (req, res) => res.end())
+    r.use(gate)
+    r.post('/after', (req, res) => res.end())
+    const routes = walkRouter(r.stack)
+    expect(routes).toEqual([
+      { sig: 'GET /before', gated: false },
+      { sig: 'POST /after', gated: true },
+    ])
+  })
+
+  test('enforcement: undeclared open route throws; declared passes', () => {
+    const r = express.Router()
+    r.get('/leak', (req, res) => res.end())
+    expect(() => assertRouterGated({ router: r, meta: {}, file: 'fake.js' }))
+      .toThrow(/Ungated route\(s\) in fake\.js.*GET \/leak/)
+    expect(() =>
+      assertRouterGated({ router: r, meta: { public: ['GET /leak'] }, file: 'fake.js' })
+    ).not.toThrow()
+  })
+
+  test('enforcement: stale and redundant declarations both throw', () => {
+    const gate = tagAuthGate((req, res, next) => next())
+    const r = express.Router()
+    r.get('/secured', gate, (req, res) => res.end())
+    expect(() =>
+      assertRouterGated({ router: r, meta: { public: ['GET /gone'] }, file: 'fake.js' })
+    ).toThrow(/do not exist/)
+    expect(() =>
+      assertRouterGated({ router: r, meta: { public: ['GET /secured'] }, file: 'fake.js' })
+    ).toThrow(/carry an auth gate/)
+  })
+})

--- a/backend/test/unit/dncRoute.test.js
+++ b/backend/test/unit/dncRoute.test.js
@@ -22,7 +22,9 @@ describe('POST /api/dnc/check (route + controller)', () => {
   beforeEach(() => checkDncForForm.mockReset());
 
   it('mounts at /api/dnc (auto-loader contract: meta.path + default export)', () => {
-    expect(dncMeta).toEqual({ path: '/api/dnc' });
+    // meta.public: default-deny routing — /check is the capture funnel's
+    // consent pre-check, declared public by design (routeGates.js).
+    expect(dncMeta).toEqual({ path: '/api/dnc', public: ['POST /check'] });
     expect(typeof dncRouter).toBe('function');
   });
 


### PR DESCRIPTION
## What this is

The structural fix for the recurring bug-class from all three audit rounds (H2, M3, M12: endpoints shipping without gates). **An ungated, undeclared route now refuses to BOOT.**

## How it works

- Auth middlewares are **tagged** (`mktrAuthGate`): `authenticateToken`, every `requireRole(...)` closure (admin/agent), `requireRedeemOps` (its chain contains tagged `authenticateToken`), and both `requireExternalHmac` variants (mktr-leads HMAC).
- `loadRoutes` walks each module's express-5 router stack — router-level gates protect everything registered after them; nested routers inherit — and throws at boot listing the exact offenders unless the route appears in the module's **`meta.public`** with a why-comment.
- Validation runs **before the feature-flag check**, so a flag-off surface (e.g. a redeem-ops router disabled in CI) is still held to the bar — no "boots green in CI, explodes when the flag flips in prod".
- Declarations are strict both directions: a declaration matching **no live route** fails boot; a declaration naming a route that **carries a gate** fails boot. The allowlist cannot rot or lie.

## The audited public surface

Walking all 43 route modules produced **47 intentionally-public endpoints across 27 modules** — auth flows, the public capture funnel (prospects / verify / dnc / tracker / analytics beacons), token-credential links (reward claim, screening callback, unsubscribe), the public marketplace/previews/featured-drops, and signature-in-handler webhook receivers (Retell, Lyfe ×3, mktr-leads ×4, HitPay, WhatsApp, Apify). **Zero surprise-open endpoints existed** post-M12; this keeps it structural.

## Ratchet + proof

- `test/routeGateAudit.test.js` snapshots the exact public surface — adding a public route is a conscious, reviewable edit to that file.
- Walker semantics (router-level inheritance) and all three enforcement failures (undeclared-open, stale, redundant) are unit-proven with fabricated routers.
- Every DB-backed suite boots through the live enforcement; unit tier **2231/2231**; eslint clean. One meta-contract unit test updated (dnc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)