### PR TITLE
feat(redeem-ops): Partners list shows who ADDED each business

### DIFF
--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -53,6 +53,11 @@ export function makePartnerService(overrides = {}) {
 
   const LIVE = { mergedIntoId: null };
   const OWNER_INCLUDE = { model: d.User, as: 'owner', attributes: ['id', 'fullName', 'email'] };
+  // Who first put the row on the books — NOT who works it now. Every creation
+  // path (manual add, CSV import, Discover) funnels through createPartner, and
+  // createdBy has been NOT NULL since migration 046 with RESTRICT on the user
+  // delete, so a live row always resolves a creator.
+  const CREATOR_INCLUDE = { model: d.User, as: 'creator', attributes: ['id', 'fullName'] };
 
   /**
    * Admin tier acts on any row; everyone else — BDMs included — must own it,
@@ -127,7 +132,7 @@ export function makePartnerService(overrides = {}) {
 
     const { rows, count } = await d.PartnerOrganisation.findAndCountAll({
       where,
-      include: [OWNER_INCLUDE],
+      include: [OWNER_INCLUDE, CREATOR_INCLUDE],
       order: [
         [d.sequelize.literal('"lastActivityAt" IS NULL'), 'ASC'],
         ['lastActivityAt', 'DESC'],

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -815,3 +815,41 @@ describe('delete — plain vs force cascade', () => {
     expect(res.status).toBe(403);
   });
 });
+
+describe('list carries who ADDED the row, not just who owns it', () => {
+  test('creator survives a reassignment — the two columns disagree on purpose', async () => {
+    const created = await createPartner(execA.token, { tradingName: 'Added By Probe Studio' });
+    expect(created.status).toBe(201);
+    const partnerId = created.body.data.partner.id;
+
+    // Hand it to execB, so owner and creator are two different people. This is
+    // the case the Partners table's "Added by" column exists to make readable.
+    const assigned = await request(app)
+      .post(`/api/redeem-ops/partners/${partnerId}/assign`)
+      .set(auth(admin.token))
+      .send({ toUserId: execB.user.id, reason: 'probe' });
+    expect(assigned.status).toBe(200);
+
+    const list = await request(app)
+      .get('/api/redeem-ops/partners')
+      .query({ search: 'Added By Probe Studio' })
+      .set(auth(admin.token));
+    expect(list.status).toBe(200);
+    const row = list.body.data.partners.find((p) => p.id === partnerId);
+    expect(row.owner.id).toBe(execB.user.id);
+    expect(row.creator.id).toBe(execA.user.id);
+    expect(row.creator.fullName).toBe(execA.user.fullName);
+  });
+
+  test('an unowned row still names its creator', async () => {
+    const created = await createPartner(execB.token, { tradingName: 'Unowned Probe Studio' });
+    const partnerId = created.body.data.partner.id;
+    const list = await request(app)
+      .get('/api/redeem-ops/partners')
+      .query({ owner: 'none', search: 'Unowned Probe Studio' })
+      .set(auth(admin.token));
+    const row = list.body.data.partners.find((p) => p.id === partnerId);
+    expect(row.owner).toBeNull();
+    expect(row.creator.id).toBe(execB.user.id);
+  });
+});

--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -63,6 +63,57 @@ const EMPTY_FORM = {
   website: '', instagramHandle: '', uen: '', notes: '',
 };
 
+/** Column heading that carries its own explanation — the dotted underline is
+ * the invitation to hover, the bubble is the sentence that stops the misread.
+ * Same shape as RedemptionsPage's DeliveryHint, dropped below the header row
+ * instead of above it. Focusable so it isn't hover-only. */
+function ColumnHint({ label, hint }) {
+  const [open, setOpen] = useState(false);
+  const tipId = `ro-col-hint-${label.toLowerCase().replace(/\s+/g, '-')}`;
+  return (
+    <span
+      className="relative inline-block"
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+    >
+      <button
+        type="button"
+        aria-describedby={open ? tipId : undefined}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onClick={() => setOpen((v) => !v)}
+        className="border-0 bg-transparent p-0 cursor-help"
+        style={{
+          font: 'inherit',
+          color: 'inherit',
+          textDecoration: 'underline dotted',
+          textDecorationColor: 'var(--ro-text-3)',
+          textUnderlineOffset: 3,
+        }}
+      >
+        {label}
+      </button>
+      {open && (
+        <span
+          id={tipId}
+          role="tooltip"
+          // Right-anchored: the table sits in an overflow-x-auto wrapper, which
+          // clips anything past its right edge — and this column is second from
+          // the right, so a left-anchored bubble loses its last few words.
+          className="absolute right-0 z-40"
+          style={{
+            top: 'calc(100% + 7px)', width: 236, padding: '8px 11px',
+            background: '#fff', border: '1px solid var(--ro-line)', borderRadius: 9,
+            boxShadow: '0 10px 28px rgba(15, 23, 42, .14)',
+            fontSize: 11.5, fontWeight: 400, lineHeight: 1.5, color: 'var(--ro-text-2)',
+            whiteSpace: 'normal', textAlign: 'left', textDecoration: 'none',
+          }}
+        >{hint}</span>
+      )}
+    </span>
+  );
+}
+
 export default function PartnersList() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -515,6 +566,12 @@ export default function PartnersList() {
                 <th className="font-semibold text-[12.5px] px-3 py-3">Category</th>
                 <th className="font-semibold text-[12.5px] px-3 py-3">Stage</th>
                 <th className="font-semibold text-[12.5px] px-3 py-3">Owner</th>
+                <th className="font-semibold text-[12.5px] px-3 py-3">
+                  <ColumnHint
+                    label="Added by"
+                    hint="Who first put this business on the books — not who owns it. Ownership sits in the Owner column and changes every time a business is claimed, assigned or released."
+                  />
+                </th>
                 <th className="font-semibold text-[12.5px] px-5 py-3 text-right">Last activity</th>
               </tr>
             </thead>
@@ -571,6 +628,13 @@ export default function PartnersList() {
                   <td className="px-3 py-2.5" style={{ color: 'var(--ro-text-2)' }}>{p.category || '—'}</td>
                   <td className="px-3 py-2.5"><RoStageTag stage={p.pipelineStage} /></td>
                   <td className="px-3 py-2.5"><RoOwner name={p.owner?.fullName} /></td>
+                  {/* Deliberately plainer than the Owner chip: this is a record
+                      of who typed it in, not a person you can act on. */}
+                  <td className="px-3 py-2.5 text-[12.5px]" style={{ color: 'var(--ro-text-2)' }}>
+                    {p.creator?.fullName
+                      ? <span title={p.creator.fullName}>{p.creator.fullName.split(/\s+/)[0]}</span>
+                      : '—'}
+                  </td>
                   <td className="px-5 py-2.5 text-right text-[12.5px] tabular-nums" style={{ color: 'var(--ro-text-3)' }}>
                     {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : 'Never'}
                   </td>
@@ -578,7 +642,7 @@ export default function PartnersList() {
               ))}
               {!listQuery.isLoading && partners.length === 0 && (
                 <tr className="border-t border-border">
-                  <td colSpan={5} className="text-center py-12" style={{ color: 'var(--ro-text-2)' }}>
+                  <td colSpan={canBulk ? 7 : 6} className="text-center py-12" style={{ color: 'var(--ro-text-2)' }}>
                     {emptyCopy}
                   </td>
                 </tr>

--- a/src/pages/redeemops/__tests__/PartnersList.addedBy.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnersList.addedBy.test.jsx
@@ -1,0 +1,116 @@
+/**
+ * PartnersList — the "Added by" column.
+ *
+ * The column exists because "Owner: —" was being read as "nobody has touched
+ * this", when in fact somebody typed the business in. Owner moves every time a
+ * row is claimed, assigned or released; the creator never does. So the two
+ * columns are expected to DISAGREE, and the header carries its own explanation
+ * (dotted underline → hover/focus bubble) rather than relying on the reader.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  listPartners: vi.fn(),
+  getConstants: vi.fn(),
+  listCategories: vi.fn(),
+  getTeam: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  t.warning = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+const authState = vi.hoisted(() => ({ user: null }));
+vi.mock('@/stores/authStore', () => ({ useAuthStore: (sel) => sel(authState) }));
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => vi.fn(),
+}));
+
+import PartnersList from '../PartnersList';
+
+const base = (id, name) => ({
+  id, tradingName: name, ownerUserId: null, availability: 'available',
+  archivedAt: null, mergedIntoId: null, pipelineStage: 'NEW', owner: null,
+  category: null, lastActivityAt: null,
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><PartnersList /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// The page renders a mobile card list AND the desktop table, so a name matches
+// twice — scope to the row that lives inside the table.
+const rowFor = async (name) => {
+  const hits = await screen.findAllByText(name);
+  const row = hits.map((el) => el.closest('tr')).find(Boolean);
+  if (!row) throw new Error(`No table row for ${name}`);
+  return row;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
+  api.getConstants.mockResolvedValue({ pipelineStages: ['NEW'], lostReasons: [] });
+  api.listCategories.mockResolvedValue([]);
+  api.getTeam.mockResolvedValue([]);
+  api.listPartners.mockResolvedValue({
+    partners: [
+      // Added by one person, now owned by another — the whole point.
+      {
+        ...base('p1', 'Handed Over Studio'),
+        ownerUserId: 'u-other', availability: 'owned',
+        owner: { id: 'u-other', fullName: 'Rachel Ho' },
+        creator: { id: 'u-me', fullName: 'Shawn Lee' },
+      },
+      // Nobody owns it, but somebody still put it on the books.
+      { ...base('p2', 'Unclaimed Gym'), creator: { id: 'u-mate', fullName: 'Vincent Chung' } },
+    ],
+    pagination: { page: 1, limit: 25, total: 2, totalPages: 1 },
+  });
+});
+
+it('shows the creator alongside the owner, and they can disagree', async () => {
+  renderPage();
+  const row = await rowFor('Handed Over Studio');
+  // Owner chip says Rachel; Added by says Shawn. Both first names, both present.
+  expect(row).toHaveTextContent('Rachel');
+  expect(row).toHaveTextContent('Shawn');
+});
+
+it('an unowned row still names who added it', async () => {
+  renderPage();
+  const row = await rowFor('Unclaimed Gym');
+  expect(row).toHaveTextContent('Vincent');
+});
+
+it('the header explains itself — hovering the dotted label says it is not the owner', async () => {
+  renderPage();
+  const label = await screen.findByRole('button', { name: 'Added by' });
+  expect(screen.queryByRole('tooltip')).toBeNull();
+  await userEvent.hover(label);
+  expect(await screen.findByRole('tooltip')).toHaveTextContent(/not who owns it/i);
+});
+
+it('the hint is reachable without a mouse', async () => {
+  renderPage();
+  const label = await screen.findByRole('button', { name: 'Added by' });
+  label.focus();
+  expect(await screen.findByRole('tooltip')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Why

On `/redeem-ops/partners`, **"Owner: —" was being read as "nobody has touched this"** — when in fact somebody typed the business in. Owner moves every time a row is claimed, assigned or released; the person who created it never does. So the two are *expected* to disagree, and the new column makes that legible.

## What

A new **Added by** column, sitting directly after Owner so the contrast is unmissable. The header is a dotted-underline hover/focus target that explains itself:

> Who first put this business on the books — not who owns it. Ownership sits in the Owner column and changes every time a business is claimed, assigned or released.


## No migration

`partner_organisations.createdBy` has been `NOT NULL` since **migration 046**, with `RESTRICT` on the user delete — and all three add paths (manual "Add business", CSV import, Discover) funnel through `createPartner`. Every live row already names a real person; the list endpoint simply wasn't returning it.

## Notes on the three judgment calls

- **Plainer than the Owner chip, on purpose.** Two avatar chips side by side read as two equally actionable people. Added by is muted text (first name, full name on `title`) — a record of who typed it in, not someone you act on.
- **Right-anchored tooltip.** The first build anchored it left and the table's `overflow-x-auto` wrapper clipped the last few words of every line. Only visible in a screenshot — tests passed either way. Verified it fits at 1440px and a squeezed 820px.
- **Mobile card left alone.** Its third line is already `Owner · date`; a third item wraps on a phone.

Also fixes the empty-state `colSpan`, which was one short even before this change (it never counted the bulk-select column).

## Verification

- `backend`: 77 tests pass across the partner suites, including 2 new ones — creator survives a reassignment, and shows on unowned rows
- `frontend`: 58 tests pass across `src/pages/redeemops/__tests__/`, including 4 new ones — the column, the tooltip copy, and keyboard reach
- eslint clean both sides
- Driven end-to-end through a real `VITE_SURFACE=ops` production build in headless Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C5b3MCRrKKp1CZiZzuPM5
