### PR TITLE
feat(quality): TypeScript checkJs ratchet — and the prod logging bug it caught

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Run unit tests
         run: cd backend && npm test -- --testPathPattern="test/unit/"
+      - name: Typecheck (JSDoc ratchet)
+        run: cd backend && npm run typecheck
 
       - name: Run integration tests
         run: cd backend && npm test -- --testPathPattern="test/(integration/|[^/]+\\.test\\.js)"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -46,7 +46,8 @@
         "@types/node": "^20.10.0",
         "jest": "^29.7.0",
         "nodemon": "^3.0.2",
-        "supertest": "^6.3.3"
+        "supertest": "^6.3.3",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9988,6 +9989,20 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=6144\" jest",
+    "typecheck": "tsc -p tsconfig.check.json",
     "test:legacy-safe": "node scripts/legacy-safe-harness.js",
     "load:smoke": "node load/run-local-load.js",
     "load:spike": "LOAD_PROFILE=spike node load/run-local-load.js",
@@ -60,7 +61,8 @@
     "@types/node": "^20.10.0",
     "jest": "^29.7.0",
     "nodemon": "^3.0.2",
-    "supertest": "^6.3.3"
+    "supertest": "^6.3.3",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/backend/src/middleware/appError.js
+++ b/backend/src/middleware/appError.js
@@ -10,6 +10,14 @@ export class AppError extends Error {
     super(message);
     this.statusCode = statusCode;
     this.details = details;
+    /**
+     * Typed-error payload ({ code, ...context }) surfaced to API clients by
+     * errorHandler — assigned after construction by the draw guards and
+     * friends. Declared here so the contract is visible (and typecheckable)
+     * instead of an ad-hoc expando.
+     * @type {Record<string, any>|undefined}
+     */
+    this.data = undefined;
     this.isOperational = true;
 
     Error.captureStackTrace(this, this.constructor);

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -19,7 +19,7 @@ import { makeLimiter } from './middleware/rateLimiters.js';
 import leadCaptureBind from './routes/leadCaptureBind.js';
 import { optionalAuth, authenticateToken, requireAdmin } from './middleware/auth.js';
 import { blockRedeemForInternalRoutes } from './middleware/internalRouteHostGuard.js';
-import { logger } from './utils/logger.js';
+import { logger, pinoInstance } from './utils/logger.js';
 import { maskTokenUrl } from './utils/redactTokens.js';
 import { isInlineSafePath } from './utils/fileSignature.js';
 import swaggerUi from 'swagger-ui-express';
@@ -144,7 +144,7 @@ export const init = async (app) => {
   // bearer tokens — /api/reward-claim/:token is a live credential and must
   // never land in access logs (see utils/redactTokens.js).
   app.use(pinoHttp({
-    logger,
+    logger: pinoInstance,
     autoLogging: { ignore: (req) => req.url === '/health' },
     serializers: {
       req(req) {

--- a/backend/src/utils/consumerScoring.js
+++ b/backend/src/utils/consumerScoring.js
@@ -628,15 +628,15 @@ export function normalizeConfig(configJson) {
 /**
  * Score one consumer.
  *
- * @param {Object} input
- * @param {Object} input.facts      resolveCurrentFacts() output (key → {value, confidence, observationId, basis, …})
- * @param {Object} input.telemetry  {signupCount, verifiedSignupCount, newestSignupAt, marketingConsent, hasEmail, whatsappReachable}
- * @param {Object} input.config     configJson from enrichment_scoring_configs (merged over defaults)
- * @param {number} input.now        epoch ms — injected so scoring is reproducible in tests and backfills
+ * @param {Object} [input]
+ * @param {Object} [input.facts]      resolveCurrentFacts() output (key → {value, confidence, observationId, basis, …})
+ * @param {Object} [input.telemetry]  {signupCount, verifiedSignupCount, newestSignupAt, marketingConsent, hasEmail, whatsappReachable}
+ * @param {Object} [input.config]     configJson from enrichment_scoring_configs (merged over defaults)
+ * @param {number} [input.now]        epoch ms — injected so scoring is reproducible in tests and backfills
  * @returns {{meetScore:number|null, buyScore:number|null, consumerScore:number|null,
  *            breakdown:Object, algorithmVersion:string}}
  */
-export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.now() } = {}) {
+export function scoreConsumer({ facts = {}, telemetry = {}, config, now = Date.now() } = /** @type {{facts?: object, telemetry?: object, config?: any, now?: number}} */ ({})) {
   const cfg = normalizeConfig(config);
   return computeScore({ cfg, facts, telemetry, now, algorithmVersion: cfg.algorithmVersion });
 }
@@ -820,7 +820,7 @@ export function normalizeLeadConfig(configJson) {
  * @returns {{meetScore:number|null, buyScore:number|null, score:number|null,
  *            breakdown:Object, algorithmVersion:string}}
  */
-export function scoreLead({ facts = {}, telemetry = {}, config, now = Date.now() } = {}) {
+export function scoreLead({ facts = {}, telemetry = {}, config, now = Date.now() } = /** @type {{facts?: object, telemetry?: object, config?: any, now?: number}} */ ({})) {
   const cfg = normalizeLeadConfig(config);
   const r = computeScore({ cfg, facts, telemetry, now, algorithmVersion: LEAD_ALGORITHM_VERSION });
   // `score` rather than `consumerScore`: same number, named for the column it

--- a/backend/src/utils/externalFetch.js
+++ b/backend/src/utils/externalFetch.js
@@ -22,7 +22,7 @@ import { incCounter, observeDuration } from '../services/observability.js';
 export const DEFAULT_TIMEOUT_MS = 12_000;
 
 const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const noopLogger = { warn: () => {}, error: () => {}, info: () => {} };
+const noopLogger = { warn: (..._a) => {}, error: (..._a) => {}, info: (..._a) => {} };
 
 /** True for the errors that mean "try again" rather than "this request is wrong". */
 export function isTransientFetchError(err) {
@@ -34,14 +34,16 @@ export function isTransientFetchError(err) {
  * `name: 'AbortError'` and `timeout: true`, which the retry layer treats as
  * transient — the request may never have reached the provider.
  */
-export async function fetchWithTimeout(fetchImpl, url, opts = {}, { timeoutMs = DEFAULT_TIMEOUT_MS, label } = {}) {
+export async function fetchWithTimeout(fetchImpl, url, opts = {}, { timeoutMs = DEFAULT_TIMEOUT_MS, label } = /** @type {{timeoutMs?: number, label?: string}} */ ({})) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     return await fetchImpl(url, { ...opts, signal: controller.signal });
   } catch (err) {
     if (controller.signal.aborted) {
-      const timeoutErr = new Error(`${label || 'external request'} timed out after ${timeoutMs}ms`);
+      const timeoutErr = /** @type {Error & {timeout?: boolean, cause?: unknown}} */ (
+        new Error(`${label || 'external request'} timed out after ${timeoutMs}ms`)
+      );
       timeoutErr.name = 'AbortError';
       timeoutErr.timeout = true;
       timeoutErr.cause = err;
@@ -65,7 +67,10 @@ export async function retryingFetch(fetchImpl, url, opts = {}, {
   sleep = defaultSleep,
   logger = noopLogger,
   logPrefix = 'external_fetch',
-} = {}) {
+} = /** @type {{label?: string, attempts?: number, timeoutMs?: number,
+      sleep?: (ms: number) => Promise<void>,
+      logger?: {warn: Function, error: Function, info: Function},
+      logPrefix?: string}} */ ({})) {
   // Every external call — WhatsApp Graph and Apify both — comes through here
   // (P2-1 unified the transport), so this is the one place that can measure
   // them, and `logPrefix` already names the dependency (P3-5).

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -2,7 +2,7 @@ import pino from 'pino';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-export const logger = pino({
+const pinoInstance = pino({
   level: process.env.LOG_LEVEL || (isProduction ? 'info' : 'debug'),
   ...(isProduction
     ? {}
@@ -43,3 +43,47 @@ export const logger = pino({
     res: pino.stdSerializers.res,
   },
 });
+
+/**
+ * The house logging convention is `logger.warn('message', { meta })`. Raw
+ * pino's contract is the REVERSE — (mergingObject, message) — and when the
+ * first argument is a string with no printf placeholders, pino silently
+ * DROPS every additional argument from JSON output. Net effect: every
+ * campaignId / prospectId / error field attached since the beginning was
+ * missing from production logs, while dev's pino-pretty rendered the
+ * interpolation args and masked it (verified empirically against a capture
+ * stream).
+ *
+ * This adapter makes the house convention real: ('msg', {meta}) is reordered
+ * to pino's (meta, 'msg'); ('msg', Error) wraps the error as { err } so the
+ * stdSerializer applies; pino-native (obj, 'msg') and printf-style calls
+ * pass through untouched. Exported as a factory so the unit test can pin the
+ * behaviour against a capture stream.
+ *
+ * @param {import('pino').Logger} base
+ */
+export function adaptHouseConvention(base) {
+  const adapt = (method) => (a, b, ...rest) => {
+    if (typeof a === 'string' && b !== undefined && rest.length === 0) {
+      if (b instanceof Error) return base[method]({ err: b }, a);
+      if (b !== null && typeof b === 'object') return base[method](b, a);
+    }
+    return base[method](a, b, ...rest);
+  };
+  return {
+    fatal: adapt('fatal'),
+    error: adapt('error'),
+    warn: adapt('warn'),
+    info: adapt('info'),
+    debug: adapt('debug'),
+    trace: adapt('trace'),
+    child: (bindings) => adaptHouseConvention(base.child(bindings)),
+    get level() { return base.level; },
+  };
+}
+
+export const logger = adaptHouseConvention(pinoInstance);
+
+// pino-http (server_internal) needs the REAL pino instance — the adapter is
+// for app code only.
+export { pinoInstance };

--- a/backend/src/utils/scoringConfigValidation.js
+++ b/backend/src/utils/scoringConfigValidation.js
@@ -78,6 +78,7 @@ export const PENALTY_COMPONENTS = Object.freeze(new Set(['coverage_headroom']));
 const MAX_TARGET_SEGMENTS = 8;
 
 const isPlainObject = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+/** @type {(error: string) => {ok: false, error: string}} */
 const fail = (error) => ({ ok: false, error });
 const isFiniteNumber = (n) => typeof n === 'number' && Number.isFinite(n);
 
@@ -128,7 +129,7 @@ function checkComponentMap(raw, label) {
  */
 function checkDominance(components, grainLabel) {
   const positive = Object.entries(components)
-    .map(([name, def]) => [name, Number(def?.maxPoints) || 0])
+    .map(([name, def]) => /** @type {[string, number]} */ ([name, Number(def?.maxPoints) || 0]))
     .filter(([, pts]) => pts > 0);
 
   const total = positive.reduce((s, [, pts]) => s + pts, 0);

--- a/backend/src/utils/sentryScrub.js
+++ b/backend/src/utils/sentryScrub.js
@@ -22,6 +22,7 @@ const PII_KEY_PATTERN = /phone|email|nric|name|token|jwt|address|otp|password|si
  * of convenience. Keep these in step with lyfe-sg / lyfe-app if they gain a
  * value-level pass.
  */
+/** @type {[RegExp, string][]} */
 const PII_VALUE_PATTERNS = [
   [/[\w.+-]+@[\w-]+\.[\w.-]+/g, '[email]'],
   // SPACED display form first (`+65 9123 4567` — the format this platform

--- a/backend/src/utils/sourceLabel.js
+++ b/backend/src/utils/sourceLabel.js
@@ -109,6 +109,7 @@ function adPlatformLabel(utmSource) {
  * identically to the same lead once it's delivered to an agent. Keep in sync with
  * mktr-leads/supabase/functions/receive-mktr-lead/leadSource.ts.
  */
+/** @param {{leadSource?: string|null, qrTag?: {label?: string|null, slug?: string|null, externalId?: string|null}|null, sourceMetadata?: Record<string, any>|null}} [signup] */
 export function signupSourceLabel({ leadSource, qrTag, sourceMetadata } = {}) {
   const meta = sourceMetadata || {};
   const source = String(leadSource || '').toLowerCase();

--- a/backend/test/unit/loggerConvention.test.js
+++ b/backend/test/unit/loggerConvention.test.js
@@ -1,0 +1,61 @@
+/**
+ * The house logging convention — logger.warn('message', { meta }) — versus
+ * raw pino, whose contract is (mergingObject, message) and which silently
+ * DROPS extra args after a placeholder-less string. Pre-adapter, every
+ * structured field attached to a production log line was missing from the
+ * JSON output while dev's pino-pretty rendered it, masking the loss.
+ * adaptHouseConvention reorders the house call into pino's contract; these
+ * tests pin every calling shape against a capture stream.
+ */
+import pino from 'pino';
+import { adaptHouseConvention } from '../../src/utils/logger.js';
+
+function capture() {
+  const lines = [];
+  const base = pino({ base: null, timestamp: false }, { write: (s) => lines.push(JSON.parse(s)) });
+  return { log: adaptHouseConvention(base), lines };
+}
+
+describe('adaptHouseConvention', () => {
+  it("house convention ('msg', {meta}) lands the meta as JSON fields", () => {
+    const { log, lines } = capture();
+    log.warn('lead held', { campaignId: 'c-123', reason: 'no_funded_agent' });
+    expect(lines[0]).toMatchObject({ msg: 'lead held', campaignId: 'c-123', reason: 'no_funded_agent' });
+  });
+
+  it('raw pino DROPS the house-convention meta — the loss this adapter exists for', () => {
+    const lines = [];
+    const raw = pino({ base: null, timestamp: false }, { write: (s) => lines.push(JSON.parse(s)) });
+    raw.warn('lead held', { campaignId: 'c-123' });
+    expect(lines[0].campaignId).toBeUndefined(); // documents the underlying behaviour
+  });
+
+  it("('msg', Error) serializes through the err serializer", () => {
+    const { log, lines } = capture();
+    log.error('boom happened', new Error('kaboom'));
+    expect(lines[0].msg).toBe('boom happened');
+    expect(lines[0].err?.message).toBe('kaboom');
+    expect(lines[0].err?.stack).toContain('kaboom');
+  });
+
+  it("pino-native (obj, 'msg') passes through untouched", () => {
+    const { log, lines } = capture();
+    log.info({ deliveryId: 'd-1' }, 'delivered');
+    expect(lines[0]).toMatchObject({ msg: 'delivered', deliveryId: 'd-1' });
+  });
+
+  it('single-string and printf-style calls pass through', () => {
+    const { log, lines } = capture();
+    log.info('plain message');
+    log.info('value is %d', 42);
+    expect(lines[0].msg).toBe('plain message');
+    expect(lines[1].msg).toBe('value is 42');
+  });
+
+  it('child loggers keep both the bindings and the house convention', () => {
+    const { log, lines } = capture();
+    const child = log.child({ component: 'webhook' });
+    child.warn('retrying', { deliveryId: 'd-9' });
+    expect(lines[0]).toMatchObject({ msg: 'retrying', component: 'webhook', deliveryId: 'd-9' });
+  });
+});

--- a/backend/tsconfig.check.json
+++ b/backend/tsconfig.check.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "es2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strict": false,
+    "noImplicitAny": false
+  },
+  "include": ["src/utils/**/*.js"]
+}


### PR DESCRIPTION
## The ratchet

`npm run typecheck` (new CI step, typescript pinned as devDependency) runs `tsc` with `checkJs` over `tsconfig.check.json`'s include list — `src/utils/**` at **zero errors**. Expansion policy (documented in CLAUDE.md, shipped in #422): add directories to the include list and drive them to zero; the CI step never comes out.

## The production bug its first run caught

House convention everywhere: `logger.warn('message', { meta })`. The logger was **raw pino**, whose contract is the reverse — `(mergingObject, message)` — and which **silently drops** extra args after a placeholder-less string. Verified against a capture stream:

```
log.warn('house convention', { campaignId: 'c-123' })   → {"msg":"house convention"}          ← meta GONE
log.warn({ campaignId: 'c-456' }, 'pino convention')    → {"campaignId":"c-456","msg":…}
```

Every `campaignId` / `prospectId` / error field attached to a log line has been **missing from production JSON output since the beginning** — dev's pino-pretty rendered interpolation args and masked it.

**Fix**: `adaptHouseConvention` wraps pino — `('msg', {meta})` reorders to `(meta, 'msg')`; `('msg', Error)` wraps as `{ err }` for the std serializer; pino-native `(obj, 'msg')`, printf-style, and single-string calls pass through; `child()` keeps both bindings and the convention. `pino-http` receives the raw `pinoInstance`. **84 call-site files fixed with zero call-site edits.** Six-case unit suite pins every shape, including the documented raw-pino loss as permanent in-repo evidence.

## The annotation fixes (39 findings → 0)

All annotation-class, fixed at the source rather than suppressed: `AppError` formally declares its typed-error `data` payload (the draw guards' contract, previously an expando); `scoringConfigValidation.fail()` typed to its discriminated union; tuple/destructured-param shapes in `sentryScrub`, `sourceLabel`, `externalFetch`, `consumerScoring`; `externalFetch`'s noop logger given real arity.

## Verification

Unit tier **2237/2237** (6 new) · campaign/prospect/webhook DB slices green · eslint clean · `npm run typecheck` zero errors · no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)