### PR TITLE
feat(quality): fused row-ownership loaders + typecheck slice 2

### DIFF
--- a/backend/src/database/connection.js
+++ b/backend/src/database/connection.js
@@ -54,7 +54,7 @@ const config = {
 };
 
 // Create Sequelize instance
-export const sequelize = new Sequelize(config);
+export const sequelize = new Sequelize(/** @type {import('sequelize').Options} */ (config));
 
 // Test connection function
 export async function testConnection() {

--- a/backend/src/database/testRunLock.js
+++ b/backend/src/database/testRunLock.js
@@ -29,7 +29,8 @@ const appName = () => `mktr-test-lock:${process.pid}`;
 
 function clientConfig() {
   const { database, username, password, host, port } = sequelize.config;
-  return { host, port, database, user: username, password, application_name: appName() };
+  // sequelize.config carries port as a string; pg.Client wants a number.
+  return { host, port: Number(port), database, user: username, password, application_name: appName() };
 }
 
 async function tryLock(client) {

--- a/backend/src/middleware/rateLimiters.js
+++ b/backend/src/middleware/rateLimiters.js
@@ -22,7 +22,7 @@ import { PostgresRateLimitStore, clientKey } from './pgRateLimitStore.js';
  * `prefix` is REQUIRED and must be unique per limiter: it namespaces the bucket,
  * so two limiters sharing one would charge each other's traffic.
  */
-export function makeLimiter({ prefix, ...options } = {}) {
+export function makeLimiter({ prefix, ...options } = /** @type {{prefix?: string} & Record<string, any>} */ ({})) {
   if (!prefix) {
     throw new Error('makeLimiter requires a unique `prefix` — limiters must not share a bucket');
   }

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -164,7 +164,17 @@ export function makeProspectService(overrides = {}) {
    * Resolves attribution, normalizes input, wraps DB writes in a transaction.
    * Returns { prospect, assignedAgentId } — caller handles email side-effect.
    */
+  // createProspect reads as five banners: INTAKE (below) → SCORE → ROUTE →
+  // PERSIST → DISPATCH. The intake stretch stays INLINE by decision: its
+  // steps thread ~30 locals (consent evidence, attribution, campaign, gates)
+  // and every extraction shape trialled meant a context-object rewrite of the
+  // hottest business path for navigation value the banners already provide.
+  // The genuinely separable complexity was already extracted (P3-1):
+  // prospectCreateTx, prospectDispatch, prospectScoring, prospectQrRouting.
   async function createProspect(body, user, { cookies, headers, meta } = {}) {
+    // --- INTAKE: unpack the submission, build SERVER-authoritative consent
+    //     evidence, resolve campaign/attribution, and run every gate that can
+    //     reject before a row exists ---
     const safeBody = body || {};
     // Prefer controller-supplied meta context; fall back to body fields if any
     // caller posts directly without the controller's extraction step.

--- a/backend/src/services/rateCounter.js
+++ b/backend/src/services/rateCounter.js
@@ -66,7 +66,7 @@ export async function bump(key, expiresAt, sequelize = defaultSequelize) {
   const [rows] = await sequelize.query(BUMP_SQL, {
     replacements: { key, expiresAt },
   });
-  const row = rows?.[0] || {};
+  const row = /** @type {{count?: number|string, expiresAt?: string|Date}} */ (rows?.[0] || {});
   return { count: Number(row.count), expiresAt: new Date(row.expiresAt) };
 }
 
@@ -91,7 +91,7 @@ export async function peek(key, sequelize = defaultSequelize) {
       WHERE key = :key AND "expiresAt" > now()`,
     { replacements: { key } },
   );
-  const row = rows?.[0];
+  const row = /** @type {{count?: number|string, expiresAt?: string|Date}|undefined} */ (rows?.[0]);
   return row ? { count: Number(row.count), expiresAt: new Date(row.expiresAt) } : { count: 0, expiresAt: null };
 }
 
@@ -110,5 +110,5 @@ export async function purgeExpired(sequelize = defaultSequelize) {
   const [, meta] = await sequelize.query(
     `DELETE FROM rate_counters WHERE "expiresAt" <= now() - interval '2 days'`,
   );
-  return meta?.rowCount ?? 0;
+  return /** @type {{rowCount?: number}} */ (meta)?.rowCount ?? 0;
 }

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -72,6 +72,18 @@ export function makePartnerService(overrides = {}) {
     );
   }
 
+  /**
+   * Fetch a live partner AND require the caller may act on its row, in ONE
+   * call — a site cannot take the row without passing the gate (H2 existed
+   * because a surface fetched without gating). `forbid` keeps each verb's
+   * exact 403 message; pass query `options` (transaction/lock) as usual.
+   */
+  async function getOwnedPartner(id, user, { forbid = 'You can only edit businesses you own', ...options } = {}) {
+    const partner = await getLivePartner(id, options);
+    if (!canActOnRow(user, partner)) throw new AppError(forbid, 403);
+    return partner;
+  }
+
   async function getLivePartner(id, options = {}) {
     const partner = await d.PartnerOrganisation.findByPk(id, options);
     if (!partner || partner.mergedIntoId) throw new AppError('Partner not found', 404);
@@ -209,10 +221,7 @@ export function makePartnerService(overrides = {}) {
   ];
 
   async function updatePartner(id, body, user, requestId = null) {
-    const partner = await getLivePartner(id);
-    if (!canActOnRow(user, partner)) {
-      throw new AppError('You can only edit businesses you own', 403);
-    }
+    const partner = await getOwnedPartner(id, user);
     const updates = {};
     for (const f of EDITABLE_FIELDS) if (body[f] !== undefined) updates[f] = body[f];
     // Verification is a public trust badge, not ordinary partner data —
@@ -445,10 +454,9 @@ export function makePartnerService(overrides = {}) {
    * until the stale sweep wakes it at snoozedUntil.
    */
   async function snoozePartnerTx(id, user, until, t, { requestId = null } = {}) {
-    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
-    if (!canActOnRow(user, partner)) {
-      throw new AppError('You can only snooze businesses you own', 403);
-    }
+    const partner = await getOwnedPartner(id, user, {
+      forbid: 'You can only snooze businesses you own', transaction: t, lock: t.LOCK.UPDATE,
+    });
     if (partner.pipelineStage === 'PARTNERED' || partner.pipelineStage === 'LOST') {
       throw new AppError('Partnered and Lost businesses cannot be snoozed', 400);
     }
@@ -476,10 +484,9 @@ export function makePartnerService(overrides = {}) {
   }
 
   async function unsnoozePartnerTx(id, user, t, { requestId = null } = {}) {
-    const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
-    if (!canActOnRow(user, partner)) {
-      throw new AppError('You can only snooze businesses you own', 403);
-    }
+    const partner = await getOwnedPartner(id, user, {
+      forbid: 'You can only snooze businesses you own', transaction: t, lock: t.LOCK.UPDATE,
+    });
     if (partner.availability !== 'follow_up_later' && !partner.snoozedUntil) return partner;
     await partner.update(
       { availability: partner.ownerUserId ? 'owned' : 'available', snoozedUntil: null },
@@ -687,8 +694,7 @@ export function makePartnerService(overrides = {}) {
   // ── Contacts & locations ─────────────────────────────────────────────────
 
   async function addContact(id, body, user) {
-    const partner = await getLivePartner(id);
-    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await getOwnedPartner(id, user);
     if (!body.name || !String(body.name).trim()) throw new AppError('Contact name is required', 400);
     return d.sequelize.transaction(async (t) => {
       if (body.isPrimary) {
@@ -722,8 +728,7 @@ export function makePartnerService(overrides = {}) {
   async function updateContact(contactId, body, user) {
     const contact = await d.PartnerContact.findByPk(contactId);
     if (!contact || contact.archivedAt) throw new AppError('Contact not found', 404);
-    const partner = await getLivePartner(contact.partnerOrganisationId);
-    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await getOwnedPartner(contact.partnerOrganisationId, user);
     const updates = {};
     for (const f of ['name', 'roleTitle', 'mobile', 'whatsapp', 'email', 'preferredChannel', 'isPrimary', 'notes']) {
       if (body[f] !== undefined) updates[f] = body[f];
@@ -745,15 +750,13 @@ export function makePartnerService(overrides = {}) {
   async function archiveContact(contactId, user) {
     const contact = await d.PartnerContact.findByPk(contactId);
     if (!contact || contact.archivedAt) throw new AppError('Contact not found', 404);
-    const partner = await getLivePartner(contact.partnerOrganisationId);
-    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await getOwnedPartner(contact.partnerOrganisationId, user);
     await contact.update({ archivedAt: new Date(), isPrimary: false });
     return contact;
   }
 
   async function addLocation(id, body, user) {
-    const partner = await getLivePartner(id);
-    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await getOwnedPartner(id, user);
     return d.PartnerLocation.create({
       partnerOrganisationId: id,
       name: body.name || null,
@@ -770,8 +773,7 @@ export function makePartnerService(overrides = {}) {
   async function updateLocation(locationId, body, user) {
     const location = await d.PartnerLocation.findByPk(locationId);
     if (!location) throw new AppError('Location not found', 404);
-    const partner = await getLivePartner(location.partnerOrganisationId);
-    if (!canActOnRow(user, partner)) throw new AppError('You can only edit businesses you own', 403);
+    await getOwnedPartner(location.partnerOrganisationId, user);
     const updates = {};
     for (const f of ['name', 'addressLine', 'postalCode', 'area', 'phone', 'isActive', 'notes']) {
       if (body[f] !== undefined) updates[f] = body[f];

--- a/backend/tsconfig.check.json
+++ b/backend/tsconfig.check.json
@@ -11,5 +11,11 @@
     "strict": false,
     "noImplicitAny": false
   },
-  "include": ["src/utils/**/*.js"]
+  "include": [
+    "src/utils/**/*.js",
+    "src/middleware/**/*.js",
+    "src/routes/routeGates.js",
+    "src/database/testRunLock.js",
+    "src/database/restoreBaseline.js"
+  ]
 }


### PR DESCRIPTION
## Three closing items from the architecture-to-A list

**1. Row authorization becomes structural.** `getOwnedPartner(id, user, {forbid, …queryOpts})` in partnerService fetches the live partner and applies `canActOnPartnerRow` in **one call** — a call site can no longer take the row without passing the gate (the H2 failure mode). Eight fetch-then-gate pairs converted (update / snooze / unsnooze / contacts ×3 / locations ×2), each keeping its byte-exact 403 message. Three deliberate exceptions stay manual and documented: `assertCanMoveRow` (claim-variant messaging), the `partners.reassign` escape hatch, and the loader itself. **Proof: 102 redeemOps tests green with zero edits.**

**2. Typecheck ratchet, slice 2.** `src/middleware/**`, `routeGates.js`, and the new test-boot infra join the include list at **zero errors** (8 fixed: numeric port for `pg.Client`, typed rate-counter rows, the Sequelize options cast). The full redeemOps slice was probed at **301 errors** and deliberately deferred as its own future pass — stated here rather than ground through at session end.

**3. createProspect sectioning — the honest version.** The missing INTAKE banner joins SCORE/ROUTE/PERSIST/DISPATCH, with the extraction no-go documented in place: the intake steps thread ~30 locals, so every extraction shape trialled meant a context-object rewrite of the hottest business path for navigation value the banners already provide. The genuinely separable complexity was already extracted in P3-1 (createTx / dispatch / scoring / qrRouting).

## Verification

Unit tier **2237/2237** · redeemOps suites **102/102** (zero edits) · prospect suites **73/73** · `npm run typecheck` zero · eslint clean · no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)