### PR TITLE
feat(redeem-ops): unreachable cadence steps pause with guidance (not silent-finish) + cadence touches auto-move NEW → Contacted

### DIFF
--- a/backend/src/database/migrations/111-cadence-paused-reason.js
+++ b/backend/src/database/migrations/111-cadence-paused-reason.js
@@ -1,0 +1,23 @@
+/**
+ * 111 — cadence pauses carry WHY they paused.
+ *
+ * Three distinct things park an enrollment in 'paused' and they need different
+ * treatment afterwards: a snooze (the reconciler may auto-resume it when the
+ * partner wakes), a rep's manual pause (nothing may auto-resume it — the
+ * reconciler was silently un-pausing these after 10 minutes), and the new
+ * missing-contact-info pause (resumed only by the contact-info hook when an
+ * email/phone/handle/location is actually added). Legacy NULL rows keep the
+ * old auto-resume behavior so in-flight snoozes survive the deploy.
+ */
+
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_cadence_enrollments ADD COLUMN IF NOT EXISTS "pausedReason" VARCHAR(32)'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_cadence_enrollments DROP COLUMN IF EXISTS "pausedReason"'
+  );
+}

--- a/backend/src/models/OutreachCadenceEnrollment.js
+++ b/backend/src/models/OutreachCadenceEnrollment.js
@@ -16,6 +16,7 @@ const OutreachCadenceEnrollment = sequelize.define('OutreachCadenceEnrollment', 
   exitReason: { type: DataTypes.STRING(32), allowNull: true },
   enrolledBy: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
   pausedAt: { type: DataTypes.DATE, allowNull: true },
+  pausedReason: { type: DataTypes.STRING(32), allowNull: true, comment: 'manual|snoozed|missing_info (NULL = legacy pause)' },
   endedAt: { type: DataTypes.DATE, allowNull: true },
 }, {
   tableName: 'outreach_cadence_enrollments',

--- a/backend/src/services/redeemOps/cadenceHooks.js
+++ b/backend/src/services/redeemOps/cadenceHooks.js
@@ -19,6 +19,7 @@ const HOOK_NAMES = [
   'onStageChange', // changeStageTx + undoStageChange
   'onSnooze', // snoozePartnerTx
   'onUnsnooze', // unsnoozePartnerTx (source:'manual') + stale-sweep wake (source:'sweep')
+  'onContactInfoAdded', // contact/location/reachability-field writes — wakes missing_info pauses
   'onRelease', // claimService.releasePartner
   'onReassign', // claimService.assignPartner
   'onMergeDuplicate', // mergePartners — fired BEFORE child repointing (§5.4 ordering)

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -456,14 +456,51 @@ export function makeCadenceService(overrides = {}) {
   }
 
   /**
+   * The edge a BLOCKED (unreachable-channel) step skips forward through: its
+   * explicit '*' edge, or its SOLE outgoing edge — builder cadences compile
+   * exactly one outgoing edge per step, and for single-outcome channels an
+   * explicit 'sent' is semantically identical to '*', so authoring "Sent"
+   * instead of "Any outcome" must not turn skip-unreachable into
+   * end-the-whole-cadence. Only a genuine branch (several specific edges,
+   * no '*') refuses to skip.
+   */
+  async function resolveSkipEdgeTx(cadenceId, fromStepId, t) {
+    const edges = await d.OutreachCadenceTransition.findAll({
+      where: { cadenceId, fromStepId }, transaction: t,
+    });
+    return edges.find((e) => e.disposition === CADENCE_WILDCARD_DISPOSITION)
+      || (edges.length === 1 ? edges[0] : null);
+  }
+
+  /**
+   * Park the enrollment because every remaining step is unreachable. The old
+   * behavior ended it as 'completed' — which the UI reads as success — while
+   * the rep could have FIXED the blockers (add an email, a handle, an outlet).
+   * Paused on the walk's entry step, it resumes through the contact-info hook
+   * or a manual Resume once the record is filled in.
+   */
+  async function pauseForInfoTx(enrollment, partner, entryStep, blocked, actorUser, t) {
+    await enrollment.update({
+      state: 'paused', pausedAt: d.now(), pausedReason: 'missing_info', currentStepId: entryStep.id,
+    }, { transaction: t });
+    await d.tasks.recomputeNextTaskAt(partner.id, t);
+    await d.audit.recordAuditEvent({
+      actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.paused_missing_info',
+      entityType: 'outreach_cadence_enrollment', entityId: enrollment.id,
+      after: { blocked }, transaction: t,
+    });
+  }
+
+  /**
    * Land the enrollment on `step` (materialize its task), chaining through
-   * blocked steps via their '*' edges; finishes the enrollment if the chain
-   * runs out (§5.3).
+   * blocked steps via their skip edges; pauses for missing contact info if the
+   * chain runs out (§5.3).
    */
   async function placeAtStepTx(enrollment, partner, step, timing, actorUser, t) {
     let cur = step;
     let curTiming = timing;
     let guard = 0;
+    const blocked = [];
     while (cur) {
       const mat = await tryMaterializeTx(enrollment, partner, cur, curTiming, actorUser, t);
       if (!mat.blocked) {
@@ -479,10 +516,11 @@ export function makeCadenceService(overrides = {}) {
         await endEnrollmentTx(enrollment, { state: 'exited', exitReason: 'released' }, actorUser, t);
         return { finished: true, reason: mat.reason };
       }
-      const edge = await resolveTransitionTx(enrollment.cadenceId, cur.id, CADENCE_WILDCARD_DISPOSITION, t);
+      blocked.push({ stepId: cur.id, stepTitle: cur.title, channel: cur.channel, reason: mat.reason });
+      const edge = await resolveSkipEdgeTx(enrollment.cadenceId, cur.id, t);
       if (!edge || !edge.toStepId) {
-        await endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, actorUser, t);
-        return { finished: true, reason: mat.reason };
+        await pauseForInfoTx(enrollment, partner, step, blocked, actorUser, t);
+        return { pausedForInfo: true, blocked };
       }
       cur = await d.OutreachCadenceStep.findByPk(edge.toStepId, { transaction: t });
       curTiming = { delayDays: edge.delayDays, timeWindow: edge.timeWindow };
@@ -573,7 +611,11 @@ export function makeCadenceService(overrides = {}) {
         after: { cadenceKey: cadence.key, version: cadence.version, partnerId, capacityOverride: !!overrideCapacity },
         requestId, transaction: t,
       });
-      return { enrollment, cadence, firstTask: placed.task || null, finishedImmediately: !!placed.finished };
+      return {
+        enrollment, cadence, firstTask: placed.task || null,
+        finishedImmediately: !!placed.finished,
+        pausedForInfo: placed.pausedForInfo ? { blocked: placed.blocked } : null,
+      };
     });
   }
 
