### PR TITLE
fix(redeem-ops): pipeline "+N more" becomes a real expander (was dead text)

### DIFF
--- a/src/pages/redeemops/TeamPipeline.jsx
+++ b/src/pages/redeemops/TeamPipeline.jsx
@@ -181,6 +181,9 @@ export default function TeamPipeline() {
   const [lostMove, setLostMove] = useState(null); // { card } — Lost requires a reason
   const [lostReason, setLostReason] = useState(null);
   const [showLost, setShowLost] = useState(false);
+  // Lanes render 30 cards then a "+N more" expander (perf guard, not a cap).
+  // Keyed by stage ('LOST' included); true = the lane shows everything.
+  const [expandedLanes, setExpandedLanes] = useState({});
   // Reps live in their own book — the board opens on it; Team is one click away.
   const [view, setView] = useState('mine'); // 'mine' | 'team'
 
@@ -370,7 +373,7 @@ export default function TeamPipeline() {
             const items = byStage[stage] || [];
             return (
               <Lane key={stage} stage={stage} items={items} activeCard={activeCard} legalTargets={legalTargets} backTargets={backTargets}>
-                {items.slice(0, 30).map((p) => (
+                {(expandedLanes[stage] ? items : items.slice(0, 30)).map((p) => (
                   <BoardCard
                     key={p.id}
                     p={p}
@@ -379,9 +382,14 @@ export default function TeamPipeline() {
                   />
                 ))}
                 {items.length > 30 && (
-                  <p className="text-[11.5px] text-center font-semibold m-0 py-1.5 bg-white border border-border rounded-full" style={{ color: 'var(--ro-text-2)' }}>
-                    + {items.length - 30} more
-                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setExpandedLanes((e) => ({ ...e, [stage]: !e[stage] }))}
+                    className="text-[11.5px] text-center font-semibold m-0 py-1.5 bg-white border border-border rounded-full cursor-pointer hover:bg-[var(--ro-subtle)] transition-colors"
+                    style={{ color: 'var(--ro-text-2)' }}
+                  >
+                    {expandedLanes[stage] ? 'Show first 30' : `+ ${items.length - 30} more`}
+                  </button>
                 )}
                 {items.length === 0 && (
                   <p className="text-[11.5px] m-0 px-1.5 py-2" style={{ color: 'var(--ro-text-3)' }}>
@@ -393,7 +401,7 @@ export default function TeamPipeline() {
           })}
           {showLost && (
             <Lane stage="LOST" items={lostItems} activeCard={activeCard} legalTargets={legalTargets}>
-              {lostItems.slice(0, 30).map((p) => (
+              {(expandedLanes.LOST ? lostItems : lostItems.slice(0, 30)).map((p) => (
                 <BoardCard
                   key={p.id}
                   p={p}
@@ -401,6 +409,16 @@ export default function TeamPipeline() {
                   onOpen={(pid) => navigate(`/redeem-ops/partners/${pid}`)}
                 />
               ))}
+              {lostItems.length > 30 && (
+                <button
+                  type="button"
+                  onClick={() => setExpandedLanes((e) => ({ ...e, LOST: !e.LOST }))}
+                  className="text-[11.5px] text-center font-semibold m-0 py-1.5 bg-white border border-border rounded-full cursor-pointer hover:bg-[var(--ro-subtle)] transition-colors"
+                  style={{ color: 'var(--ro-text-2)' }}
+                >
+                  {expandedLanes.LOST ? 'Show first 30' : `+ ${lostItems.length - 30} more`}
+                </button>
+              )}
               {lostItems.length === 0 && (
                 <p className="text-[11.5px] m-0 px-1.5 py-2" style={{ color: 'var(--ro-text-3)' }}>
                   Nothing marked Lost — drag back to Contacted to re-engage.

--- a/src/pages/redeemops/__tests__/TeamPipeline.view.test.jsx
+++ b/src/pages/redeemops/__tests__/TeamPipeline.view.test.jsx
@@ -112,3 +112,24 @@ it('an empty book points at Unowned instead of showing a bare board', async () =
   await waitFor(() => expect(api.getTeamPipeline).toHaveBeenCalled());
   expect(await screen.findByText(/No businesses in your book yet/)).toBeInTheDocument();
 });
+
+it('"+N more" is a real button: expands the lane to every card, then collapses back', async () => {
+  api.getTeamPipeline.mockResolvedValue({
+    counts: [],
+    partners: Array.from({ length: 35 }, (_, i) => mine(`p-${i + 1}`, `Biz ${i + 1}`, 'CONTACTED')),
+  });
+  renderPage();
+  await screen.findByText('Biz 1');
+
+  // perf guard: 30 cards render, the 31st waits behind the expander
+  expect(screen.queryByText('Biz 31')).not.toBeInTheDocument();
+  const expander = screen.getByRole('button', { name: '+ 5 more' });
+  await userEvent.click(expander);
+  expect(screen.getByText('Biz 31')).toBeInTheDocument();
+  expect(screen.getByText('Biz 35')).toBeInTheDocument();
+
+  // and back — the same button now collapses the lane
+  await userEvent.click(screen.getByRole('button', { name: 'Show first 30' }));
+  expect(screen.queryByText('Biz 35')).not.toBeInTheDocument();
+  expect(screen.getByText('Biz 30')).toBeInTheDocument();
+});


### PR DESCRIPTION
## What

Shawn couldn't click "+ 19 more" on the Contacted lane — because it was a plain `<p>`, not a control. Lanes render 30 cards as a perf guard and the remainder was represented by unclickable text; the Lost rail truncated at 30 with **no indicator at all**.

Both are now a per-lane toggle button:
- **"+ N more"** → lane shows every card
- **"Show first 30"** → collapses back
- Same pill styling, now with hover affordance; LOST lane gets the expander too.

Built on top of #429 (Mine/Team views) — expansion state is per-lane and orthogonal to the view switch.

## Tests
New case in `TeamPipeline.view.test.jsx`: a 35-card lane renders 30, `+ 5 more` reveals 31–35, `Show first 30` collapses. 5/5 green, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8NsnANkm3qT9gApdj67Bk