### PR TITLE
fix(meta): a routing qrTag never labels a Meta lead as a QR scan

### DIFF
--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -558,7 +558,11 @@ export function makeMetaLeadService(overrides = {}) {
         } : null;
         deliveryPairs = await d.persistEventDeliveries(
           'lead.created',
-          () => d.buildLeadCreatedPayload(prospect, 'meta_lead_ad', agentForWebhook, assignedAgentId, campaign, qrTag || null, null),
+          // qrTag is deliberately NOT shipped: for Meta leads it is a routing
+          // artifact (per-agent form → that agent), not a capture source — the
+          // receiver's label logic treats any qrTag as "scanned a QR code" and
+          // would mislabel the lead (found live on the first pilot lead).
+          () => d.buildLeadCreatedPayload(prospect, 'meta_lead_ad', agentForWebhook, assignedAgentId, campaign, null, null),
           { destination },
           t
         );

--- a/backend/src/utils/sourceLabel.js
+++ b/backend/src/utils/sourceLabel.js
@@ -115,7 +115,11 @@ export function signupSourceLabel({ leadSource, qrTag, sourceMetadata } = {}) {
   const source = String(leadSource || '').toLowerCase();
 
   if (source === 'referral') return 'Referral';
-  if ((qrTag && (qrTag.slug || qrTag.externalId)) || source === 'qr_code') return 'QR code';
+  // Meta-native lead (instant form): metaLeadgenId is written ONLY by the Meta
+  // ingestion pipe. Any qrTag on such a lead is per-agent ROUTING plumbing,
+  // never a scan — without this guard the QR branch below mislabels it.
+  const metaNative = Boolean(meta.metaLeadgenId);
+  if (!metaNative && ((qrTag && (qrTag.slug || qrTag.externalId)) || source === 'qr_code')) return 'QR code';
   if (source === 'call_bot') return 'Voice call';
 
   const utmSource = meta.utm?.utm_source;

--- a/backend/test/unit/metaLeadService.test.js
+++ b/backend/test/unit/metaLeadService.test.js
@@ -94,6 +94,7 @@ function makeDeps(overrides = {}) {
     resolveConsumerForCaptureTx: jest.fn().mockResolvedValue('consumer-1'),
     recordCaptureConsentEventsTx: jest.fn().mockResolvedValue(1),
     persistEventDeliveries: jest.fn().mockResolvedValue([{ delivery: {}, subscriber: {} }]),
+    buildLeadCreatedPayload: jest.fn().mockReturnValue({ event: 'lead.created' }),
     flushDeliveries: jest.fn(),
     sendLeadAssignmentEmail: jest.fn().mockResolvedValue({}),
     resolvePageAccessToken: jest.fn().mockResolvedValue({ token: 'tok' }),
@@ -281,6 +282,12 @@ describe('metaLeadService (unit)', () => {
       }));
       expect(deps.persistEventDeliveries).toHaveBeenCalledWith(
         'lead.created', expect.any(Function), { destination: 'mktr_leads' }, expect.anything()
+      );
+      // The payload must NOT carry the routing qrTag (6th arg null): the
+      // receiver labels any qrTag as "scanned a QR code" — wrong for Meta.
+      deps.persistEventDeliveries.mock.calls[0][1]();
+      expect(deps.buildLeadCreatedPayload).toHaveBeenCalledWith(
+        expect.anything(), 'meta_lead_ad', expect.anything(), 'agent-1', expect.anything(), null, null
       );
       expect(row.status).toBe('completed');
       expect(seq.txs[0].commit).toHaveBeenCalled();

--- a/backend/test/unit/sourceLabel.test.js
+++ b/backend/test/unit/sourceLabel.test.js
@@ -1,0 +1,46 @@
+import '../setup.js';
+import { signupSourceLabel } from '../../src/utils/sourceLabel.js';
+
+/**
+ * Twin contract with mktr-leads receive-mktr-lead/leadSource.ts — the two
+ * label helpers must agree. The meta-native guard exists because per-agent
+ * Meta forms route via a qrTag: routing plumbing, never a scan (the pilot's
+ * first Meta lead labeled itself "QR code", 2026-08-07).
+ */
+describe('signupSourceLabel (unit)', () => {
+  it('meta-native lead with a routing qrTag labels as a Meta ad, not QR', () => {
+    expect(signupSourceLabel({
+      leadSource: 'social_media',
+      qrTag: { slug: 'agent-qr', externalId: 'qr-1' },
+      sourceMetadata: { metaLeadgenId: '123', utm: { utm_source: 'meta' } },
+    })).toBe('Meta ad');
+  });
+
+  it('fb/ig platform names survive the guard path', () => {
+    expect(signupSourceLabel({
+      leadSource: 'social_media',
+      qrTag: { externalId: 'qr-1' },
+      sourceMetadata: { metaLeadgenId: '9', utm: { utm_source: 'ig' } },
+    })).toBe('Instagram ad');
+  });
+
+  it('a real scan (no metaLeadgenId) still labels QR code — even with utm noise', () => {
+    expect(signupSourceLabel({
+      leadSource: 'website',
+      qrTag: { slug: 'shop-window' },
+      sourceMetadata: { utm: { utm_source: 'fb' } },
+    })).toBe('QR code');
+  });
+
+  it('explicit qr_code source without metaLeadgenId stays QR', () => {
+    expect(signupSourceLabel({ leadSource: 'qr_code' })).toBe('QR code');
+  });
+
+  it('referral still wins over everything', () => {
+    expect(signupSourceLabel({
+      leadSource: 'referral',
+      qrTag: { slug: 'x' },
+      sourceMetadata: { metaLeadgenId: '1' },
+    })).toBe('Referral');
+  });
+});


### PR DESCRIPTION
First pilot Meta lead (per-agent form → qrTag routing) labeled its genesis activity **'via QR code'**. Both label twins prioritized qrTag presence over Meta attribution — correct for real scans, wrong for Meta-native leads where the qrTag is routing plumbing.

**Fixes (both sides of the twin contract):**
- `metaLeadService` stops shipping the qrTag block in `lead.created` payloads.
- `signupSourceLabel` (platform) + `deriveLeadSource` (mktr-leads receiver, deployed `34aaf80`): `sourceMetadata.metaLeadgenId` — written only by the Meta pipe — now beats the QR branch.

**Tests:** new `sourceLabel.test.js` twin-contract suite, payload-arg assertion in `metaLeadService.test.js`, receiver regression in mktr-leads (33/33). Verified live: fresh test lead processed post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUuqU2nS4jZEaMs2yPZXFT