@@ -640,10 +682,25 @@ export function makeCadenceService(overrides = {}) {
 
       await enrollment.update({ lastDisposition: disposition }, { transaction: t });
 
+      // 2b. A completed cadence touch IS first contact — a business still in
+      //    NEW moves to CONTACTED in the same transaction. Cadence completions
+      //    only; manual activity logging still never moves stages. systemAuto
+      //    because the move is a side-effect of the completion — a manager
+      //    finishing another rep's task must not 403 on row rights. Skipped
+      //    when this same completion marks the business Lost (NEW → LOST is
+      //    one honest move, not two). The stage hook ignores CONTACTED, so
+      //    the enrollment survives its own stage move.
+      if (partner.pipelineStage === 'NEW' && !(disposition === 'not_interested' && alsoMarkLost)) {
+        await d.partners.changeStageTx(partner.id, 'CONTACTED', user, t, {
+          reason: 'Auto: first cadence touch', requestId, systemAuto: true,
+        });
+      }
+
       // 3. Terminal dispositions end the enrollment; the stage move (if asked
       //    for) happens in the SAME transaction so no contradictory half-state
       //    can survive a crash (§5.2.6).
       let nextTask = null;
+      let cadencePaused = null;
       if (CADENCE_TERMINAL_DISPOSITIONS.includes(disposition)) {
         const exitReason = disposition === 'replied' ? 'replied' : 'not_interested';
         await endEnrollmentTx(enrollment, { state: 'exited', exitReason }, user, t);
@@ -663,6 +720,7 @@ export function makeCadenceService(overrides = {}) {
             { delayDays: edge.delayDays, timeWindow: edge.timeWindow }, user, t
           );
           nextTask = placed.task || null;
+          if (placed.pausedForInfo) cadencePaused = { blocked: placed.blocked };
         }
       }
 
@@ -672,7 +730,7 @@ export function makeCadenceService(overrides = {}) {
         entityId: taskId, after: { disposition, enrollmentState: enrollment.state }, requestId, transaction: t,
       });
 
-      return { task, enrollment, nextTask };
+      return { task, enrollment, nextTask, cadencePaused };
     });
   }
 
