### PR TITLE
feat(redeem-ops): Pipeline opens on YOUR book, with an Unowned door

### DIFF
--- a/src/pages/redeemops/PartnersList.jsx
+++ b/src/pages/redeemops/PartnersList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
@@ -117,12 +117,17 @@ function ColumnHint({ label, hint }) {
 export default function PartnersList() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
 
   const [search, setSearch] = useState('');
   const [stage, setStage] = useState('all');
   // Reps live in their own book — default to it; the dropdown flips to the
-  // whole database ("Any owner") in one click.
-  const [owner, setOwner] = useState('me');
+  // whole database ("Any owner") in one click. ?owner=none|all|me deep-links a
+  // pre-filtered view (the Pipeline's Unowned button lands here).
+  const [owner, setOwner] = useState(() => {
+    const fromUrl = searchParams.get('owner');
+    return ['me', 'none', 'all'].includes(fromUrl) ? fromUrl : 'me';
+  });
   const [category, setCategory] = useState('all');
   const [page, setPage] = useState(1);
   const debouncedSearch = useDebounced(search);

--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -181,6 +181,8 @@ export default function TeamPipeline() {
   const [lostMove, setLostMove] = useState(null); // { card } — Lost requires a reason
   const [lostReason, setLostReason] = useState(null);
   const [showLost, setShowLost] = useState(false);
+  // Reps live in their own book — the board opens on it; Team is one click away.
+  const [view, setView] = useState('mine'); // 'mine' | 'team'
 
   const constants = useQuery({
     queryKey: ['redeem-ops', 'constants'],
@@ -230,13 +232,22 @@ export default function TeamPipeline() {
   const lostReasons = constants.data?.lostReasons || [];
   const partners = boardQuery.data?.partners || [];
 
+  // Unowned businesses aren't on either board view — the button links to the
+  // Partners list pre-filtered to them, where claiming (incl. bulk) lives.
+  const unownedCount = useMemo(() => partners.filter((p) => !p.ownerUserId).length, [partners]);
+
+  const visiblePartners = useMemo(
+    () => (view === 'mine' ? partners.filter((p) => p.ownerUserId === user?.id) : partners),
+    [partners, view, user?.id]
+  );
+
   const byStage = useMemo(() => {
     const map = {};
-    for (const p of partners) {
+    for (const p of visiblePartners) {
       (map[p.pipelineStage] = map[p.pipelineStage] || []).push(p);
     }
     return map;
-  }, [partners]);
+  }, [visiblePartners]);
 
   // Admin tier drags anyone's card; everyone else only their own, so they get
   // an extra line of explanation for the cards that won't lift.
@@ -297,7 +308,7 @@ export default function TeamPipeline() {
     <div className="flex flex-col md:h-full md:min-h-0 p-6 md:p-8 md:pb-4 gap-0">
       <div className="flex flex-wrap items-end gap-3">
         <div>
-          <h1 className="ro-title">Team pipeline</h1>
+          <h1 className="ro-title">Pipeline</h1>
           <p className="ro-sub">
           Drag a business forward — or onto the red bar to mark it Lost. Dragging back to an earlier column asks you to confirm.
           {!movesAnyCard && ' You can move the businesses you own; claim an unowned one to work it.'}
@@ -305,17 +316,48 @@ export default function TeamPipeline() {
           <span className="hidden md:inline"> Click to open.</span>
         </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowLost((v) => !v)}
-          className="ml-auto h-[34px] px-4 rounded-full text-[12.5px] font-semibold border cursor-pointer"
-          style={showLost
-            ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
-            : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
-        >
-          Lost ({lostItems.length})
-        </button>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <div className="flex rounded-full border overflow-hidden" style={{ borderColor: 'var(--ro-border-strong)' }}>
+            {[['mine', 'My pipeline'], ['team', 'Team']].map(([v, label]) => (
+              <button
+                key={v}
+                type="button"
+                onClick={() => setView(v)}
+                className="h-[34px] px-4 text-[12.5px] font-semibold cursor-pointer border-0"
+                style={view === v
+                  ? { background: 'var(--ro-bunker)', color: '#fff' }
+                  : { background: '#fff', color: 'var(--ro-bunker)' }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/redeem-ops/partners?owner=none')}
+            className="h-[34px] px-4 rounded-full text-[12.5px] font-semibold border cursor-pointer"
+            style={{ background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+          >
+            Unowned ({unownedCount})
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowLost((v) => !v)}
+            className="h-[34px] px-4 rounded-full text-[12.5px] font-semibold border cursor-pointer"
+            style={showLost
+              ? { background: 'var(--ro-bunker)', borderColor: 'var(--ro-bunker)', color: '#fff' }
+              : { background: '#fff', borderColor: 'var(--ro-border-strong)', color: 'var(--ro-bunker)' }}
+          >
+            Lost ({lostItems.length})
+          </button>
+        </div>
       </div>
+
+      {view === 'mine' && !boardQuery.isLoading && visiblePartners.length === 0 && (
+        <p className="text-[12.5px] mt-3 mb-0" style={{ color: 'var(--ro-text-2)' }}>
+          No businesses in your book yet — open <b>Unowned ({unownedCount})</b> to claim some, or switch to Team.
+        </p>
+      )}
 
       <DndContext
         sensors={sensors}

--- a/src/pages/redeemops/__tests__/PartnersList.ownerParam.test.jsx
+++ b/src/pages/redeemops/__tests__/PartnersList.ownerParam.test.jsx
@@ -1,0 +1,68 @@
+/**
+ * PartnersList — ?owner= deep link.
+ *
+ * The Pipeline's Unowned button lands on /redeem-ops/partners?owner=none; the
+ * param must pre-select the Owner filter (and reach the API), while a missing
+ * or bogus value keeps the "my book" default.
+ */
+import { render, waitFor } from '@testing-library/react';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  listPartners: vi.fn(),
+  getConstants: vi.fn(),
+  listCategories: vi.fn(),
+  getTeam: vi.fn(),
+  claimPartnersBulk: vi.fn(),
+  releasePartnersBulk: vi.fn(),
+  assignPartnersBulk: vi.fn(),
+  changeStageBulk: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), warning: vi.fn() }) }));
+
+const authState = vi.hoisted(() => ({ user: null }));
+vi.mock('@/stores/authStore', () => ({ useAuthStore: (sel) => sel(authState) }));
+
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => vi.fn(),
+}));
+
+import PartnersList from '../PartnersList';
+
+function renderAt(url) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[url]}><PartnersList /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
+  api.getConstants.mockResolvedValue({ pipelineStages: ['NEW'], lostReasons: [] });
+  api.listCategories.mockResolvedValue([]);
+  api.getTeam.mockResolvedValue([]);
+  api.listPartners.mockResolvedValue({ partners: [], pagination: { page: 1, limit: 25, total: 0, totalPages: 1 } });
+});
+
+it('?owner=none pre-filters to unowned businesses', async () => {
+  renderAt('/redeem-ops/partners?owner=none');
+  await waitFor(() => expect(api.listPartners).toHaveBeenCalledWith(expect.objectContaining({ owner: 'none' })));
+});
+
+it('no param keeps the "my book" default', async () => {
+  renderAt('/redeem-ops/partners');
+  await waitFor(() => expect(api.listPartners).toHaveBeenCalledWith(expect.objectContaining({ owner: 'me' })));
+});
+
+it('a bogus value falls back to the default instead of leaking into the API', async () => {
+  renderAt('/redeem-ops/partners?owner=DROP%20TABLE');
+  await waitFor(() => expect(api.listPartners).toHaveBeenCalledWith(expect.objectContaining({ owner: 'me' })));
+});

