### PR TITLE
feat(ops): internal staff skip the API rate limiter + Discover searches can run uncapped

### DIFF
--- a/backend/src/controllers/redeemOps/discoveryController.js
+++ b/backend/src/controllers/redeemOps/discoveryController.js
@@ -7,7 +7,7 @@ import { logger } from '../../utils/logger.js';
 const startSchema = Joi.object({
   category: Joi.string().max(64).allow(''), // optional — ad-hoc terms/hashtags can stand in
   area: Joi.string().min(1).max(120).required(),
-  limit: Joi.number().integer().min(1).max(500), // sanity bound; service clamps to DISCOVERY_MAX_RESULTS_PER_RUN
+  limit: Joi.number().integer().min(0).max(500), // 0 (or absent) = uncapped — pull every match; bounded runs clamp to DISCOVERY_MAX_RESULTS_PER_RUN
   // Mechanism pick; omitted = Maps. The IG pilot additionally needs DISCOVERY_IG_ENABLED.
   provider: Joi.string().valid('google_maps', 'instagram_hashtag'),
   // Ad-hoc, type-and-go overrides of the category's saved terms/hashtags.

--- a/backend/src/middleware/rateLimiters.js
+++ b/backend/src/middleware/rateLimiters.js
@@ -43,3 +43,15 @@ export function makeLimiter({ prefix, ...options } = /** @type {{prefix?: string
 export function userOrClientKey(req) {
   return req.user?.id ? `u:${req.user.id}` : clientKey(req);
 }
+
+/**
+ * Authenticated internal staff are exempt from the public transport limiter.
+ * The ops console legitimately polls (Discover refetches a running search
+ * every 2.5s), which burned the 200/15min public budget and 429'd the whole
+ * surface for the operator (2026-08-05). Requires a VERIFIED token — an
+ * expired/forged one leaves req.user unset and the public limit applies.
+ */
+const INTERNAL_STAFF_ROLES = ['admin', 'redeem_ops'];
+export function isInternalStaff(req) {
+  return Boolean(req.user && INTERNAL_STAFF_ROLES.includes(req.user.role));
+}

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -13,7 +13,7 @@ import { errorHandler } from './middleware/errorHandler.js';
 import { notFound } from './middleware/notFound.js';
 import { bootstrapDatabase } from './database/bootstrap.js';
 import { requestId } from './middleware/requestId.js';
-import { makeLimiter } from './middleware/rateLimiters.js';
+import { makeLimiter, isInternalStaff } from './middleware/rateLimiters.js';
 
 // Non-autodiscoverable middleware
 import leadCaptureBind from './routes/leadCaptureBind.js';
@@ -99,7 +99,7 @@ export const init = async (app) => {
     })
   );
 
-  // Rate limiting (relaxed for development, bypass for authenticated admins)
+  // Rate limiting (relaxed for development, bypass for internal staff)
   const isProd = process.env.NODE_ENV === 'production';
   // Client-keyed + durable like every other limiter (P1-6): the default
   // MemoryStore + req.ip keyed this on the Cloudflare EDGE address, so every
@@ -108,26 +108,27 @@ export const init = async (app) => {
   const limiter = makeLimiter({
     prefix: 'rl:api',
     windowMs: isProd ? parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000 : 60 * 1000, // 1 minute window in dev
-    max: (req) => {
-      if (isProd && req.user && req.user.role === 'admin') return 2000;
-      return isProd
+    max: () =>
+      isProd
         ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 200
-        : parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000000;
-    },
-    // Exempt server-to-server webhooks under /api/integrations/lyfe/,
-    // /api/external/ and /api/whatsapp/ — they are HMAC-authenticated (not
-    // IP-based), and a Supabase pg_net burst, a reconciliation backfill or a
-    // Meta status-callback burst must not be throttled by the public IP
-    // limiter. The WhatsApp route rejects unsigned traffic with a cheap HMAC
-    // check before doing any work.
+        : parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000000,
+    // Exempt: (1) authenticated internal staff — the ops console's Discover
+    // polling burned the public budget and 429'd the operator; the limiter is
+    // for unauthenticated public traffic. (2) server-to-server webhooks under
+    // /api/integrations/lyfe/, /api/external/ and /api/whatsapp/ — they are
+    // HMAC-authenticated (not IP-based), and a Supabase pg_net burst, a
+    // reconciliation backfill or a Meta status-callback burst must not be
+    // throttled by the public IP limiter. The WhatsApp route rejects unsigned
+    // traffic with a cheap HMAC check before doing any work.
     skip: (req) =>
       !isProd ||
+      isInternalStaff(req) ||
       req.originalUrl.startsWith('/api/integrations/lyfe/') ||
       req.originalUrl.startsWith('/api/external/') ||
       req.originalUrl.startsWith('/api/whatsapp/'),
     message: 'Too many requests from this IP, please try again later.',
   });
-  // Ensure we decode JWT (if present) before limiter so skip() can see admin
+  // Ensure we decode JWT (if present) before limiter so skip() can see staff
   if (isProd) {
     logger.info('Rate limiter enabled (production mode)');
     app.use('/api', optionalAuth, limiter);

--- a/backend/src/services/redeemOps/discoveryService.js
+++ b/backend/src/services/redeemOps/discoveryService.js
@@ -235,7 +235,15 @@ export function makeDiscoveryService(overrides = {}) {
     const canonicalCategory = resolved ? resolved.name : null;
     const c = cfg();
     if (!c.resultQuotaEnabled) await assertQuota(user);
-    const requestedLimit = Math.min(Math.max(Number(limit) || 60, 1), c.maxResultsPerRun);
+    // limit 0 (or absent) = UNCAPPED (requestedLimit 0): pull every matching
+    // place, so re-running a search surfaces new businesses instead of the same
+    // top slice. Two modes can't run uncapped and clamp to maxResultsPerRun:
+    // the IG hashtag actor requires a numeric post budget, and result-quota
+    // mode must reserve a concrete amount up front.
+    const askedUncapped = !Number(limit);
+    const requestedLimit = askedUncapped
+      ? (isInstagram || c.resultQuotaEnabled ? c.maxResultsPerRun : 0)
+      : Math.min(Math.max(Number(limit), 1), c.maxResultsPerRun);
     const igHashtagsUsed = isInstagram
       ? (overrideTags.length ? overrideTags : resolved.hashtags)
       : null;
@@ -262,9 +270,13 @@ export function makeDiscoveryService(overrides = {}) {
       );
     }
     // The Maps actor applies this cap to EACH search string, so divide the requested
-    // total across terms to avoid multiplying crawl cost by N (a single term = full limit).
+    // total across terms to avoid multiplying crawl cost by N (a single term = full
+    // limit). Uncapped runs send the actor's own "all places" sentinel instead.
+    const UNCAPPED_PLACES_PER_SEARCH = 9999999;
     const perSearchLimit = isInstagram ? null
-      : Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length));
+      : (requestedLimit === 0
+        ? UNCAPPED_PLACES_PER_SEARCH
+        : Math.max(1, Math.floor(requestedLimit / searchTermsUsed.length)));
 
     const runValues = {
       // createdByEmail: immutable identity snapshot — survives the operator's
@@ -273,7 +285,11 @@ export function makeDiscoveryService(overrides = {}) {
       provider: isInstagram ? 'apify_instagram_hashtag' : 'apify_google_maps',
       category: canonicalCategory, area: String(area).trim(),
       requestedLimit, status: 'pending',
-      estimatedCostUsd: Number((requestedLimit * c.costPerResultUsd).toFixed(4)),
+      // Uncapped runs have no up-front bound — cost is only known when the run
+      // finishes (actualCostUsd from the provider); null ≠ free.
+      estimatedCostUsd: requestedLimit === 0
+        ? null
+        : Number((requestedLimit * c.costPerResultUsd).toFixed(4)),
     };
     // Snapshot the fired query so the recent-searches list and the results query
     // bar can show exactly what was searched — the category is only the CRM bucket
@@ -414,6 +430,8 @@ export function makeDiscoveryService(overrides = {}) {
       return;
     }
 
+    // requestedLimit 0 (uncapped) is falsy → apifyClient omits the limit param
+    // and the dataset download returns every item the crawl produced.
     const items = await d.apify.getDatasetItems(info.datasetId, { limit: run.requestedLimit });
     if (run.provider === 'apify_instagram') {
       await applyEnrichment(run, items);

--- a/backend/test/redeemOpsDiscovery.test.js
+++ b/backend/test/redeemOpsDiscovery.test.js
@@ -87,6 +87,19 @@ describe('start + quota', () => {
     expect(Number(run.estimatedCostUsd)).toBeGreaterThan(0);
   });
 
+  test('limit 0 = uncapped: all-places sentinel to the actor, requestedLimit 0, no cost estimate', async () => {
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+    const run = await svc.startDiscovery({ category: 'Nail Salon', area: 'Tampines', limit: 0 }, solo.user);
+    expect(run.requestedLimit).toBe(0);
+    // null ≠ free: an uncapped run has no up-front bound, only actualCostUsd.
+    expect(run.estimatedCostUsd).toBeNull();
+    const input = apify.startRun.mock.calls[0][1];
+    expect(input.maxCrawledPlacesPerSearch).toBe(9999999);
+  });
+
   test('per-user daily quota → 429', async () => {
     process.env.DISCOVERY_MAX_RUNS_PER_USER_DAY = '2';
     const apify = makeApifyStub();

--- a/backend/test/redeemOpsDiscoveryInstagram.test.js
+++ b/backend/test/redeemOpsDiscoveryInstagram.test.js
@@ -196,6 +196,23 @@ describe('IG run start', () => {
     expect(audit.after.hashtags).toEqual(['sgnails', 'homebasednailssg']);
   });
 
+  test('uncapped (limit 0) clamps to maxResultsPerRun — the hashtag actor needs a numeric budget', async () => {
+    process.env.DISCOVERY_MAX_RESULTS_PER_RUN = '75';
+    const apify = makeApifyStub();
+    const svc = makeDiscoveryService({ apify });
+    const solo = await createTestUser({ role: 'admin' });
+    apify.startRun.mockImplementation(async () => uniqueRunId());
+
+    const run = await svc.startDiscovery(
+      { area: 'All Singapore', limit: 0, provider: 'instagram_hashtag', hashtags: ['sgnails'] },
+      solo.user,
+    );
+
+    expect(run.requestedLimit).toBe(75);
+    const [, input] = apify.startRun.mock.calls[0];
+    expect(input).toEqual({ hashtags: ['sgnails'], resultsLimit: 75 });
+  });
+
   // Regression: ad-hoc hashtags without a category leave `resolved` null; the audit
   // payload used to read resolved.hashtags and crash AFTER Apify spend began.
   test('ad-hoc-only start (no category) completes and audits the fired hashtags', async () => {

--- a/backend/test/redeemOpsDiscoveryUsage.test.js
+++ b/backend/test/redeemOpsDiscoveryUsage.test.js
@@ -119,6 +119,21 @@ describe('search reservation lifecycle', () => {
     expect(quota.estimatedSpendUsd).toBe(0.021);
   });
 
+  test('quota mode clamps an uncapped (limit 0) run to maxResultsPerRun — never reserves 0', async () => {
+    process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
+    process.env.DISCOVERY_MAX_RESULTS_PER_RUN = '40';
+    process.env.DISCOVERY_RESULTS_PER_USER_DAY = '100';
+    process.env.DISCOVERY_RESULTS_PER_TEAM_DAY = '10000';
+    const { user } = await createTestUser({ role: 'admin' });
+    const apify = apifyStub();
+    const discovery = makeDiscoveryService({ apify });
+    const run = await discovery.startDiscovery(
+      { category: 'Nail Salon', area: 'Bedok', limit: 0 }, user,
+    );
+    expect(run.requestedLimit).toBe(40);
+    expect((await makeDiscoveryUsageService().getUsage(user.id, sgDateKey())).resultsUsed).toBe(40);
+  });
+
   test('pre-Apify start failure refunds the full search reservation', async () => {
     process.env.DISCOVERY_RESULT_QUOTA_ENABLED = 'true';
     process.env.DISCOVERY_RESULTS_PER_USER_DAY = '100';

--- a/backend/test/unit/internalStaffExempt.test.js
+++ b/backend/test/unit/internalStaffExempt.test.js
@@ -1,0 +1,22 @@
+import { isInternalStaff } from '../../src/middleware/rateLimiters.js';
+
+/**
+ * The global /api limiter skips authenticated internal staff (admin +
+ * redeem_ops) — the ops console's Discover polling burned the 200/15min
+ * public budget and 429'd the operator (2026-08-05). Everyone else,
+ * including other authenticated roles, stays on the public budget.
+ */
+describe('isInternalStaff (global /api limiter exemption)', () => {
+  test('admin and redeem_ops are exempt', () => {
+    expect(isInternalStaff({ user: { role: 'admin' } })).toBe(true);
+    expect(isInternalStaff({ user: { role: 'redeem_ops' } })).toBe(true);
+  });
+
+  test('unauthenticated and non-staff roles are not exempt', () => {
+    expect(isInternalStaff({})).toBe(false);
+    expect(isInternalStaff({ user: null })).toBe(false);
+    expect(isInternalStaff({ user: { role: 'agent' } })).toBe(false);
+    expect(isInternalStaff({ user: { role: 'customer' } })).toBe(false);
+    expect(isInternalStaff({ user: { role: 'driver_partner' } })).toBe(false);
+  });
+});

--- a/src/pages/redeemops/DiscoverPage.jsx
+++ b/src/pages/redeemops/DiscoverPage.jsx
@@ -65,7 +65,9 @@ const timeAgo = (iso) => {
 export default function DiscoverPage() {
   const queryClient = useQueryClient();
   const [form, setForm] = useState({
-    area: '', limit: '30', provider: 'google_maps',
+    // limit 'all' → API limit 0 = uncapped: re-running a capped search just
+    // returns the same top slice, so the default pulls everything.
+    area: '', limit: 'all', provider: 'google_maps',
     adhoc: '', minStars: 'any', skipClosed: true, filterWords: '',
   });
   const [runId, setRunId] = useState(null);
@@ -317,7 +319,7 @@ export default function DiscoverPage() {
   const runSearch = () => {
     const terms = parseCsv(form.adhoc); // the search is what you type: terms (Maps) / hashtags (IG)
     if (!form.area.trim() || terms.length === 0 || startMutation.isPending) return;
-    const body = { area: form.area.trim(), limit: Number(form.limit), provider: form.provider };
+    const body = { area: form.area.trim(), limit: form.limit === 'all' ? 0 : Number(form.limit), provider: form.provider };
     if (isIg) {
       body.hashtags = terms;
     } else {
@@ -481,7 +483,7 @@ export default function DiscoverPage() {
                 <Label>Results</Label>
                 <Select value={form.limit} onValueChange={(v) => setForm((f) => ({ ...f, limit: v }))}>
                   <SelectTrigger className="w-full"><SelectValue /></SelectTrigger>
-                  <SelectContent>{['30', '60', '120', '300', '500'].map((n) => <SelectItem key={n} value={n}>{n}</SelectItem>)}</SelectContent>
+                  <SelectContent>{['all', '30', '60', '120', '300', '500'].map((n) => <SelectItem key={n} value={n}>{n === 'all' ? 'No limit' : n}</SelectItem>)}</SelectContent>
                 </Select>
               </div>
               <Button disabled={!canSearch} onClick={() => runSearch()}>
@@ -543,12 +545,16 @@ export default function DiscoverPage() {
                 </span>
               ) : (
                 <span className="text-[12px]" style={{ color: 'var(--ro-text-3)' }}>
-                  Results is a total, split across your phrases.
+                  {form.limit === 'all'
+                    ? 'No limit — pulls every match Google returns for your phrases.'
+                    : 'Results is a total, split across your phrases.'}
                 </span>
               )}
               {!isIg && quota?.costPerResultUsd > 0 && (
                 <span className="ml-auto text-[12px]" style={{ color: 'var(--ro-text-3)' }}>
-                  ≈ ${(Number(form.limit) * quota.costPerResultUsd).toFixed(2)} max
+                  {form.limit === 'all'
+                    ? `$${quota.costPerResultUsd.toFixed(3)} per result — no cap`
+                    : `≈ $${(Number(form.limit) * quota.costPerResultUsd).toFixed(2)} max`}
                 </span>
               )}
             </div>
@@ -598,7 +604,7 @@ export default function DiscoverPage() {
                 ? [['Categories', run.rawPayload.categoryFilterWords.join(', '), true]] : []),
               ...(run?.rawPayload?.categoryFilterWordsDropped?.length
                 ? [['Ignored', run.rawPayload.categoryFilterWordsDropped.join(', '), true]] : []),
-              ['Area', run?.area, false], ['Results', run?.requestedLimit, false],
+              ['Area', run?.area, false], ['Results', run?.requestedLimit === 0 ? 'No limit' : run?.requestedLimit, false],
               ...(run?.actualCostUsd != null ? [['Cost', `$${Number(run.actualCostUsd).toFixed(2)}`, false]] : []),
             ].map(([k, v, truncate]) => (
               <span key={k} className="inline-flex items-center gap-2 h-9 px-3.5 rounded-full text-[13.5px] font-semibold max-w-full min-w-0" style={{ border: '1px solid var(--ro-border-strong)' }}>
@@ -619,7 +625,7 @@ export default function DiscoverPage() {
             <span className="w-[18px] h-[18px] rounded-full animate-spin" style={{ border: '2.4px solid var(--ro-azure-tint)', borderTopColor: 'var(--ro-azure)' }} />
             <b className="text-[15px]">{isIgRun ? 'Searching Instagram…' : 'Searching Google Maps…'}</b>
             <span className="hidden sm:inline text-[13px]" style={{ color: 'var(--ro-text-2)' }}>
-              {run?.requestedLimit > 120 ? 'large search — usually 2–6 minutes' : 'usually 30–60 seconds'} · you can keep working other tabs
+              {run?.requestedLimit === 0 || run?.requestedLimit > 120 ? 'large search — usually 2–6 minutes' : 'usually 30–60 seconds'} · you can keep working other tabs
             </span>
           </div>
           <div className="rounded-2xl border border-border bg-white overflow-hidden">


### PR DESCRIPTION
## Why

Today's 429 storm on ops.redeem.sg ("Too many requests from this IP"): the Discover page polls a running search every 2.5s (by design), which burned the public 200-requests-per-15-min budget in ~6 minutes and 429'd the entire console — including `/auth/profile`. The operator's `redeem_ops` login never qualified for the limiter's admin-only 2000 bypass (`role === 'admin'` literally; admin@mktr.sg is `redeem_ops`).

## What

**1. Internal staff skip the global `/api` limiter entirely.**
- New `isInternalStaff(req)` in `middleware/rateLimiters.js` — `admin` + `redeem_ops`, requires a *verified* token (expired/forged → `req.user` unset → public limit applies).
- Wired into the limiter's `skip` in `server_internal.js`; the now-dead admin `max: 2000` branch removed. Public/unauthenticated traffic keeps the 200/15min budget; the HMAC webhook exemptions are unchanged.

**2. Discover "Results" gains a No limit option — the new default.**
Re-running a capped search just returns the same top slice, so the default now pulls every match:
- UI: "No limit" in the Results select (default), per-result cost copy (`$0.007 per result — no cap`), run chip shows "No limit", uncapped counts as a large search in the duration hint.
- API: `limit: 0` (Joi min 0) → `requestedLimit 0` → Maps actor gets the all-places sentinel `maxCrawledPlacesPerSearch: 9999999`.
- `estimatedCostUsd` is `NULL` for uncapped runs (no up-front bound ≠ free); `actualCostUsd` still lands from the provider.
- Materialization downloads the full dataset (`limit 0` is falsy → param omitted → Apify returns everything).
- Two modes deliberately still clamp to `DISCOVERY_MAX_RESULTS_PER_RUN`: the IG hashtag actor requires a numeric post budget, and result-quota mode must reserve a concrete amount up front (never reserve 0 = quota bypass).
- Daily run caps (5/user, 25/team) and enrichment quotas untouched.

## Cost note

An uncapped "All Singapore" sweep of a dense category can crawl a few thousand places at ~$0.007/result (≈$20–35 worst case). Spend stays bounded by the daily run caps; the per-run bound is gone by request.

## Tests

- `test/unit/internalStaffExempt.test.js` (new) — exemption covers exactly admin + redeem_ops.
- `redeemOpsDiscovery.test.js` — uncapped start: sentinel to the actor, `requestedLimit 0`, `estimatedCostUsd NULL`.
- `redeemOpsDiscoveryUsage.test.js` — quota mode clamps uncapped to `maxResultsPerRun`, reserves 40 not 0.
- `redeemOpsDiscoveryInstagram.test.js` — IG uncapped clamps to a numeric `resultsLimit`.
- All 79 tests across the three discovery suites pass locally (real Postgres); DiscoverPage vitest 17/17; eslint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3mADsbVzSXMym2f8SMA6n