@@ -696,7 +754,7 @@ export function makeCadenceService(overrides = {}) {
         { status: 'cancelled' },
         { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
       );
-      await enrollment.update({ state: 'paused', pausedAt: d.now() }, { transaction: t });
+      await enrollment.update({ state: 'paused', pausedAt: d.now(), pausedReason: 'manual' }, { transaction: t });
       await d.tasks.recomputeNextTaskAt(partnerId, t);
       await d.audit.recordAuditEvent({
         actorUser: user, action: 'cadence.paused', entityType: 'outreach_cadence_enrollment',
@@ -707,16 +765,20 @@ export function makeCadenceService(overrides = {}) {
   }
 
   async function resumeEnrollmentTx(enrollment, partner, actorUser, t) {
-    await enrollment.update({ state: 'active', pausedAt: null }, { transaction: t });
+    await enrollment.update({ state: 'active', pausedAt: null, pausedReason: null }, { transaction: t });
     const step = await d.OutreachCadenceStep.findByPk(enrollment.currentStepId, { transaction: t });
     if (!step) {
       return endEnrollmentTx(enrollment, { state: 'completed', exitReason: 'finished' }, actorUser, t);
     }
-    await placeAtStepTx(enrollment, partner, step, { delayDays: 0, timeWindow: 'any' }, actorUser, t);
-    await d.audit.recordAuditEvent({
-      actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.resumed',
-      entityType: 'outreach_cadence_enrollment', entityId: enrollment.id, transaction: t,
-    });
+    const placed = await placeAtStepTx(enrollment, partner, step, { delayDays: 0, timeWindow: 'any' }, actorUser, t);
+    // A resume that immediately re-parks (still nothing reachable) is not a
+    // resume — the paused_missing_info audit row already tells that story.
+    if (!placed.pausedForInfo) {
+      await d.audit.recordAuditEvent({
+        actorUser, actorType: actorUser ? 'staff' : 'system', action: 'cadence.resumed',
+        entityType: 'outreach_cadence_enrollment', entityId: enrollment.id, transaction: t,
+      });
+    }
     return enrollment;
   }
 
@@ -783,7 +845,7 @@ export function makeCadenceService(overrides = {}) {
           { status: 'cancelled' },
           { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
         );
-        await enrollment.update({ state: 'paused', pausedAt: d.now() }, { transaction: t });
+        await enrollment.update({ state: 'paused', pausedAt: d.now(), pausedReason: 'snoozed' }, { transaction: t });
         await d.tasks.recomputeNextTaskAt(partner.id, t);
       },
       onUnsnooze: async ({ partner, partnerId, user, transaction }) => {
@@ -791,11 +853,28 @@ export function makeCadenceService(overrides = {}) {
         const run = async (t) => {
           const enrollment = await liveEnrollmentForPartnerTx(pid, t, { states: ['paused'] });
           if (!enrollment) return;
+          // A wake only undoes the pause the snooze created — a manual pause
+          // or a missing-info park stays put until ITS trigger clears it.
+          if (enrollment.pausedReason && enrollment.pausedReason !== 'snoozed') return;
           const p = await d.PartnerOrganisation.findByPk(pid, { transaction: t, lock: t.LOCK.UPDATE });
           if (!p || p.mergedIntoId || p.archivedAt) return;
           await resumeEnrollmentTx(enrollment, p, user || null, t);
         };
         // Sweep wake arrives without a transaction — open our own.
+        if (transaction) return run(transaction);
+        return d.sequelize.transaction(run);
+      },
+      onContactInfoAdded: async ({ partnerId, user, transaction }) => {
+        const run = async (t) => {
+          // Global lock order: partner → enrollment.
+          const p = await d.PartnerOrganisation.findByPk(partnerId, { transaction: t, lock: t.LOCK.UPDATE });
+          if (!p || p.mergedIntoId || p.archivedAt || !p.ownerUserId) return;
+          const enrollment = await liveEnrollmentForPartnerTx(partnerId, t, { states: ['paused'] });
+          // Only the park THIS event can clear — snoozes wake on their own
+          // schedule and a manual pause stays the rep's call.
+          if (!enrollment || enrollment.pausedReason !== 'missing_info') return;
+          await resumeEnrollmentTx(enrollment, p, user || null, t);
+        };
         if (transaction) return run(transaction);
         return d.sequelize.transaction(run);
       },
@@ -831,11 +910,14 @@ export function makeCadenceService(overrides = {}) {
       // the global partner → enrollment order and re-validates under lock.
 
       // (a) paused enrollments whose partner is awake — the sweep-wake hook
-      //     failed or crashed mid-way; finish the resume it owed.
+      //     failed or crashed mid-way; finish the resume it owed. Scoped to
+      //     snooze-born pauses (+ legacy NULL rows): a rep's manual pause and
+      //     a missing-contact-info park are DELIBERATE states, not faults.
       const strandedPaused = await d.sequelize.query(
         `SELECT e.id, e."partnerOrganisationId" AS pid FROM outreach_cadence_enrollments e
            JOIN partner_organisations p ON p.id = e."partnerOrganisationId"
           WHERE e.state = 'paused' AND e."pausedAt" < NOW() - INTERVAL '10 minutes'
+            AND (e."pausedReason" IS NULL OR e."pausedReason" = 'snoozed')
             AND p.availability NOT IN ('follow_up_later')
             AND p."archivedAt" IS NULL AND p."mergedIntoId" IS NULL
             AND p."ownerUserId" IS NOT NULL
@@ -846,6 +928,7 @@ export function makeCadenceService(overrides = {}) {
         const partner = await d.PartnerOrganisation.findByPk(row.pid, { transaction: t, lock: t.LOCK.UPDATE });
         const enrollment = await d.OutreachCadenceEnrollment.findByPk(row.id, { transaction: t, lock: t.LOCK.UPDATE });
         if (!partner || !enrollment || enrollment.state !== 'paused' || partner.availability === 'follow_up_later') continue;
+        if (enrollment.pausedReason && enrollment.pausedReason !== 'snoozed') continue;
         await resumeEnrollmentTx(enrollment, partner, null, t);
         resumed += 1;
       }

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -255,6 +255,11 @@ export function makePartnerService(overrides = {}) {
         actorUser: user, action: 'partner.edited', entityType: 'partner_organisation',
         entityId: id, before, after: updates, requestId, transaction: t,
       });
+      // A newly-filled reachability field can wake a cadence parked on
+      // missing contact info (pausedReason 'missing_info').
+      if (['primaryPhone', 'primaryEmail', 'instagramHandle'].some((f) => updates[f])) {
+        await d.fireCadenceHook('onContactInfoAdded', { partnerId: id, user, transaction: t });
+      }
     });
     return partner;
   }
@@ -288,13 +293,18 @@ export function makePartnerService(overrides = {}) {
     }
   }
 
-  async function changeStageTx(id, toStage, user, t, { reason = null, requestId = null, lostReason = null } = {}) {
+  async function changeStageTx(id, toStage, user, t, { reason = null, requestId = null, lostReason = null, systemAuto = false } = {}) {
     if (!PIPELINE_STAGES.includes(toStage)) throw new AppError('Unknown stage', 400);
     if (toStage === 'LOST' && !LOST_REASONS.includes(lostReason)) {
       throw new AppError('A reason is required when marking a business as Lost', 400);
     }
     const partner = await getLivePartner(id, { transaction: t, lock: t.LOCK.UPDATE });
-    assertCanMoveRow(user, partner);
+    // systemAuto = the engine moving the stage as a side-effect of an action
+    // that was itself permission-checked (e.g. completing a cadence task moves
+    // NEW → CONTACTED). The transition map below still applies — only the
+    // row-ownership check is waived, so a manager completing another rep's
+    // task doesn't 403 on a move neither of them chose.
+    if (!systemAuto) assertCanMoveRow(user, partner);
     const fromStage = partner.pipelineStage;
     if (fromStage === toStage) return partner;
 
@@ -713,7 +723,7 @@ export function makePartnerService(overrides = {}) {
           { where: { partnerOrganisationId: id }, transaction: t }
         );
       }
-      return d.PartnerContact.create(
+      const contact = await d.PartnerContact.create(
         {
           partnerOrganisationId: id,
           name: String(body.name).trim(),
@@ -727,6 +737,10 @@ export function makePartnerService(overrides = {}) {
         },
         { transaction: t }
       );
+      if (contact.mobile || contact.whatsapp || contact.email) {
+        await d.fireCadenceHook('onContactInfoAdded', { partnerId: id, user, transaction: t });
+      }
+      return contact;
     });
   }
 
@@ -738,16 +752,25 @@ export function makePartnerService(overrides = {}) {
     for (const f of ['name', 'roleTitle', 'mobile', 'whatsapp', 'email', 'preferredChannel', 'isPrimary', 'notes']) {
       if (body[f] !== undefined) updates[f] = body[f];
     }
+    // Reachability gained? Then the contact-info hook fires below — and the
+    // parent must be locked BEFORE the contact row (merge holds partner →
+    // repoints contacts; the reverse order here would be an AB-BA deadlock).
+    const touchesReachability = ['mobile', 'whatsapp', 'email'].some((f) => updates[f]);
     return d.sequelize.transaction(async (t) => {
-      if (updates.isPrimary === true) {
+      if (updates.isPrimary === true || touchesReachability) {
         // M7: same serialization as addContact — lock the parent, then swap.
         await d.PartnerOrganisation.findByPk(contact.partnerOrganisationId, { transaction: t, lock: t.LOCK.UPDATE });
+      }
+      if (updates.isPrimary === true) {
         await d.PartnerContact.update(
           { isPrimary: false },
           { where: { partnerOrganisationId: contact.partnerOrganisationId }, transaction: t }
         );
       }
       await contact.update(updates, { transaction: t });
+      if (touchesReachability) {
+        await d.fireCadenceHook('onContactInfoAdded', { partnerId: contact.partnerOrganisationId, user, transaction: t });
+      }
       return contact;
     });
   }
@@ -762,16 +785,23 @@ export function makePartnerService(overrides = {}) {
 
   async function addLocation(id, body, user) {
     await getOwnedPartner(id, user);
-    return d.PartnerLocation.create({
-      partnerOrganisationId: id,
-      name: body.name || null,
-      addressLine: body.addressLine || null,
-      postalCode: body.postalCode || null,
-      postalDistrict: postalDistrictOf(body.postalCode),
-      area: body.area || null,
-      phone: body.phone || null,
-      isActive: body.isActive !== false,
-      notes: body.notes || null,
+    return d.sequelize.transaction(async (t) => {
+      const location = await d.PartnerLocation.create({
+        partnerOrganisationId: id,
+        name: body.name || null,
+        addressLine: body.addressLine || null,
+        postalCode: body.postalCode || null,
+        postalDistrict: postalDistrictOf(body.postalCode),
+        area: body.area || null,
+        phone: body.phone || null,
+        isActive: body.isActive !== false,
+        notes: body.notes || null,
+      }, { transaction: t });
+      // A first active outlet makes 'visit' steps reachable.
+      if (location.isActive) {
+        await d.fireCadenceHook('onContactInfoAdded', { partnerId: id, user, transaction: t });
+      }
+      return location;
     });
   }
 
@@ -784,8 +814,18 @@ export function makePartnerService(overrides = {}) {
       if (body[f] !== undefined) updates[f] = body[f];
     }
     if (updates.postalCode !== undefined) updates.postalDistrict = postalDistrictOf(updates.postalCode);
-    await location.update(updates);
-    return location;
+    if (updates.isActive !== true) {
+      await location.update(updates);
+      return location;
+    }
+    // Re-activation can wake a missing_info pause; partner lock FIRST (same
+    // AB-BA reasoning as updateContact — merge repoints locations too).
+    return d.sequelize.transaction(async (t) => {
+      await d.PartnerOrganisation.findByPk(location.partnerOrganisationId, { transaction: t, lock: t.LOCK.UPDATE });
+      await location.update(updates, { transaction: t });
+      await d.fireCadenceHook('onContactInfoAdded', { partnerId: location.partnerOrganisationId, user, transaction: t });
+      return location;
+    });
   }
 
   // ── Merge ────────────────────────────────────────────────────────────────

--- a/backend/test/redeemOpsCadences.test.js
+++ b/backend/test/redeemOpsCadences.test.js
@@ -330,15 +330,153 @@ describe('hook-driven exits and pauses', () => {
 });
 
 describe('suppressions', () => {
-  test("an 'any'-channel suppression blocks every step → enrollment finishes immediately", async () => {
+  test("an 'any'-channel suppression blocks every step → enrollment pauses for info", async () => {
     const p = await ownedPartner('Suppressed Cafe');
     await OutreachSuppression.create({ channel: 'any', value: p.primaryPhone, reason: 'opt_out' });
-    // IG / visit steps blocked too (no handle, no location), so the chain finishes
-    const { enrollment, finishedImmediately } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
-    expect(finishedImmediately).toBe(true);
+    // IG / visit steps blocked too (no handle, no location) — nothing is
+    // reachable, so instead of the old silent 'completed' the enrollment parks.
+    const { enrollment, finishedImmediately, pausedForInfo } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    expect(finishedImmediately).toBe(false);
+    expect(pausedForInfo).toBeTruthy();
+    expect(pausedForInfo.blocked.length).toBeGreaterThanOrEqual(7); // every seed step audited
     const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
-    expect(e.state).toBe('completed');
+    expect(e.state).toBe('paused');
+    expect(e.pausedReason).toBe('missing_info');
     expect(await openCadenceTask(enrollment.id)).toBeNull();
+  });
+});
+
+describe('blocked steps & missing contact info', () => {
+  test("a blocked step skips through its sole explicit edge ('sent'), not just '*'", async () => {
+    // Builder dialect: authors pick "Sent" instead of "Any outcome" — for
+    // single-outcome channels the two are semantically identical and must
+    // both skip an unreachable step (the tuition-centre trap).
+    await svc.createCadence({
+      name: 'Sent Edge Skip',
+      steps: [
+        { channel: 'email', title: 'Email intro', delayDays: 0, timeWindow: 'any', continueOn: 'sent' },
+        { channel: 'whatsapp', title: 'WA fallback', delayDays: 0, timeWindow: 'any' },
+      ],
+    }, admin.user);
+    const p = await ownedPartner('Sent Edge Cafe'); // phone on record, no email
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'sent_edge_skip' }, execA.user);
+    expect(firstTask.title).toBe('WA fallback'); // email skipped, not cadence-ended
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+  });
+
+  test('nothing reachable at enroll → paused missing_info; adding a contact email auto-resumes', async () => {
+    await svc.createCadence({
+      name: 'Email Only Chase',
+      steps: [{ channel: 'email', title: 'The email', delayDays: 0, timeWindow: 'any' }],
+    }, admin.user);
+    const p = await ownedPartner('No Email Cafe');
+    const { enrollment, firstTask, pausedForInfo } = await svc.enrollPartner(p.id, { cadenceKey: 'email_only_chase' }, execA.user);
+    expect(firstTask).toBeNull();
+    expect(pausedForInfo.blocked).toEqual([
+      expect.objectContaining({ channel: 'email', reason: 'no_email' }),
+    ]);
+    let e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+    expect(e.pausedReason).toBe('missing_info');
+
+    // The reconciler must NOT clobber the park (it only owns snoozed/legacy pauses).
+    await sequelize.query(
+      `UPDATE outreach_cadence_enrollments SET "pausedAt" = NOW() - INTERVAL '30 minutes' WHERE id = :eid`,
+      { replacements: { eid: enrollment.id } }
+    );
+    await svc.reconcile();
+    e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+
+    // Adding reachability wakes it via onContactInfoAdded — no manual Resume.
+    await partnerSvc.addContact(p.id, { name: 'Owner', email: 'Owner@Resume.SG' }, execA.user);
+    e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+    expect(e.pausedReason).toBeNull();
+    const task = await openCadenceTask(enrollment.id);
+    expect(task).toBeTruthy();
+    expect(task.title).toBe('The email');
+    expect(task.snapshotRecipient).toBe('owner@resume.sg');
+  });
+
+  test('advance onto an unreachable tail pauses (reported to the completer); a partner-field edit resumes it', async () => {
+    await svc.createCadence({
+      name: 'Call Then Email',
+      steps: [
+        { channel: 'call', title: 'First call', delayDays: 0, timeWindow: 'any', continueOn: 'no_answer' },
+        { channel: 'email', title: 'Follow-up email', delayDays: 0, timeWindow: 'any' },
+      ],
+    }, admin.user);
+    const p = await ownedPartner('Advance Park Cafe');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'call_then_email' }, execA.user);
+    const result = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    expect(result.nextTask).toBeNull();
+    expect(result.cadencePaused).toBeTruthy();
+    let e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+    expect(e.pausedReason).toBe('missing_info');
+
+    await partnerSvc.updatePartner(p.id, { primaryEmail: 'biz@park.sg' }, execA.user);
+    e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active');
+    const task = await openCadenceTask(enrollment.id);
+    expect(task.title).toBe('Follow-up email');
+    expect(task.snapshotRecipient).toBe('biz@park.sg');
+  });
+
+  test('a manual pause survives the reconciler (it used to auto-resume after 10 minutes)', async () => {
+    const p = await ownedPartner('Manual Pause Cafe');
+    const { enrollment } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await svc.pauseEnrollment(p.id, execA.user);
+    let e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.pausedReason).toBe('manual');
+    await sequelize.query(
+      `UPDATE outreach_cadence_enrollments SET "pausedAt" = NOW() - INTERVAL '30 minutes' WHERE id = :eid`,
+      { replacements: { eid: enrollment.id } }
+    );
+    const result = await svc.reconcile();
+    expect(result.skipped).toBeUndefined();
+    e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+  });
+});
+
+describe('auto NEW → CONTACTED on cadence touches', () => {
+  test('the first completed touch moves the stage; later touches are a no-op; the enrollment survives', async () => {
+    const p = await ownedPartner('Auto Contacted Cafe');
+    expect(p.pipelineStage).toBe('NEW');
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+
+    const r1 = await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, execA.user);
+    let reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.pipelineStage).toBe('CONTACTED');
+    let e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('active'); // the CONTACTED move must not exit its own cadence
+
+    await svc.completeCadenceTask(r1.nextTask.id, { disposition: 'sent' }, execA.user);
+    reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.pipelineStage).toBe('CONTACTED'); // idempotent, no error
+  });
+
+  test("a manager completing another rep's task still moves the stage (systemAuto bypasses row rights)", async () => {
+    const p = await ownedPartner('Manager Touch Cafe', execA);
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    // bdm is manager-tier for completion but deliberately fails
+    // canActOnPartnerRow — without systemAuto the auto-move would 403.
+    await svc.completeCadenceTask(firstTask.id, { disposition: 'no_answer' }, bdm.user);
+    const reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.pipelineStage).toBe('CONTACTED');
+  });
+
+  test('not_interested + alsoMarkLost goes NEW → LOST in one move, no CONTACTED detour', async () => {
+    const p = await ownedPartner('Straight Lost Cafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceKey: 'fnb_call_first' }, execA.user);
+    await svc.completeCadenceTask(firstTask.id, {
+      disposition: 'not_interested', alsoMarkLost: true, lostReason: 'not_interested',
+    }, execA.user);
+    const reloaded = await PartnerOrganisation.findByPk(p.id);
+    expect(reloaded.pipelineStage).toBe('LOST');
   });
 });
 

--- a/docs/plans/redeem-ops-cadences.md
+++ b/docs/plans/redeem-ops-cadences.md
@@ -301,3 +301,27 @@ merge exits duplicate BEFORE repointing. 3. `visit` becomes a real activity type
 bootstrap. 5. No automatic stage movement; one-click suggestion after `replied`. 6. Queue
 excludes scheduled cadence first-touches; coverage counts outreach-type tasks only. 7. Capacity
 cap ships in P1.
+
+## 14. Revision 2026-08-06 — missing contact info pauses (not silent-finish), auto-CONTACTED
+
+Two product calls (Shawn, 2026-08-06) supersede parts of §5.3 and §13.5:
+
+- **Blocked-step skip follows a step's SOLE outgoing edge, not just `'*'`.** The builder
+  compiles one edge per step, and for single-outcome channels an explicit `sent` is
+  semantically `'*'` — authoring "Sent" must not disable skipping (the tuition-centre cadence
+  ended at step 1 for handle-less businesses while Email/WhatsApp/Call/Visit were reachable).
+  Genuine branches (several specific edges, no `'*'`) still refuse to skip.
+- **A walk with nothing reachable PAUSES instead of completing.** `pausedReason='missing_info'`,
+  parked on the walk's entry step; the old silent `completed/finished` read as success while a
+  fixable record (no email on file) killed the run. Resumed by the `onContactInfoAdded` hook
+  (contact/location/reachability-field writes) or a manual Resume. UI names exactly what's
+  missing and deep-links the Contacts/Locations tab.
+- **`pausedReason` now disambiguates every pause** (`manual` | `snoozed` | `missing_info`;
+  legacy NULL = pre-migration). The reconciler's stranded-pause auto-resume is scoped to
+  `snoozed`/NULL — it was silently un-pausing MANUAL pauses after 10 minutes (latent bug, fixed
+  here); unsnooze wakes only snooze-born pauses.
+- **§13.5 narrowed: completing a cadence task auto-moves a NEW business to CONTACTED** (same
+  transaction, `systemAuto` bypasses only the row-ownership check, transition map still
+  enforced, skipped when the completion itself marks the business Lost). Manual activity
+  logging still never moves stages. Rationale: the queue already treats a cadence touch as
+  "first outreach done" — the kanban column disagreeing with it was operator-visible drift.

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -36,11 +36,12 @@ const toastMock = vi.hoisted(() => {
   const t = vi.fn();
   t.success = vi.fn();
   t.error = vi.fn();
+  t.warning = vi.fn();
   return t;
 });
 vi.mock('sonner', () => ({ toast: toastMock }));
 
-import { CadenceOutcomeButton, CadenceChip, CadencePanel } from '../cadence';
+import { CadenceOutcomeButton, CadenceChip, CadencePanel, unreachableChannels, needsSentence } from '../cadence';
 import { toBuilderSteps } from '../cadenceBuilder';
 import CadenceEditorPage from '@/pages/redeemops/CadenceEditorPage';
 import { useAuthStore } from '@/stores/authStore';
@@ -516,5 +517,122 @@ describe('CadencePanel — outstanding tasks zone', () => {
     wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'LOST' }} onAddTask={onAddTask} />);
     await screen.findByText(/no open tasks/i);
     expect(screen.queryByRole('button', { name: /add task/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('reachability helpers', () => {
+  const bare = { id: 'p-1', ownerUserId: 'u-1' };
+
+  it('unreachableChannels names what each unreachable channel needs', () => {
+    expect(unreachableChannels(bare, ['call', 'whatsapp', 'email', 'instagram_dm', 'visit'])).toEqual([
+      { channel: 'call', need: 'a phone number' },
+      { channel: 'whatsapp', need: 'a phone number' },
+      { channel: 'email', need: 'an email address' },
+      { channel: 'instagram_dm', need: 'an Instagram handle' },
+      { channel: 'visit', need: 'an outlet address' },
+    ]);
+  });
+
+  it('org fields, live contacts and active locations all satisfy reachability; archived contacts do not', () => {
+    const partner = {
+      ...bare,
+      instagramHandle: 'cafe.sg',
+      contacts: [
+        { id: 'c-1', email: 'gone@x.sg', archivedAt: '2026-01-01' },
+        { id: 'c-2', mobile: '+6581112222' },
+      ],
+      locations: [{ id: 'l-1', isActive: true }],
+    };
+    // email only lives on the ARCHIVED contact → still missing
+    expect(unreachableChannels(partner, ['call', 'email', 'instagram_dm', 'visit', 'custom'])).toEqual([
+      { channel: 'email', need: 'an email address' },
+    ]);
+  });
+
+  it('needsSentence joins deduped needs readably', () => {
+    expect(needsSentence([{ channel: 'call', need: 'a phone number' }, { channel: 'whatsapp', need: 'a phone number' }]))
+      .toBe('a phone number');
+    expect(needsSentence(unreachableChannels({ id: 'p' }, ['email', 'instagram_dm'])))
+      .toBe('an email address and an Instagram handle');
+  });
+});
+
+describe('paused-for-missing-info guidance', () => {
+  it('names the missing info and deep-links the fix tab', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-1', state: 'paused', pausedReason: 'missing_info',
+        cadence: {
+          id: 'c-1', name: 'Tuition chase', version: 4,
+          steps: [
+            { id: 's-1', stepOrder: 1, title: 'DM', channel: 'instagram_dm' },
+            { id: 's-2', stepOrder: 2, title: 'Email', channel: 'email' },
+          ],
+        },
+        currentStep: { id: 's-1', stepOrder: 1, channel: 'instagram_dm' },
+      },
+      openTask: null,
+    });
+    api.listTasks.mockResolvedValue({ tasks: [] });
+    const onFixContactInfo = vi.fn();
+    const user = userEvent.setup();
+    wrap(
+      <CadencePanel
+        partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }}
+        onFixContactInfo={onFixContactInfo}
+      />
+    );
+    await screen.findByText(/no way to reach them for the remaining steps/i);
+    expect(screen.getByText(/an Instagram handle and an email address/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /add contact info/i }));
+    expect(onFixContactInfo).toHaveBeenCalledWith('contacts');
+  });
+
+  it('a plain manual pause keeps the old quiet copy', async () => {
+    api.getPartnerCadence.mockResolvedValue({
+      enrollment: {
+        id: 'e-2', state: 'paused', pausedReason: 'manual',
+        cadence: { id: 'c-1', name: 'Chase', version: 1, steps: [] },
+        currentStep: null,
+      },
+      openTask: null,
+    });
+    api.listTasks.mockResolvedValue({ tasks: [] });
+    wrap(<CadencePanel partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW' }} />);
+    await screen.findByText(/no tasks will be scheduled until resumed/i);
+    expect(screen.queryByText(/no way to reach them/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('enroll dialog reachability warnings', () => {
+  it('flags a fully-unreachable cadence as pausing on enroll', async () => {
+    api.getPartnerCadence.mockResolvedValue({ enrollment: null, openTask: null });
+    api.listTasks.mockResolvedValue({ tasks: [] });
+    api.listCadences.mockResolvedValue({
+      cadences: [
+        {
+          id: 'c-ig', name: 'IG only', publishedAt: '2026-01-01',
+          steps: [{ id: 's-1', stepOrder: 1, channel: 'instagram_dm', title: 'DM' }],
+        },
+        {
+          id: 'c-call', name: 'Call first', publishedAt: '2026-01-01',
+          steps: [
+            { id: 's-2', stepOrder: 1, channel: 'call', title: 'Call' },
+            { id: 's-3', stepOrder: 2, channel: 'email', title: 'Email' },
+          ],
+        },
+      ],
+    });
+    useAuthStore.setState({ user: { id: 'u-1', role: 'redeem_ops', redeemOpsRole: 'outreach_exec' } });
+    const user = userEvent.setup();
+    wrap(
+      <CadencePanel
+        partner={{ id: 'p-1', ownerUserId: 'u-1', pipelineStage: 'NEW', primaryPhone: '+6581110000' }}
+      />
+    );
+    await user.click(await screen.findByRole('button', { name: /start cadence/i }));
+    // IG-only: nothing reachable → hard warning; call-first: email step only → soft skip note
+    expect(await screen.findByText(/needs an instagram handle — enrolling pauses/i)).toBeInTheDocument();
+    expect(screen.getByText(/missing an email address — those steps will be skipped/i)).toBeInTheDocument();
   });
 });

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -47,13 +47,44 @@ const CHANNEL_LABELS = {
 /* The rail shows at most this many rows; the rest sit behind "View all n". */
 const MAX_VISIBLE_TASKS = 4;
 
-function invalidateCadenceData(queryClient, partnerId) {
+export function invalidateCadenceData(queryClient, partnerId) {
   queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'queue'] });
   queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'tasks'] });
   if (partnerId) {
     queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', partnerId] });
     queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner-cadence', partnerId] });
   }
+}
+
+/**
+ * Client-side mirror of the engine's recipient resolution: which of these
+ * channels can reach THIS business right now, and what each unreachable one
+ * needs. Contacts/locations ride the partner payload the detail page already
+ * holds. `custom` steps need nothing.
+ */
+export function unreachableChannels(partner, channels) {
+  const contacts = (partner?.contacts || []).filter((c) => !c.archivedAt);
+  const hasPhone = !!(partner?.primaryPhone || contacts.some((c) => c.mobile || c.whatsapp));
+  const hasEmail = !!(partner?.primaryEmail || contacts.some((c) => c.email));
+  const reach = {
+    call: { ok: hasPhone, need: 'a phone number' },
+    whatsapp: { ok: hasPhone, need: 'a phone number' },
+    email: { ok: hasEmail, need: 'an email address' },
+    instagram_dm: { ok: !!partner?.instagramHandle, need: 'an Instagram handle' },
+    visit: { ok: (partner?.locations || []).some((l) => l.isActive !== false), need: 'an outlet address' },
+  };
+  const out = [];
+  for (const ch of channels || []) {
+    const r = reach[ch];
+    if (r && !r.ok && !out.some((o) => o.channel === ch)) out.push({ channel: ch, need: r.need });
+  }
+  return out;
+}
+
+/** "an email address and an Instagram handle" — dedupes repeated needs. */
+export function needsSentence(missing) {
+  const needs = [...new Set(missing.map((m) => m.need))];
+  return needs.length <= 1 ? needs.join('') : `${needs.slice(0, -1).join(', ')} and ${needs[needs.length - 1]}`;
 }
 
 /**
@@ -157,6 +188,11 @@ export function CadenceOutcomeButton({ task, size = 'sm', disabled = false, disa
       if (next) {
         toast.success('Logged — next step scheduled', {
           description: `${next.title} · ${new Date(next.dueAt).toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })}`,
+        });
+      } else if (data?.cadencePaused) {
+        toast.warning('Logged — cadence paused: the remaining steps can’t reach anyone', {
+          description: 'Add the missing contact info (email, phone, handle or outlet) on the business record and the cadence continues on its own.',
+          duration: 8000,
         });
       } else {
         toast.success('Logged — cadence finished for this business');
@@ -408,7 +444,7 @@ function PartnerTaskRow({
 // canManage = may work TASKS here. canRunCadence = may start/pause/stop the
 // cadence, which is working the deal itself and so follows business ownership
 // (#307); it defaults to canManage so other call sites keep their behavior.
-export function CadencePanel({ partner, canManage = true, canRunCadence = canManage, variant = 'card', onAddTask, onEditTask }) {
+export function CadencePanel({ partner, canManage = true, canRunCadence = canManage, variant = 'card', onAddTask, onEditTask, onFixContactInfo }) {
   const queryClient = useQueryClient();
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [stripExpanded, setStripExpanded] = useState(false);
@@ -442,9 +478,16 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
     mutationFn: (body) => redeemOpsApi.enrollCadence(partnerId, body),
     onSuccess: (data) => {
       setEnrollOpen(false);
-      toast.success(data?.finishedImmediately
-        ? 'Enrolled — but every step was blocked (check phone/handle on record)'
-        : 'Cadence started — first task is in the queue');
+      if (data?.pausedForInfo) {
+        toast.warning('Enrolled — paused: no way to reach them yet', {
+          description: 'Add an email, phone, handle or outlet to the record and the cadence starts on its own.',
+          duration: 8000,
+        });
+      } else if (data?.finishedImmediately) {
+        toast.warning('Enrolled — but the cadence ended immediately');
+      } else {
+        toast.success('Cadence started — first task is in the queue');
+      }
       invalidateCadenceData(queryClient, partnerId);
     },
     onError: (err) => toast.error('Could not enroll', { description: err.message }),
@@ -456,7 +499,16 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
   });
   const resumeMutation = useMutation({
     mutationFn: () => redeemOpsApi.resumeCadence(partnerId),
-    onSuccess: () => { toast.success('Cadence resumed'); invalidateCadenceData(queryClient, partnerId); },
+    onSuccess: (resumed) => {
+      // A resume that re-parked means nothing became reachable — say so
+      // instead of pretending it's running.
+      if (resumed?.state === 'paused') {
+        toast.warning('Still can’t reach them — add the missing contact info first');
+      } else {
+        toast.success('Cadence resumed');
+      }
+      invalidateCadenceData(queryClient, partnerId);
+    },
     onError: (err) => toast.error('Could not resume', { description: err.message }),
   });
   const stopMutation = useMutation({
@@ -483,6 +535,14 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
   const steps = enrollment?.cadence?.steps || [];
   const currentOrder = enrollment?.currentStep?.stepOrder || 0;
   const terminalStage = ['PARTNERED', 'LOST'].includes(partner?.pipelineStage);
+
+  // Parked on missing contact info: name exactly what the remaining steps
+  // need, so the fix is one glance away (the hook resumes it automatically).
+  const pausedForInfo = paused && enrollment?.pausedReason === 'missing_info';
+  const missingInfo = pausedForInfo
+    ? unreachableChannels(partner, steps.filter((s) => s.stepOrder >= currentOrder).map((s) => s.channel))
+    : [];
+  const fixTab = missingInfo.length > 0 && missingInfo.every((m) => m.channel === 'visit') ? 'locations' : 'contacts';
 
   // Rows: the live cadence task always leads; manual tasks follow in the
   // backend's dueAt-ascending order (overdue first by construction).
@@ -566,7 +626,23 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
               ))}
             </div>
           )}
-          {paused && (
+          {pausedForInfo ? (
+            <div className="rounded-lg px-3 py-2.5 mt-2" style={{ background: 'var(--ro-tag-yellow-bg, #FFF6DE)' }}>
+              <p className="text-[12.5px] font-semibold m-0" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
+                Paused — no way to reach them for the remaining steps.
+              </p>
+              <p className="text-[12px] m-0 mt-1 leading-relaxed" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
+                {missingInfo.length > 0
+                  ? <>Add {needsSentence(missingInfo)} and the cadence continues on its own.</>
+                  : 'Add contact info (or lift the do-not-contact block) and resume.'}
+              </p>
+              {onFixContactInfo && (
+                <Button size="sm" variant="outline" className="mt-2" onClick={() => onFixContactInfo(fixTab)}>
+                  Add contact info
+                </Button>
+              )}
+            </div>
+          ) : paused && (
             <p className="text-[12.5px] mt-2 mb-0" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
               Paused — no tasks will be scheduled until resumed.
             </p>
@@ -709,7 +785,7 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
       <span className="font-semibold" style={{ color: 'var(--ro-bunker)' }}>
         <CadenceName cadence={enrollment.cadence} /> · step {currentOrder}/{steps.length}
       </span>
-      {paused ? ' · paused' : ' · scheduling next step…'}
+      {pausedForInfo ? ' · paused — add contact info' : paused ? ' · paused' : ' · scheduling next step…'}
     </p>
   ) : (
     <div className="flex items-center justify-between gap-2">
@@ -743,31 +819,47 @@ export function CadencePanel({ partner, canManage = true, canRunCadence = canMan
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2 min-h-0 overflow-y-auto">
-            {cadenceDefs.map((c) => (
-              <button
-                key={c.id}
-                type="button"
-                className="w-full text-left rounded-xl border border-border px-4 py-3 hover:bg-[var(--ro-subtle)] transition-colors disabled:opacity-60"
-                disabled={enrollMutation.isPending}
-                onClick={() => enrollMutation.mutate({ cadenceId: c.id })}
-              >
-                <p className="text-sm font-semibold m-0">
-                  {c.name}
-                  {/* drafts only reach their creator + admins — flag them */}
-                  {!c.publishedAt && (
-                    <span
-                      className="ml-2 inline-block align-middle rounded-full border border-dashed border-border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
-                      style={{ color: 'var(--ro-text-2)' }}
-                    >
-                      Draft
-                    </span>
+            {cadenceDefs.map((c) => {
+              // Warn BEFORE enrolling: which of this cadence's channels can't
+              // reach the business yet. Unreachable steps skip; if none are
+              // reachable the cadence pauses until the record is filled in.
+              const missing = unreachableChannels(partner, (c.steps || []).map((s) => s.channel));
+              const reachableSteps = (c.steps || []).filter(
+                (s) => s.channel === 'custom' || !missing.some((m) => m.channel === s.channel)
+              );
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  className="w-full text-left rounded-xl border border-border px-4 py-3 hover:bg-[var(--ro-subtle)] transition-colors disabled:opacity-60"
+                  disabled={enrollMutation.isPending}
+                  onClick={() => enrollMutation.mutate({ cadenceId: c.id })}
+                >
+                  <p className="text-sm font-semibold m-0">
+                    {c.name}
+                    {/* drafts only reach their creator + admins — flag them */}
+                    {!c.publishedAt && (
+                      <span
+                        className="ml-2 inline-block align-middle rounded-full border border-dashed border-border px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+                        style={{ color: 'var(--ro-text-2)' }}
+                      >
+                        Draft
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
+                    {c.steps?.length || 0} steps — {(c.steps || []).map((s) => CHANNEL_LABELS[s.channel] || s.channel).join(' → ')}
+                  </p>
+                  {missing.length > 0 && (
+                    <p className="text-xs m-0 mt-1 font-medium" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
+                      {reachableSteps.length === 0
+                        ? `Needs ${needsSentence(missing)} — enrolling pauses until it's added.`
+                        : `Missing ${needsSentence(missing)} — those steps will be skipped.`}
+                    </p>
                   )}
-                </p>
-                <p className="text-xs m-0 mt-0.5" style={{ color: 'var(--ro-text-2)' }}>
-                  {c.steps?.length || 0} steps — {(c.steps || []).map((s) => CHANNEL_LABELS[s.channel] || s.channel).join(' → ')}
-                </p>
-              </button>
-            ))}
+                </button>
+              );
+            })}
             {defsQuery.isLoading && <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Loading cadences…</p>}
             {!defsQuery.isLoading && cadenceDefs.length === 0 && (
               <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>No cadences defined yet.</p>

--- a/src/pages/redeemops/CadenceEditorPage.jsx
+++ b/src/pages/redeemops/CadenceEditorPage.jsx
@@ -388,7 +388,10 @@ export default function CadenceEditorPage() {
               A step only reaches the next one on its “continue when” outcome. Replies and
               “not interested” end the cadence immediately; moving the business to Meeting or
               beyond, snoozing, or releasing it stops the schedule automatically. Steps that can’t
-              reach anyone (no phone or handle on record) are skipped.
+              reach anyone (no phone or handle on record) are skipped — and if none of the
+              remaining steps can reach the business, the cadence pauses until contact info is
+              added, then continues on its own. Completing a step also moves a New business to
+              Contacted.
             </p>
           </div>
         </div>

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -35,7 +35,7 @@ import Plus from 'lucide-react/icons/plus';
 import Pencil from 'lucide-react/icons/pencil';
 import ArrowLeft from 'lucide-react/icons/arrow-left';
 import { RoStageTag, RoAvatar, RoTag, prettyEnum } from '@/components/redeemops/ui';
-import { CadencePanel } from '@/components/redeemops/cadence';
+import { CadencePanel, invalidateCadenceData } from '@/components/redeemops/cadence';
 import CategorySelect from '@/components/redeemops/CategorySelect';
 
 function useDebounced(value, ms = 300) {
@@ -316,7 +316,14 @@ export default function PartnerDetail() {
     // Edits, tasks, contacts and stage moves all create timeline entries now —
     // keep the open timeline honest (review finding: stale after edit).
     queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'partner', id, 'timeline'] });
+    // Contact/detail writes can auto-resume a cadence parked on missing info —
+    // refresh the cadence card and task rail so the revived task shows at once.
+    invalidateCadenceData(queryClient, id);
   };
+
+  // Controlled so the cadence card's "Add contact info" nudge can land the
+  // rep straight on the Contacts / Locations tab.
+  const [activeTab, setActiveTab] = useState('timeline');
 
   const useSimpleMutation = (fn, okMsg) => useMutation({
     mutationFn: fn,
@@ -711,10 +718,11 @@ export default function PartnerDetail() {
         variant="summary"
         onAddTask={() => setTaskOpen(true)}
         onEditTask={openTaskEdit}
+        onFixContactInfo={(tab) => setActiveTab(tab || 'contacts')}
       />
 
       <div className="grid gap-5 lg:grid-cols-[1fr_320px] items-start">
-        <Tabs defaultValue="timeline">
+        <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="max-w-full overflow-x-auto">
           <TabsList className="w-max">
             <TabsTrigger value="timeline">Timeline</TabsTrigger>
@@ -866,6 +874,7 @@ export default function PartnerDetail() {
               canRunCadence={canActOnRow && hasCapability(user, 'tasks.manage')}
               onAddTask={() => setTaskOpen(true)}
               onEditTask={openTaskEdit}
+              onFixContactInfo={(tab) => setActiveTab(tab || 'contacts')}
             />
           </div>
 


### PR DESCRIPTION
## Why

Shawn asked what happens when a business with **no contacts/emails** is enrolled in the tuition-centre cadence. Code + prod-DB tracing showed three problems:

1. **The "Sent" trap.** The blocked-step skip only followed literal `'*'` edges. The live cadence (`tuition_centre_parent_reach_outreach` v4) uses `sent` / `no_answer` edges, so ONE unreachable step (e.g. no IG handle) silently ended the entire run as **"finished"** — Email/WhatsApp/Call/Visit never attempted even when reachable. For single-outcome channels "Sent" and "Any outcome" are functionally identical *except* for this trap.
2. **Silent success.** A fully-unreachable enrollment completed as `finished` — the card shows "Last cadence finished." Nothing tells the rep an email would have fixed it.
3. **Kanban drift.** Completing a first touch ("Sent") never moved the business out of NEW, while the queue already stopped listing it under *awaiting first outreach* — two surfaces disagreeing about what "contacted" means (plan §13.5 decided no-auto-moves; the promised one-click nudge was never built).

## What changed

**Engine (`cadenceService.js`)**
- Blocked steps skip through their **sole outgoing edge**, not just `'*'` (genuine multi-edge branches still refuse).
- Nothing-reachable walks now **pause** — `pausedReason='missing_info'`, parked on the walk's entry step — instead of completing. Reported to the caller (`pausedForInfo` on enroll, `cadencePaused` on completion).
- New **`onContactInfoAdded` hook**: contact/location/reachability-field writes (`partnerService`) auto-resume the park in the same transaction. Partner→enrollment lock order; `updateContact`/`updateLocation` pre-lock the parent to avoid an AB-BA with merge repointing.
- **Auto NEW → CONTACTED** on any completed cadence touch, same transaction. `systemAuto` waives only the row-ownership check (manager completing another rep's task must not 403); the transition map still rules; skipped when the same completion marks the business Lost. The stage hook ignores CONTACTED, so the cadence survives its own move.
- **Latent bug fixed:** the reconciler auto-resumed *manual* pauses after 10 min (stranded-pause repair assumed every pause was snooze-born). `pausedReason` (`manual|snoozed|missing_info`, migration **111**) scopes repair to `snoozed`/legacy-NULL; unsnooze wakes only what the snooze parked.

**UI**
- Paused card names exactly what's missing ("Add an email address and an Instagram handle and the cadence continues on its own") with an **Add contact info** button that deep-links the Contacts/Locations tab (PartnerDetail tabs now controlled).
- Enroll dialog warns per cadence *before* enrolling: fully unreachable → "enrolling pauses until it's added"; partially → "those steps will be skipped".
- Honest toasts for enroll-paused / advance-paused / resume-that-re-parked; editor sidebar copy updated.

## Notes for review
- The live tuition cadence needs **no re-save**: with the skip fix its `sent` edges now behave as the sidebar always promised.
- `reason` values on suppressed/template blocks also ride the pause path — copy stays generic there ("lift the do-not-contact block").
- Plan doc §14 records both product calls (supersedes §13.5 for cadence completions).

## Tests
- Engine suite **43/43** — 7 new: sent-edge skip, pause-on-unreachable at enroll + on advance, contact-add and partner-edit auto-resume, reconciler leaves manual/missing_info pauses alone, auto-CONTACTED (idempotent, survives own move, bdm systemAuto, straight-to-Lost).
- Partners **43/43**, migrations **23/23** (incl. 111), frontend cadence **31/31**, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8NsnANkm3qT9gApdj67Bk