--- a/src/pages/redeemops/__tests__/TeamPipeline.view.test.jsx
+++ b/src/pages/redeemops/__tests__/TeamPipeline.view.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * TeamPipeline — Mine/Team views and the Unowned door.
+ *
+ * The board opens on the rep's OWN book (their claimed businesses); Team is an
+ * explicit switch. Unowned businesses are on neither view by default — the
+ * Unowned button deep-links to the Partners list pre-filtered to them, where
+ * claiming (incl. bulk) lives.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const api = vi.hoisted(() => ({
+  getTeamPipeline: vi.fn(),
+  getConstants: vi.fn(),
+  changeStage: vi.fn(),
+  undoStage: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+const authState = vi.hoisted(() => ({ user: null }));
+vi.mock('@/stores/authStore', () => ({ useAuthStore: (sel) => sel(authState) }));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (orig) => ({
+  ...(await orig()),
+  useNavigate: () => navigateMock,
+}));
+
+import TeamPipeline from '../TeamPipeline';
+
+const partner = (id, name, overrides = {}) => ({
+  id, tradingName: name, pipelineStage: 'NEW', category: 'Nails',
+  ownerUserId: null, owner: null, availability: 'available',
+  atRiskFlag: false, staleFlag: false, lostReason: null,
+  stageSince: new Date().toISOString(),
+  ...overrides,
+});
+const mine = (id, name, stage = 'NEW') => partner(id, name, {
+  pipelineStage: stage, ownerUserId: 'u-me', availability: 'owned',
+  owner: { id: 'u-me', fullName: 'Me Myself' },
+});
+const theirs = (id, name, stage = 'NEW') => partner(id, name, {
+  pipelineStage: stage, ownerUserId: 'u-other', availability: 'owned',
+  owner: { id: 'u-other', fullName: 'Someone Else' },
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter><TeamPipeline /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authState.user = { id: 'u-me', role: 'redeem_ops', redeemOpsRole: 'outreach_exec' };
+  api.getConstants.mockResolvedValue({
+    stageTransitions: { NEW: ['CONTACTED'], CONTACTED: ['MEETING', 'LOST'] },
+    lostReasons: ['not_interested'],
+  });
+  api.getTeamPipeline.mockResolvedValue({
+    counts: [],
+    partners: [
+      mine('p-mine', 'My Nail Bar', 'CONTACTED'),
+      theirs('p-theirs', 'Their Cafe'),
+      partner('p-free', 'Free Gym'),
+    ],
+  });
+});
+
+it('opens on My pipeline: my businesses only, colleagues and unowned hidden', async () => {
+  renderPage();
+  expect(await screen.findByText('My Nail Bar')).toBeInTheDocument();
+  expect(screen.queryByText('Their Cafe')).not.toBeInTheDocument();
+  expect(screen.queryByText('Free Gym')).not.toBeInTheDocument();
+});
+
+it('Team shows everyone, including unowned cards', async () => {
+  renderPage();
+  await screen.findByText('My Nail Bar');
+  await userEvent.click(screen.getByRole('button', { name: 'Team' }));
+  expect(screen.getByText('Their Cafe')).toBeInTheDocument();
+  expect(screen.getByText('Free Gym')).toBeInTheDocument();
+});
+
+it('the Unowned button counts unclaimed businesses and opens the pre-filtered Partners list', async () => {
+  renderPage();
+  const btn = await screen.findByRole('button', { name: 'Unowned (1)' });
+  await userEvent.click(btn);
+  expect(navigateMock).toHaveBeenCalledWith('/redeem-ops/partners?owner=none');
+});
+
+it('an empty book points at Unowned instead of showing a bare board', async () => {
+  api.getTeamPipeline.mockResolvedValue({
+    counts: [],
+    partners: [theirs('p-theirs', 'Their Cafe'), partner('p-free', 'Free Gym')],
+  });
+  renderPage();
+  await waitFor(() => expect(api.getTeamPipeline).toHaveBeenCalled());
+  expect(await screen.findByText(/No businesses in your book yet/)).toBeInTheDocument();
+});


### PR DESCRIPTION
## What

The Pipeline tab showed the whole team's board by default. Now:

- **My pipeline (default)** — only the businesses the signed-in user has claimed. **Team** is a one-click segmented switch back to everyone. Pure client-side filter: the `/team/pipeline` payload already carries `ownerUserId` per row, so no backend change.
- **Unowned (N) button** — counts unclaimed businesses from the same payload and deep-links to the Partners list at `?owner=none`, the existing Unowned filter where claiming (incl. bulk claim) already lives. `PartnersList` now initializes its Owner filter from the URL param, validated against `me|none|all` — anything else keeps the `'me'` default.
- **Empty book state** — a rep with nothing claimed sees "No businesses in your book yet — open Unowned to claim some, or switch to Team" instead of a bare board.
- Title "Team pipeline" → "Pipeline" since it opens personal now. The Lost toggle and all drag/stage/undo behaviour are untouched (Lost counts follow the active view).

## Tests

- `TeamPipeline.view.test.jsx` (new): opens on Mine (colleague + unowned cards hidden), Team reveals everyone, Unowned button counts and navigates to `?owner=none`, empty-book hint.
- `PartnersList.ownerParam.test.jsx` (new): `?owner=none` reaches the API, no param keeps `'me'`, bogus values fall back instead of leaking.
- Existing `PartnersList.selection` suite still green; 19/19 across the three files; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3mADsbVzSXMym2f8SMA6n