### PR TITLE
feat(meta): Connect Facebook — self-serve agent onboarding backend (flag off)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -496,6 +496,27 @@ META_PAGE_TOKEN_ENC_KEY=
 # this exact page id — set BOTH or NEITHER (boot-enforced pair).
 # META_PAGE_ID=
 # META_PAGE_ACCESS_TOKEN=
+
+# ── Connect Facebook — agent self-serve OAuth (docs/plans/facebook-connect-self-serve.md) ──
+# Requires META_LEAD_ADS_ENABLED=true. With this "true" in production, boot
+# FAILS unless META_APP_ID, FB_LOGIN_CONFIG_ID, META_AGENT_ADS_CAMPAIGN_ID and
+# EXTERNAL_APP_SECRET are all present.
+META_OAUTH_ENABLED=false
+# App ID of the same Meta app that owns META_APP_SECRET.
+META_APP_ID=
+# Facebook Login for Business configuration id (app dashboard → Facebook
+# Login for Business → Configurations).
+FB_LOGIN_CONFIG_ID=
+# Campaign every self-serve agent's leads route into. Must be active with
+# quota OFF and no leadPriceCents (agents pay with their own ad spend) —
+# bootstrap re-arms drift and refuses to boot if the campaign is missing.
+META_AGENT_ADS_CAMPAIGN_ID=
+# Bare https origin serving /api/meta/oauth/callback (defaults to
+# https://api.mktr.sg). Must exactly match the Valid OAuth Redirect URI in
+# the Meta app dashboard.
+# META_OAUTH_CALLBACK_ORIGIN=
+# Browser completion page (defaults to https://redeem.sg/fb-connected).
+# META_OAUTH_COMPLETION_URL=
 # "add" (additive POST /users — default, verified) or "replace" (POST
 # /usersreplace — authoritative full replace; probe before relying on it).
 REDEEMED_AUDIENCE_SYNC_MODE=add

--- a/backend/env.example
+++ b/backend/env.example
@@ -193,7 +193,7 @@ META_WA_ACCESS_TOKEN=
 # META_WA_TEMPLATE_NAME=auth_otp
 # META_WA_TEMPLATE_LANG=en_US
 # Shared across every Meta Graph call (CAPI, WA, audiences)
-# META_GRAPH_API_VERSION=v21.0
+# META_GRAPH_API_VERSION=v23.0   (single source for EVERY Graph call — client default is v23.0)
 
 # -----------------------------------------------------------------------------
 # WhatsApp — Redeem Ops reward / draw sends

--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -87,6 +87,23 @@ export function validateEnv() {
     }
   }
 
+  // Connect Facebook (docs/plans/facebook-connect-self-serve.md §5): the flag
+  // arms a PUBLIC OAuth surface — half-configured must refuse to boot.
+  if (String(process.env.META_OAUTH_ENABLED || 'false').toLowerCase() === 'true') {
+    if (String(process.env.META_LEAD_ADS_ENABLED || 'false').toLowerCase() !== 'true') {
+      throw new Error('FATAL: META_OAUTH_ENABLED=true requires META_LEAD_ADS_ENABLED=true — self-serve connects ride the lead pipe');
+    }
+    const oauthRequired = ['META_APP_ID', 'FB_LOGIN_CONFIG_ID', 'META_AGENT_ADS_CAMPAIGN_ID', 'EXTERNAL_APP_SECRET'];
+    const missingOauth = oauthRequired.filter((key) => !process.env[key]);
+    if (missingOauth.length > 0) {
+      throw new Error(`FATAL: META_OAUTH_ENABLED=true but missing: ${missingOauth.join(', ')}`);
+    }
+    const origin = process.env.META_OAUTH_CALLBACK_ORIGIN;
+    if (origin && !/^https:\/\/[^/]+$/.test(origin)) {
+      throw new Error('FATAL: META_OAUTH_CALLBACK_ORIGIN must be a bare https origin (e.g. https://api.mktr.sg)');
+    }
+  }
+
   if (process.env.WEBHOOK_ENABLED && String(process.env.WEBHOOK_ENABLED).toLowerCase() !== 'true') {
     console.warn(`⚠️ WEBHOOK_ENABLED is "${process.env.WEBHOOK_ENABLED}" (not "true") — webhook delivery is disabled, leads will not reach Lyfe`);
   }
@@ -125,7 +142,7 @@ export function validateEnv() {
     'ENRICHMENT_MAP_ARTIFACT_JOBS', 'ENRICHMENT_SCORING_ENABLED',
     'LYFE_LEAD_SUPPRESSED_ENABLED', 'MKTR_LEADS_LEAD_SUPPRESSED_ENABLED',
     'SYNC_AGENT_CRON', 'WHATSAPP_QR_HEADER', 'ENABLE_AUTH_MAPPING',
-    'META_LEAD_ADS_ENABLED',
+    'META_LEAD_ADS_ENABLED', 'META_OAUTH_ENABLED',
   ];
   const mistyped = booleanFlags.filter((k) => {
     const v = process.env[k];

--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -98,8 +98,13 @@ export function validateEnv() {
     if (missingOauth.length > 0) {
       throw new Error(`FATAL: META_OAUTH_ENABLED=true but missing: ${missingOauth.join(', ')}`);
     }
+    // Explicit in production (review F18): a staging/custom host silently
+    // inheriting the api.mktr.sg default would register the WRONG callback.
     const origin = process.env.META_OAUTH_CALLBACK_ORIGIN;
-    if (origin && !/^https:\/\/[^/]+$/.test(origin)) {
+    if (!origin) {
+      throw new Error('FATAL: META_OAUTH_ENABLED=true requires META_OAUTH_CALLBACK_ORIGIN (bare https origin, e.g. https://api.mktr.sg)');
+    }
+    if (!/^https:\/\/[^/]+$/.test(origin)) {
       throw new Error('FATAL: META_OAUTH_CALLBACK_ORIGIN must be a bare https origin (e.g. https://api.mktr.sg)');
     }
   }

--- a/backend/src/controllers/externalFacebookConnectController.js
+++ b/backend/src/controllers/externalFacebookConnectController.js
@@ -24,10 +24,18 @@ function fail(res, err, op) {
   return res.status(500).json({ success: false, error: 'Internal server error' });
 }
 
+const oauthEnabled = () => String(process.env.META_OAUTH_ENABLED || 'false').toLowerCase() === 'true';
+
 export async function facebookConnect(req, res) {
   const { action, agentMktrUserId, pageId } = req.body || {};
   if (!agentMktrUserId || typeof agentMktrUserId !== 'string') {
     return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  }
+  // Feature dark (review F17): status answers honestly so the app screen can
+  // hide itself; mutations refuse with a stable taxonomy code.
+  if (!oauthEnabled()) {
+    if (action === 'status') return res.json({ success: true, connection: { enabled: false, status: 'none' } });
+    return res.status(409).json({ success: false, error: 'feature_disabled' });
   }
   try {
     switch (action) {

--- a/backend/src/controllers/externalFacebookConnectController.js
+++ b/backend/src/controllers/externalFacebookConnectController.js
@@ -1,0 +1,57 @@
+import {
+  startConnect, getConnectionStatus, selectPage, disconnect,
+} from '../services/metaConnectService.js';
+import { logger } from '../utils/logger.js';
+
+export { requireExternalHmac } from './externalBillingController.js';
+
+/**
+ * mktr-leads broker → Connect-Facebook actions
+ * (docs/plans/facebook-connect-self-serve.md §2.1/§2.4).
+ *
+ * HMAC-gated (shared requireExternalHmac). The EF injects agentMktrUserId
+ * after its own JWT + live-row gate — the app body NEVER controls it.
+ * Error contract: `agent_sync_pending` is 503 (mirror lag — retryable),
+ * never conflated with the EF-side 403 `not_linked`.
+ */
+
+function fail(res, err, op) {
+  if (err?.code) {
+    const status = err.statusCode || err.status || 500;
+    return res.status(status).json({ success: false, error: err.code });
+  }
+  logger.error(`[external-fb-connect] ${op} failed`, { error: err?.message || String(err) });
+  return res.status(500).json({ success: false, error: 'Internal server error' });
+}
+
+export async function facebookConnect(req, res) {
+  const { action, agentMktrUserId, pageId } = req.body || {};
+  if (!agentMktrUserId || typeof agentMktrUserId !== 'string') {
+    return res.status(400).json({ success: false, error: 'agentMktrUserId is required' });
+  }
+  try {
+    switch (action) {
+      case 'start': {
+        const r = await startConnect({ agentMktrUserId });
+        return res.json({ success: true, startUrl: r.startUrl });
+      }
+      case 'status': {
+        const r = await getConnectionStatus({ agentMktrUserId });
+        return res.json({ success: true, connection: r });
+      }
+      case 'select_page': {
+        if (!pageId) return res.status(400).json({ success: false, error: 'pageId is required' });
+        await selectPage({ agentMktrUserId, pageId: String(pageId) });
+        return res.json({ success: true });
+      }
+      case 'disconnect': {
+        await disconnect({ agentMktrUserId });
+        return res.json({ success: true });
+      }
+      default:
+        return res.status(400).json({ success: false, error: 'unknown action' });
+    }
+  } catch (err) {
+    return fail(res, err, action || 'unknown');
+  }
+}

--- a/backend/src/controllers/metaController.js
+++ b/backend/src/controllers/metaController.js
@@ -2,6 +2,7 @@ import {
   MetaPage, MetaFormMapping, MetaLeadgenEvent, Campaign, QrTag, User,
 } from '../models/index.js';
 import { verifyMetaSignature, enqueueLeadgenChanges, drainMetaInbox, isMetaLeadAdsArmed } from '../services/metaLeadService.js';
+import { handleOAuthCallback, handleDeauthorize, handleDataDeletion } from '../services/metaConnectService.js';
 import { sealPageToken } from '../services/metaPageTokens.js';
 import { logger } from '../utils/logger.js';
 
@@ -86,6 +87,50 @@ export const handleWebhook = async (req, res) => {
   // the happy path (form submit → agent push) sub-second.
   setImmediate(() => drainMetaInbox().catch((err) =>
     logger.error('[Meta] drain kick failed', { error: err?.message })));
+};
+
+// ── Connect Facebook: OAuth + platform callbacks ─────────────────────────
+
+const oauthEnabled = () => String(process.env.META_OAUTH_ENABLED || 'false').toLowerCase() === 'true';
+const completionUrl = () => process.env.META_OAUTH_COMPLETION_URL || 'https://redeem.sg/fb-connected';
+
+/**
+ * GET /api/meta/oauth/callback — the browser lands here from Facebook's
+ * dialog. MINIMUM work (nonce consume + sealed-code stash + worker kick in
+ * the service), then a 302 to the HTTPS completion page carrying nothing
+ * but a coarse status token (URLs leak via history/referrers).
+ */
+export const oauthCallback = async (req, res) => {
+  if (!oauthEnabled()) return res.sendStatus(404);
+  try {
+    const r = await handleOAuthCallback({
+      code: req.query.code,
+      state: req.query.state,
+      error: req.query.error,
+      errorDescription: req.query.error_description,
+    });
+    const suffix = r.redirect === 'pending' ? 's=pending' : `s=${r.redirect}${r.code ? `&c=${encodeURIComponent(r.code)}` : ''}`;
+    return res.redirect(302, `${completionUrl()}?${suffix}`);
+  } catch (err) {
+    logger.error('[Meta] oauth callback failed', { error: err?.message });
+    return res.redirect(302, `${completionUrl()}?s=error&c=internal`);
+  }
+};
+
+/** POST /api/meta/oauth/deauthorize — Meta's user-revoked-access callback (signed_request). */
+export const oauthDeauthorize = async (req, res) => {
+  if (!oauthEnabled()) return res.sendStatus(404);
+  const r = await handleDeauthorize(req.body?.signed_request);
+  if (!r.ok) return res.sendStatus(400);
+  return res.json({ success: true });
+};
+
+/** POST /api/meta/oauth/data-deletion — Meta's data-deletion request callback (signed_request). */
+export const oauthDataDeletion = async (req, res) => {
+  if (!oauthEnabled()) return res.sendStatus(404);
+  const r = await handleDataDeletion(req.body?.signed_request);
+  if (!r) return res.sendStatus(400);
+  return res.json(r);
 };
 
 // ── Admin: pages ──────────────────────────────────────────────────────────

--- a/backend/src/controllers/metaController.js
+++ b/backend/src/controllers/metaController.js
@@ -109,6 +109,9 @@ export const oauthCallback = async (req, res) => {
       error: req.query.error,
       errorDescription: req.query.error_description,
     });
+    // Unarmed subsystem = infrastructure failure, not a user outcome — 503
+    // (round-2 #7) so nothing acknowledges intake the worker can't service.
+    if (r.code === 'not_armed') return res.sendStatus(503);
     const suffix = r.redirect === 'pending' ? 's=pending' : `s=${r.redirect}${r.code ? `&c=${encodeURIComponent(r.code)}` : ''}`;
     return res.redirect(302, `${completionUrl()}?${suffix}`);
   } catch (err) {
@@ -156,6 +159,20 @@ export const upsertPage = async (req, res) => {
   if (existing && !existing.accessTokenEnc && req.body.isActive === true && !accessToken) {
     return res.status(422).json({ error: 'this page was disconnected — reactivating requires a fresh accessToken' });
   }
+  // OAuth-ownership handoff (round-2 NEW-3): reactivating an OAuth tombstone
+  // with a fresh token CONVERTS it to admin management — stale connection
+  // ownership must not let a later deauth/deletion wipe an admin page. A
+  // LIVE owner blocks the takeover entirely.
+  let ownershipClear = {};
+  if (existing && existing.connectionId && accessToken) {
+    const { MetaAgentConnection: MAC } = await import('../models/index.js');
+    const owner = await MAC.findByPk(existing.connectionId);
+    const ownerLive = owner && ['awaiting_callback', 'provisioning', 'needs_page_selection', 'waiting_for_agent', 'connected', 'reauth_required'].includes(owner.status);
+    if (ownerLive) {
+      return res.status(409).json({ error: 'this page belongs to a live agent connection — disconnect it first' });
+    }
+    ownershipClear = { connectionId: null, connectedVia: null };
+  }
   let accessTokenEnc;
   if (accessToken) {
     try {
@@ -168,6 +185,7 @@ export const upsertPage = async (req, res) => {
     ? await existing.update({
         ...(name !== undefined ? { name: String(name).slice(0, 120) } : {}),
         ...(accessTokenEnc ? { accessTokenEnc } : {}),
+        ...ownershipClear,
         isActive: req.body.isActive !== undefined ? req.body.isActive === true : existing.isActive,
       })
     : await MetaPage.create({

--- a/backend/src/controllers/metaController.js
+++ b/backend/src/controllers/metaController.js
@@ -151,6 +151,11 @@ export const upsertPage = async (req, res) => {
   if (!existing && !accessToken) {
     return res.status(400).json({ error: 'accessToken is required for a new page' });
   }
+  // Tombstone guard (review F17): an inactive row with a wiped token can
+  // only come back to life WITH a fresh token — isActive ⇒ token present.
+  if (existing && !existing.accessTokenEnc && req.body.isActive === true && !accessToken) {
+    return res.status(422).json({ error: 'this page was disconnected — reactivating requires a fresh accessToken' });
+  }
   let accessTokenEnc;
   if (accessToken) {
     try {

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -790,9 +790,12 @@ async function ensureMetaOauth() {
     logger.info('[MetaConnect] agent-ads campaign re-armed', { campaignId });
   }
 
+  const { drainMetaConnections, probeConnectionsHealth, armMetaOauth } = await import('../services/metaConnectService.js');
+  // Armed ONLY here (review F7): the server shell keeps mounted routes
+  // serving on init failure — the OAuth surface refuses until this point.
+  armMetaOauth();
   if (isTest) return; // jest drives drains manually — never leak intervals
 
-  const { drainMetaConnections, probeConnectionsHealth } = await import('../services/metaConnectService.js');
   setInterval(() => {
     drainMetaConnections().catch((err) => logger.warn('[MetaConnect] drain failed', { error: err?.message }));
   }, 60_000);

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -67,6 +67,12 @@ export async function bootstrapDatabase() {
   // silently strand webhook leads, so ensure failure is boot-fatal.
   if (String(process.env.META_LEAD_ADS_ENABLED || 'false').toLowerCase() === 'true') {
     await ensureMetaLeadAds();
+    // Connect Facebook (docs/plans/facebook-connect-self-serve.md): also
+    // boot-fatal — a mis-set agent-ads campaign would mis-route every
+    // self-serve agent's leads.
+    if (String(process.env.META_OAUTH_ENABLED || 'false').toLowerCase() === 'true') {
+      await ensureMetaOauth();
+    }
   }
 
   await safeRun('Webhook recovery', async () => {
@@ -749,4 +755,50 @@ async function ensureMetaLeadAds() {
   armMetaLeadAds();
   drainMetaInbox().catch((err) => logger.warn('[Meta] boot drain failed', { error: err?.message }));
   logger.info('[Meta] leadgen inbox worker started (30s interval)');
+}
+
+/**
+ * Connect Facebook boot (docs/plans/facebook-connect-self-serve.md §0):
+ * validate the agent-ads campaign every self-serve connection routes into,
+ * then start the provisioning worker + daily token-health probe. Called only
+ * when META_OAUTH_ENABLED (inside the META_LEAD_ADS_ENABLED block); throws on
+ * failure — boot-fatal by design.
+ */
+async function ensureMetaOauth() {
+  // Tests own their fixtures (the campaign row can only exist AFTER boot ran
+  // the migrations) — soft-skip there; production stays boot-fatal.
+  const isTest = process.env.NODE_ENV === 'test';
+  const campaignId = process.env.META_AGENT_ADS_CAMPAIGN_ID;
+  if (!campaignId) {
+    if (isTest) { logger.warn('[MetaConnect] META_AGENT_ADS_CAMPAIGN_ID unset (test) — ensure skipped'); return; }
+    throw new Error('META_OAUTH_ENABLED=true requires META_AGENT_ADS_CAMPAIGN_ID');
+  }
+  const campaign = await Campaign.findByPk(campaignId);
+  if (!campaign) {
+    if (isTest) { logger.warn('[MetaConnect] agent-ads campaign missing (test) — ensure skipped'); return; }
+    throw new Error(`META_AGENT_ADS_CAMPAIGN_ID ${campaignId} not found`);
+  }
+  // "Agents pay with ad spend": EITHER quota trigger would start charging
+  // credits per lead — both must be off, and the campaign must accept intake.
+  const drift = campaign.status !== 'active' || !campaign.is_active
+    || campaign.enforceLeadQuota !== false
+    || (Number.isInteger(campaign.leadPriceCents) && campaign.leadPriceCents > 0);
+  if (drift) {
+    await campaign.update({
+      status: 'active', is_active: true, enforceLeadQuota: false, leadPriceCents: null,
+    });
+    logger.info('[MetaConnect] agent-ads campaign re-armed', { campaignId });
+  }
+
+  if (isTest) return; // jest drives drains manually — never leak intervals
+
+  const { drainMetaConnections, probeConnectionsHealth } = await import('../services/metaConnectService.js');
+  setInterval(() => {
+    drainMetaConnections().catch((err) => logger.warn('[MetaConnect] drain failed', { error: err?.message }));
+  }, 60_000);
+  setInterval(() => {
+    probeConnectionsHealth().catch((err) => logger.warn('[MetaConnect] health probe failed', { error: err?.message }));
+  }, 6 * 3600 * 1000);
+  drainMetaConnections().catch(() => {});
+  logger.info('[MetaConnect] provisioning worker started (60s) + health probe (6h)');
 }

--- a/backend/src/database/migrations/116-meta-agent-connections.js
+++ b/backend/src/database/migrations/116-meta-agent-connections.js
@@ -1,0 +1,63 @@
+/**
+ * 116 — meta_agent_connections: the Connect-Facebook state machine
+ * (docs/plans/facebook-connect-self-serve.md §1).
+ *
+ * One row per agent OAuth journey: awaiting_callback → provisioning →
+ * needs_page_selection | waiting_for_agent → connected → reauth_required |
+ * disconnected | failed. Ownership is the LOCAL users.id (RESTRICT — a user
+ * with an active connection must disconnect first); agentMktrUserId is an
+ * audit snapshot only. stateNonce is the opaque single-use OAuth state.
+ */
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+  if (!tables.includes('meta_agent_connections')) {
+    await queryInterface.createTable('meta_agent_connections', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false },
+      userId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'RESTRICT',
+      },
+      agentMktrUserId: { type: Sequelize.STRING(64), allowNull: true },
+      status: { type: Sequelize.STRING(24), allowNull: false, defaultValue: 'awaiting_callback' },
+      statusDetail: { type: Sequelize.TEXT, allowNull: true },
+      fbUserIdAppScoped: { type: Sequelize.STRING(64), allowNull: true },
+      pageId: { type: Sequelize.STRING(64), allowNull: true },
+      metaPageRowId: { type: Sequelize.UUID, allowNull: true },
+      qrTagId: { type: Sequelize.UUID, allowNull: true },
+      formId: { type: Sequelize.STRING(64), allowNull: true },
+      mappingId: { type: Sequelize.UUID, allowNull: true },
+      stateNonce: { type: Sequelize.STRING(64), allowNull: true },
+      oauthCodeEnc: { type: Sequelize.TEXT, allowNull: true },
+      candidatePages: { type: Sequelize.JSONB, allowNull: true },
+      grantedScopes: { type: Sequelize.JSONB, allowNull: true },
+      pageTasks: { type: Sequelize.JSONB, allowNull: true },
+      leadsAccessOk: { type: Sequelize.BOOLEAN, allowNull: true },
+      attempts: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      nextAttemptAt: { type: Sequelize.DATE, allowNull: true },
+      lastError: { type: Sequelize.TEXT, allowNull: true },
+      tokenExpiresAt: { type: Sequelize.DATE, allowNull: true },
+      dataAccessExpiresAt: { type: Sequelize.DATE, allowNull: true },
+      lastTokenCheckAt: { type: Sequelize.DATE, allowNull: true },
+      connectedAt: { type: Sequelize.DATE, allowNull: true },
+      disconnectedAt: { type: Sequelize.DATE, allowNull: true },
+      disconnectReason: { type: Sequelize.STRING(64), allowNull: true },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+  const idx = (sql) => queryInterface.sequelize.query(sql);
+  await idx('CREATE UNIQUE INDEX IF NOT EXISTS uq_mac_state_nonce ON meta_agent_connections ("stateNonce") WHERE "stateNonce" IS NOT NULL');
+  // 1:1 v1 — one LIVE connection per agent, one per page.
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_mac_live_user ON meta_agent_connections ("userId")
+             WHERE status IN ('awaiting_callback','provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required')`);
+  await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_mac_live_page ON meta_agent_connections ("pageId")
+             WHERE "pageId" IS NOT NULL AND status IN ('provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required')`);
+  await idx('CREATE INDEX IF NOT EXISTS idx_mac_status_next ON meta_agent_connections (status, "nextAttemptAt")');
+  await idx('CREATE INDEX IF NOT EXISTS idx_mac_fb_user ON meta_agent_connections ("fbUserIdAppScoped")');
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP TABLE IF EXISTS meta_agent_connections');
+}

--- a/backend/src/database/migrations/116-meta-agent-connections.js
+++ b/backend/src/database/migrations/116-meta-agent-connections.js
@@ -29,7 +29,10 @@ export async function up(queryInterface, Sequelize) {
       formId: { type: Sequelize.STRING(64), allowNull: true },
       mappingId: { type: Sequelize.UUID, allowNull: true },
       stateNonce: { type: Sequelize.STRING(64), allowNull: true },
+      stateExpiresAt: { type: Sequelize.DATE, allowNull: true },
       oauthCodeEnc: { type: Sequelize.TEXT, allowNull: true },
+      secretKind: { type: Sequelize.STRING(16), allowNull: true },
+      deletionCode: { type: Sequelize.STRING(48), allowNull: true },
       candidatePages: { type: Sequelize.JSONB, allowNull: true },
       grantedScopes: { type: Sequelize.JSONB, allowNull: true },
       pageTasks: { type: Sequelize.JSONB, allowNull: true },
@@ -52,8 +55,10 @@ export async function up(queryInterface, Sequelize) {
   // 1:1 v1 — one LIVE connection per agent, one per page.
   await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_mac_live_user ON meta_agent_connections ("userId")
              WHERE status IN ('awaiting_callback','provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required')`);
+  // Page reservation (review F3): the reserve happens DURING provisioning and
+  // reauth keeps the page while awaiting — every live status holds the claim.
   await idx(`CREATE UNIQUE INDEX IF NOT EXISTS uq_mac_live_page ON meta_agent_connections ("pageId")
-             WHERE "pageId" IS NOT NULL AND status IN ('provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required')`);
+             WHERE "pageId" IS NOT NULL AND status IN ('awaiting_callback','provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required')`);
   await idx('CREATE INDEX IF NOT EXISTS idx_mac_status_next ON meta_agent_connections (status, "nextAttemptAt")');
   await idx('CREATE INDEX IF NOT EXISTS idx_mac_fb_user ON meta_agent_connections ("fbUserIdAppScoped")');
 }

--- a/backend/src/database/migrations/117-meta-pages-connection-columns.js
+++ b/backend/src/database/migrations/117-meta-pages-connection-columns.js
@@ -26,7 +26,14 @@ export async function down(queryInterface) {
   await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_meta_pages_connection');
   await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectedVia"');
   await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectionId"');
-  // Rows with a wiped token cannot re-acquire NOT NULL — leave nullability in
-  // place on down (compatible with pre-117 code, which never reads NULL rows
-  // because inactive pages are DENY).
+  // Honest rollback (review F18): NOT NULL can only be restored when no
+  // wiped-token tombstones exist — refuse loudly instead of "succeeding"
+  // while silently leaving the schema changed.
+  const [[{ count }]] = await queryInterface.sequelize.query(
+    'SELECT COUNT(*)::int AS count FROM meta_pages WHERE "accessTokenEnc" IS NULL'
+  );
+  if (count > 0) {
+    throw new Error(`117 down: ${count} meta_pages row(s) have a wiped (NULL) token — delete those tombstones first, then re-run`);
+  }
+  await queryInterface.sequelize.query('ALTER TABLE meta_pages ALTER COLUMN "accessTokenEnc" SET NOT NULL');
 }

--- a/backend/src/database/migrations/117-meta-pages-connection-columns.js
+++ b/backend/src/database/migrations/117-meta-pages-connection-columns.js
@@ -23,17 +23,20 @@ export async function up(queryInterface, Sequelize) {
 }
 
 export async function down(queryInterface) {
-  await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_meta_pages_connection');
-  await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectedVia"');
-  await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectionId"');
-  // Honest rollback (review F18): NOT NULL can only be restored when no
-  // wiped-token tombstones exist — refuse loudly instead of "succeeding"
-  // while silently leaving the schema changed.
+  // Honest rollback (review F18 + round-2 NEW-5): the refusal check runs
+  // BEFORE any DDL, and the whole rollback is one transaction — a refusal
+  // leaves the schema untouched, never half-rolled-back.
   const [[{ count }]] = await queryInterface.sequelize.query(
     'SELECT COUNT(*)::int AS count FROM meta_pages WHERE "accessTokenEnc" IS NULL'
   );
   if (count > 0) {
     throw new Error(`117 down: ${count} meta_pages row(s) have a wiped (NULL) token — delete those tombstones first, then re-run`);
   }
-  await queryInterface.sequelize.query('ALTER TABLE meta_pages ALTER COLUMN "accessTokenEnc" SET NOT NULL');
+  await queryInterface.sequelize.transaction(async (transaction) => {
+    const q = (sql) => queryInterface.sequelize.query(sql, { transaction });
+    await q('DROP INDEX IF EXISTS idx_meta_pages_connection');
+    await q('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectedVia"');
+    await q('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectionId"');
+    await q('ALTER TABLE meta_pages ALTER COLUMN "accessTokenEnc" SET NOT NULL');
+  });
 }

--- a/backend/src/database/migrations/117-meta-pages-connection-columns.js
+++ b/backend/src/database/migrations/117-meta-pages-connection-columns.js
@@ -1,0 +1,32 @@
+/**
+ * 117 — meta_pages joins the connection lifecycle
+ * (docs/plans/facebook-connect-self-serve.md §1).
+ *
+ * accessTokenEnc becomes NULLABLE: disconnect WIPES the sealed token while
+ * the row remains as an inactive tombstone — deleting the row would re-arm
+ * the single-page env fallback for that pageId, silently reviving intake.
+ * connectionId links a page to the agent connection that provisioned it.
+ */
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE meta_pages ALTER COLUMN "accessTokenEnc" DROP NOT NULL'
+  );
+  await queryInterface.sequelize.query(
+    'ALTER TABLE meta_pages ADD COLUMN IF NOT EXISTS "connectionId" UUID'
+  );
+  await queryInterface.sequelize.query(
+    "ALTER TABLE meta_pages ADD COLUMN IF NOT EXISTS \"connectedVia\" VARCHAR(16)"
+  );
+  await queryInterface.sequelize.query(
+    'CREATE INDEX IF NOT EXISTS idx_meta_pages_connection ON meta_pages ("connectionId")'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query('DROP INDEX IF EXISTS idx_meta_pages_connection');
+  await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectedVia"');
+  await queryInterface.sequelize.query('ALTER TABLE meta_pages DROP COLUMN IF EXISTS "connectionId"');
+  // Rows with a wiped token cannot re-acquire NOT NULL — leave nullability in
+  // place on down (compatible with pre-117 code, which never reads NULL rows
+  // because inactive pages are DENY).
+}

--- a/backend/src/models/MetaAgentConnection.js
+++ b/backend/src/models/MetaAgentConnection.js
@@ -35,7 +35,7 @@ const MetaAgentConnection = sequelize.define('MetaAgentConnection', {
   stateNonce: { type: DataTypes.STRING(64), allowNull: true },
   stateExpiresAt: { type: DataTypes.DATE, allowNull: true },
   oauthCodeEnc: { type: DataTypes.TEXT, allowNull: true, comment: 'sealed OAuth secret (metaPageTokens envelope, AAD=cx:<id>) — kind in secretKind; wiped at terminals' },
-  secretKind: { type: DataTypes.STRING(16), allowNull: true, validate: { isIn: [['oauth_code', 'long_token']] }, comment: 'phase of oauthCodeEnc (review F1: a code is never a token)' },
+  secretKind: { type: DataTypes.STRING(16), allowNull: true, validate: { isIn: [['oauth_code', 'exchanging', 'long_token']] }, comment: 'phase of oauthCodeEnc (F1: a code is never a token; exchanging = ambiguous-on-resume)' },
   deletionCode: { type: DataTypes.STRING(48), allowNull: true, comment: 'opaque Meta data-deletion confirmation code (never the row PK)' },
   candidatePages: { type: DataTypes.JSONB, allowNull: true },
   grantedScopes: { type: DataTypes.JSONB, allowNull: true },

--- a/backend/src/models/MetaAgentConnection.js
+++ b/backend/src/models/MetaAgentConnection.js
@@ -33,7 +33,10 @@ const MetaAgentConnection = sequelize.define('MetaAgentConnection', {
   formId: { type: DataTypes.STRING(64), allowNull: true },
   mappingId: { type: DataTypes.UUID, allowNull: true },
   stateNonce: { type: DataTypes.STRING(64), allowNull: true },
-  oauthCodeEnc: { type: DataTypes.TEXT, allowNull: true, comment: 'sealed OAuth code (metaPageTokens envelope, AAD=connection id)' },
+  stateExpiresAt: { type: DataTypes.DATE, allowNull: true },
+  oauthCodeEnc: { type: DataTypes.TEXT, allowNull: true, comment: 'sealed OAuth secret (metaPageTokens envelope, AAD=cx:<id>) — kind in secretKind; wiped at terminals' },
+  secretKind: { type: DataTypes.STRING(16), allowNull: true, validate: { isIn: [['oauth_code', 'long_token']] }, comment: 'phase of oauthCodeEnc (review F1: a code is never a token)' },
+  deletionCode: { type: DataTypes.STRING(48), allowNull: true, comment: 'opaque Meta data-deletion confirmation code (never the row PK)' },
   candidatePages: { type: DataTypes.JSONB, allowNull: true },
   grantedScopes: { type: DataTypes.JSONB, allowNull: true },
   pageTasks: { type: DataTypes.JSONB, allowNull: true },
@@ -51,6 +54,10 @@ const MetaAgentConnection = sequelize.define('MetaAgentConnection', {
   tableName: 'meta_agent_connections',
   indexes: [
     { unique: true, fields: ['stateNonce'], name: 'uq_mac_state_nonce', where: { stateNonce: { [Op.ne]: null } } },
+    // Mirrors of migration 116's partial uniques (review F18) — one live
+    // connection per agent AND per page.
+    { unique: true, fields: ['userId'], name: 'uq_mac_live_user', where: { status: { [Op.in]: MAC_LIVE_STATUSES } } },
+    { unique: true, fields: ['pageId'], name: 'uq_mac_live_page', where: { pageId: { [Op.ne]: null }, status: { [Op.in]: MAC_LIVE_STATUSES } } },
     { fields: ['status', 'nextAttemptAt'], name: 'idx_mac_status_next' },
     { fields: ['fbUserIdAppScoped'], name: 'idx_mac_fb_user' },
   ],

--- a/backend/src/models/MetaAgentConnection.js
+++ b/backend/src/models/MetaAgentConnection.js
@@ -1,0 +1,59 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Connect-Facebook state machine row
+ * (docs/plans/facebook-connect-self-serve.md §1). One live row per agent
+ * (partial unique in migration 116). LOCAL users.id is ownership;
+ * agentMktrUserId is an audit snapshot of the app-side identity.
+ */
+export const MAC_LIVE_STATUSES = Object.freeze([
+  'awaiting_callback', 'provisioning', 'needs_page_selection',
+  'waiting_for_agent', 'connected', 'reauth_required',
+]);
+export const MAC_STATUSES = Object.freeze([
+  ...MAC_LIVE_STATUSES, 'disconnected', 'failed',
+]);
+
+const MetaAgentConnection = sequelize.define('MetaAgentConnection', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  userId: { type: DataTypes.UUID, allowNull: false, references: { model: 'users', key: 'id' } },
+  agentMktrUserId: { type: DataTypes.STRING(64), allowNull: true },
+  status: {
+    type: DataTypes.STRING(24),
+    allowNull: false,
+    defaultValue: 'awaiting_callback',
+    validate: { isIn: [MAC_STATUSES] },
+  },
+  statusDetail: { type: DataTypes.TEXT, allowNull: true },
+  fbUserIdAppScoped: { type: DataTypes.STRING(64), allowNull: true },
+  pageId: { type: DataTypes.STRING(64), allowNull: true },
+  metaPageRowId: { type: DataTypes.UUID, allowNull: true },
+  qrTagId: { type: DataTypes.UUID, allowNull: true },
+  formId: { type: DataTypes.STRING(64), allowNull: true },
+  mappingId: { type: DataTypes.UUID, allowNull: true },
+  stateNonce: { type: DataTypes.STRING(64), allowNull: true },
+  oauthCodeEnc: { type: DataTypes.TEXT, allowNull: true, comment: 'sealed OAuth code (metaPageTokens envelope, AAD=connection id)' },
+  candidatePages: { type: DataTypes.JSONB, allowNull: true },
+  grantedScopes: { type: DataTypes.JSONB, allowNull: true },
+  pageTasks: { type: DataTypes.JSONB, allowNull: true },
+  leadsAccessOk: { type: DataTypes.BOOLEAN, allowNull: true },
+  attempts: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  nextAttemptAt: { type: DataTypes.DATE, allowNull: true },
+  lastError: { type: DataTypes.TEXT, allowNull: true },
+  tokenExpiresAt: { type: DataTypes.DATE, allowNull: true },
+  dataAccessExpiresAt: { type: DataTypes.DATE, allowNull: true },
+  lastTokenCheckAt: { type: DataTypes.DATE, allowNull: true },
+  connectedAt: { type: DataTypes.DATE, allowNull: true },
+  disconnectedAt: { type: DataTypes.DATE, allowNull: true },
+  disconnectReason: { type: DataTypes.STRING(64), allowNull: true },
+}, {
+  tableName: 'meta_agent_connections',
+  indexes: [
+    { unique: true, fields: ['stateNonce'], name: 'uq_mac_state_nonce', where: { stateNonce: { [Op.ne]: null } } },
+    { fields: ['status', 'nextAttemptAt'], name: 'idx_mac_status_next' },
+    { fields: ['fbUserIdAppScoped'], name: 'idx_mac_fb_user' },
+  ],
+});
+
+export default MetaAgentConnection;

--- a/backend/src/models/MetaPage.js
+++ b/backend/src/models/MetaPage.js
@@ -12,8 +12,12 @@ const MetaPage = sequelize.define('MetaPage', {
   id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
   pageId: { type: DataTypes.STRING(64), allowNull: false, comment: 'Meta page id (webhook entry.id)' },
   name: { type: DataTypes.STRING(120), allowNull: true },
-  accessTokenEnc: { type: DataTypes.TEXT, allowNull: false, comment: 'AES-256-GCM envelope (metaPageTokens.js), AAD = pageId' },
+  // NULLABLE since migration 117: disconnect WIPES the token while the row
+  // stays as an inactive tombstone (deleting it would re-arm the env fallback).
+  accessTokenEnc: { type: DataTypes.TEXT, allowNull: true, comment: 'AES-256-GCM envelope (metaPageTokens.js), AAD = pageId' },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  connectionId: { type: DataTypes.UUID, allowNull: true, comment: 'meta_agent_connections row that provisioned this page (117)' },
+  connectedVia: { type: DataTypes.STRING(16), allowNull: true, comment: "'oauth' for self-serve connects; NULL for admin-registered pages" },
 }, {
   tableName: 'meta_pages',
   indexes: [

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -342,6 +342,11 @@ function defineAssociations() {
   Campaign.hasMany(models.MetaFormMapping, { foreignKey: 'campaignId', as: 'metaFormMappings', onDelete: 'RESTRICT' });
   models.MetaFormMapping.belongsTo(Campaign, { foreignKey: 'campaignId', as: 'campaign' });
   models.MetaFormMapping.belongsTo(QrTag, { foreignKey: 'qrTagId', as: 'qrTag' });
+
+  // Connect Facebook state machine (docs/plans/facebook-connect-self-serve.md §1)
+  User.hasMany(models.MetaAgentConnection, { foreignKey: 'userId', as: 'metaConnections', onDelete: 'RESTRICT' });
+  models.MetaAgentConnection.belongsTo(User, { foreignKey: 'userId', as: 'user' });
+  models.MetaAgentConnection.belongsTo(models.MetaPage, { foreignKey: 'metaPageRowId', as: 'metaPage' });
 }
 
 defineAssociations();
@@ -388,7 +393,7 @@ export const {
   SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient,
   WaMessageStatus, WaMessageSend, ConsumerObservation, ConsumerProfile, EnrichmentJob,
   EnrichmentScoringConfig, EnrichmentSweepRun,
-  MetaPage, MetaFormMapping, MetaLeadgenEvent
+  MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/externalFacebookConnect.js
+++ b/backend/src/routes/externalFacebookConnect.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import { requireExternalHmac, facebookConnect } from '../controllers/externalFacebookConnectController.js';
+
+/**
+ * mktr-leads app broker endpoint for Connect Facebook
+ * (docs/plans/facebook-connect-self-serve.md §2). Signed raw-body POSTs only
+ * (shared requireExternalHmac gate: X-Webhook-Signature over rawBody +
+ * body.timestamp freshness). Flag-gated with the OAuth feature.
+ */
+export const meta = {
+  path: '/api/external/facebook-connect',
+  flag: 'META_OAUTH_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+router.post('/', requireExternalHmac, facebookConnect);
+
+export default router;

--- a/backend/src/routes/externalFacebookConnect.js
+++ b/backend/src/routes/externalFacebookConnect.js
@@ -7,9 +7,12 @@ import { requireExternalHmac, facebookConnect } from '../controllers/externalFac
  * (shared requireExternalHmac gate: X-Webhook-Signature over rawBody +
  * body.timestamp freshness). Flag-gated with the OAuth feature.
  */
+// Mounted with the LEAD-ADS flag (review F17): when OAuth is off the app
+// must receive a clean `{enabled:false}` from `status`, never a 404 that is
+// indistinguishable from an outage.
 export const meta = {
   path: '/api/external/facebook-connect',
-  flag: 'META_OAUTH_ENABLED',
+  flag: 'META_LEAD_ADS_ENABLED',
   flagDefault: 'false',
 };
 

--- a/backend/src/routes/meta.js
+++ b/backend/src/routes/meta.js
@@ -17,13 +17,23 @@ export const meta = {
   path: '/api/meta',
   flag: 'META_LEAD_ADS_ENABLED',
   flagDefault: 'false',
-  public: ['GET /webhook', 'POST /webhook'],
+  // OAuth trio is public by protocol (browser redirect + Meta's signed_request
+  // callbacks — verified inside the handlers); all three 404 unless
+  // META_OAUTH_ENABLED is also on.
+  public: [
+    'GET /webhook', 'POST /webhook',
+    'GET /oauth/callback', 'POST /oauth/deauthorize', 'POST /oauth/data-deletion',
+  ],
 };
 
 const router = express.Router();
 
 router.get('/webhook', metaController.verifyWebhook);
 router.post('/webhook', metaController.handleWebhook);
+
+router.get('/oauth/callback', metaController.oauthCallback);
+router.post('/oauth/deauthorize', metaController.oauthDeauthorize);
+router.post('/oauth/data-deletion', metaController.oauthDataDeletion);
 
 router.post('/pages', authenticateToken, requireAdmin, metaController.upsertPage);
 router.get('/pages', authenticateToken, requireAdmin, metaController.listPages);

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -449,6 +449,16 @@ async function runSync(adapter, localIdField, startedAt) {
   try {
     if (upstreamExternalIds.length > 0) {
       // 1. Bulk-deactivate currently-active agents missing from upstream.
+      // Capture ids BEFORE the flip so live Facebook connections can be
+      // disconnected for exactly the agents this pass deactivates (review F9).
+      const toDeactivate = await User.findAll({
+        attributes: ['id'],
+        where: {
+          role: 'agent',
+          isActive: true,
+          [localIdField]: { [Op.notIn]: upstreamExternalIds, [Op.ne]: null },
+        },
+      });
       const [deactivatedCount] = await User.update(
         { isActive: false },
         {
@@ -460,6 +470,14 @@ async function runSync(adapter, localIdField, startedAt) {
         }
       );
       deactivated = deactivatedCount;
+      if (toDeactivate.length > 0) {
+        try {
+          const { disconnectForUsers } = await import('./metaConnectService.js');
+          await disconnectForUsers(toDeactivate.map((u) => u.id), { reason: 'agent_deactivated' });
+        } catch (err) {
+          logger.warn('[AgentSync] connection disconnect hook failed (non-fatal)', { error: err?.message });
+        }
+      }
 
       // 2. Mark fresh orphans (no prospects) for deletion. Use raw SQL
       //    for the prospect-attachment check to avoid loading every row.
@@ -479,6 +497,23 @@ async function runSync(adapter, localIdField, startedAt) {
       // 3. Hard-delete agents whose grace window expired AND still no
       //    prospects (re-check at delete time to close the read-then-delete
       //    race).
+      // Terminal-history policy (review F9): scrub disconnected/failed
+      // connection rows for delete-eligible users first, so history can never
+      // block the RESTRICT FK; a LIVE connection still blocks the delete
+      // (excluded below) until the deactivation hook has disconnected it.
+      await sequelize.query(
+        `DELETE FROM meta_agent_connections
+          WHERE status IN ('disconnected','failed')
+            AND "userId" IN (
+              SELECT id FROM users
+               WHERE role = 'agent'
+                 AND "isActive" = false
+                 AND "${localIdField}" IS NOT NULL
+                 AND "${localIdField}" NOT IN (:upstreamExternalIds)
+                 AND pending_deletion_at IS NOT NULL
+                 AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours')`,
+        { replacements: { upstreamExternalIds } }
+      );
       const [{ count: deletedCount }] = await sequelize.query(
         `WITH deleted AS (
             DELETE FROM users
@@ -490,6 +525,7 @@ async function runSync(adapter, localIdField, startedAt) {
                AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours'
                AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
                AND id NOT IN (SELECT DISTINCT "agentId" FROM wallet_ledger)
+               AND id NOT IN (SELECT DISTINCT "userId" FROM meta_agent_connections)
             RETURNING id
          )
          SELECT COUNT(*)::int AS count FROM deleted`,

--- a/backend/src/services/agentSyncService.js
+++ b/backend/src/services/agentSyncService.js
@@ -497,41 +497,40 @@ async function runSync(adapter, localIdField, startedAt) {
       // 3. Hard-delete agents whose grace window expired AND still no
       //    prospects (re-check at delete time to close the read-then-delete
       //    race).
-      // Terminal-history policy (review F9): scrub disconnected/failed
-      // connection rows for delete-eligible users first, so history can never
-      // block the RESTRICT FK; a LIVE connection still blocks the delete
-      // (excluded below) until the deactivation hook has disconnected it.
-      await sequelize.query(
-        `DELETE FROM meta_agent_connections
-          WHERE status IN ('disconnected','failed')
-            AND "userId" IN (
-              SELECT id FROM users
-               WHERE role = 'agent'
-                 AND "isActive" = false
-                 AND "${localIdField}" IS NOT NULL
-                 AND "${localIdField}" NOT IN (:upstreamExternalIds)
-                 AND pending_deletion_at IS NOT NULL
-                 AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours')`,
-        { replacements: { upstreamExternalIds } }
-      );
-      const [{ count: deletedCount }] = await sequelize.query(
-        `WITH deleted AS (
-            DELETE FROM users
-             WHERE role = 'agent'
-               AND "isActive" = false
-               AND "${localIdField}" IS NOT NULL
-               AND "${localIdField}" NOT IN (:upstreamExternalIds)
-               AND pending_deletion_at IS NOT NULL
-               AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours'
-               AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
-               AND id NOT IN (SELECT DISTINCT "agentId" FROM wallet_ledger)
-               AND id NOT IN (SELECT DISTINCT "userId" FROM meta_agent_connections)
-            RETURNING id
-         )
-         SELECT COUNT(*)::int AS count FROM deleted`,
-        { replacements: { upstreamExternalIds }, type: sequelize.QueryTypes.SELECT }
-      );
-      hardDeleted = deletedCount || 0;
+      // Terminal-history policy (review F9 + round-2 NEW-2): ONE transaction
+      // computes the EXACT delete candidates (every predicate — prospects,
+      // wallet, LIVE connections), scrubs their terminal connection history,
+      // then deletes the users. History is never erased for a user any other
+      // predicate retains, and a crash can't separate the two deletes.
+      hardDeleted = await sequelize.transaction(async (t) => {
+        const candidates = await sequelize.query(
+          `SELECT id FROM users
+            WHERE role = 'agent'
+              AND "isActive" = false
+              AND "${localIdField}" IS NOT NULL
+              AND "${localIdField}" NOT IN (:upstreamExternalIds)
+              AND pending_deletion_at IS NOT NULL
+              AND pending_deletion_at < NOW() - INTERVAL '${DELETE_GRACE_HOURS} hours'
+              AND id NOT IN (SELECT DISTINCT "assignedAgentId" FROM prospects WHERE "assignedAgentId" IS NOT NULL)
+              AND id NOT IN (SELECT DISTINCT "agentId" FROM wallet_ledger)
+              AND id NOT IN (SELECT DISTINCT "userId" FROM meta_agent_connections
+                              WHERE status IN ('awaiting_callback','provisioning','needs_page_selection','waiting_for_agent','connected','reauth_required'))
+            FOR UPDATE SKIP LOCKED`,
+          { replacements: { upstreamExternalIds }, type: sequelize.QueryTypes.SELECT, transaction: t }
+        );
+        const ids = candidates.map((c) => c.id);
+        if (ids.length === 0) return 0;
+        await sequelize.query(
+          'DELETE FROM meta_agent_connections WHERE "userId" IN (:ids) AND status IN (\'disconnected\',\'failed\')',
+          { replacements: { ids }, transaction: t }
+        );
+        const [{ count }] = await sequelize.query(
+          `WITH deleted AS (DELETE FROM users WHERE id IN (:ids) RETURNING id)
+           SELECT COUNT(*)::int AS count FROM deleted`,
+          { replacements: { ids }, type: sequelize.QueryTypes.SELECT, transaction: t }
+        );
+        return count || 0;
+      });
     }
   } catch (err) {
     logger.error(

--- a/backend/src/services/metaConnectService.js
+++ b/backend/src/services/metaConnectService.js
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { Op } from 'sequelize';
 import {
-  sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection,
+  sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection, Prospect,
 } from '../models/index.js';
 import { sealPageToken, openPageToken } from './metaPageTokens.js';
 import { makeMetaGraphClient, GraphError, redactGraphError } from './metaGraphClient.js';
@@ -10,25 +10,49 @@ import { AppError } from '../middleware/appError.js';
 import { logger } from '../utils/logger.js';
 
 /**
- * Connect-Facebook state machine (docs/plans/facebook-connect-self-serve.md).
+ * Connect-Facebook state machine
+ * (docs/plans/facebook-connect-self-serve.md + fb-connect-review-round1.md).
  *
  * Journey: awaiting_callback → provisioning → (needs_page_selection |
  * waiting_for_agent) → connected → (reauth_required | disconnected | failed).
- * The public OAuth callback does the MINIMUM (consume nonce, stash sealed
- * code, kick); ALL Graph work happens here in the claim-fenced worker —
- * the leadgen-inbox pattern, reused.
  *
- * Secrets custody: the OAuth code, then (during provisioning only) the
- * long-lived USER token, live sealed in `oauthCodeEnc` (AAD = `cx:<row id>`)
- * and are WIPED at every terminal state. Steady state stores PAGE tokens
- * only, in meta_pages (existing envelope, AAD = pageId).
+ * Custody rules (F1/F2): `oauthCodeEnc` holds ONE sealed secret whose phase
+ * is `secretKind` — 'oauth_code' until the exchange, then 'long_token'
+ * persisted IMMEDIATELY (the code is single-use; any ambiguous exchange
+ * failure demands a fresh dialog, never a re-exchange). Wiped at terminals.
+ *
+ * Fencing (F4): every receipt write is a conditional UPDATE on
+ * {id, status='provisioning', attempts=claimed}; disconnect bumps attempts
+ * so an in-flight worker loses its next fence and runs asset cleanup.
+ *
+ * Reauth (F1): a previously-connected row keeps its assets live through the
+ * new dialog; denial/expiry RESTORES 'connected' — never orphans assets
+ * under 'failed'.
  */
 
 const MAX_ATTEMPTS = 8;
 const CLAIM_LEASE_MS = 5 * 60 * 1000;
+const STATE_TTL_MS = 10 * 60 * 1000;
 const LIVE = ['awaiting_callback', 'provisioning', 'needs_page_selection', 'waiting_for_agent', 'connected', 'reauth_required'];
+const REQUIRED_SCOPES = ['leads_retrieval', 'pages_show_list', 'pages_manage_metadata', 'pages_read_engagement', 'pages_manage_ads'];
+const LEAD_CAPABLE_TASKS = ['MANAGE', 'ADVERTISE'];
 
 const cxAad = (row) => `cx:${row.id}`;
+
+// ── armed latch (F7): the server shell keeps mounted routes serving even
+// when bootstrap fails — every mutating surface refuses until armed. ──
+let metaOauthArmed = false;
+export function armMetaOauth() { metaOauthArmed = true; }
+export function isMetaOauthArmed() { return metaOauthArmed; }
+export function disarmMetaOauthForTests() { metaOauthArmed = false; }
+
+function requireArmed() {
+  if (!metaOauthArmed) {
+    const err = new AppError('Facebook connect not armed', 503);
+    err.code = 'not_armed';
+    throw err;
+  }
+}
 
 export function callbackUri() {
   const origin = process.env.META_OAUTH_CALLBACK_ORIGIN || 'https://api.mktr.sg';
@@ -57,10 +81,14 @@ export function parseSignedRequest(signedRequest, secret = process.env.META_APP_
   }
 }
 
+class FenceLost extends Error {
+  constructor() { super('claim fence lost'); this.fenceLost = true; }
+}
+
 export function makeMetaConnectService(overrides = {}) {
   const graph = overrides.graph || makeMetaGraphClient(overrides.graphDeps || {});
   const d = {
-    sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection,
+    sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection, Prospect,
     sealPageToken, openPageToken,
     syncAgents: async () => (await import('./agentSyncService.js')).syncAgentsFromMktrLeads(),
     logger,
@@ -68,13 +96,12 @@ export function makeMetaConnectService(overrides = {}) {
   };
 
   const agentAdsCampaignId = () => process.env.META_AGENT_ADS_CAMPAIGN_ID || null;
+  const wasConnected = (row) => Boolean(row.connectedAt);
 
   async function resolveLocalAgent(agentMktrUserId, { allowSync = true } = {}) {
     const where = { mktrLeadsId: String(agentMktrUserId), isActive: true, role: 'agent' };
     let user = await d.User.findOne({ where });
     if (!user && allowSync) {
-      // Mirror lag: one targeted sync attempt, then re-look. Still missing is
-      // NOT "not linked" — the app-side gate already proved linkage.
       try { await d.syncAgents(); } catch (err) {
         d.logger.warn('[MetaConnect] mirror sync attempt failed', { error: err?.message });
       }
@@ -83,9 +110,10 @@ export function makeMetaConnectService(overrides = {}) {
     return user;
   }
 
-  // ── start ────────────────────────────────────────────────────────────────
+  // ── start (F8: serialized per user, expiring state) ──────────────────────
 
   async function startConnect({ agentMktrUserId }) {
+    requireArmed();
     const user = await resolveLocalAgent(agentMktrUserId);
     if (!user) {
       const err = new AppError('Agent mirror row not available yet', 503);
@@ -100,30 +128,47 @@ export function makeMetaConnectService(overrides = {}) {
       throw err;
     }
 
-    let row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: { [Op.in]: LIVE } } });
-    if (row && row.status === 'provisioning') {
-      const fresh = row.nextAttemptAt && new Date(row.nextAttemptAt).getTime() > Date.now() - CLAIM_LEASE_MS;
-      if (fresh) {
-        const err = new AppError('A connection attempt is already in progress', 409);
-        err.code = 'in_progress';
-        throw err;
-      }
-    }
-
     const nonce = crypto.randomBytes(24).toString('hex');
-    if (row) {
-      // Restart / reauth: same row, fresh journey. Receipts (qr/form/mapping)
-      // survive so re-provisioning is idempotent.
-      await row.update({
-        status: 'awaiting_callback', stateNonce: nonce, oauthCodeEnc: null,
-        attempts: 0, nextAttemptAt: null, lastError: null, statusDetail: null,
-        agentMktrUserId: String(agentMktrUserId),
+    const expires = new Date(Date.now() + STATE_TTL_MS);
+    let row;
+    try {
+      row = await d.sequelize.transaction(async (t) => {
+        const live = await d.MetaAgentConnection.findOne({
+          where: { userId: user.id, status: { [Op.in]: LIVE } },
+          lock: t.LOCK.UPDATE,
+          transaction: t,
+        });
+        if (live && live.status === 'provisioning') {
+          const fresh = live.nextAttemptAt && new Date(live.nextAttemptAt).getTime() > Date.now() - CLAIM_LEASE_MS;
+          if (fresh) {
+            const err = new AppError('A connection attempt is already in progress', 409);
+            err.code = 'in_progress';
+            throw err;
+          }
+        }
+        if (live) {
+          // Reauth / restart: receipts + pageId survive so a previously-
+          // connected agent's assets stay wired through the new dialog.
+          await live.update({
+            status: 'awaiting_callback', stateNonce: nonce, stateExpiresAt: expires,
+            oauthCodeEnc: null, secretKind: null,
+            attempts: 0, nextAttemptAt: null, lastError: null, statusDetail: null,
+            agentMktrUserId: String(agentMktrUserId),
+          }, { transaction: t });
+          return live;
+        }
+        return d.MetaAgentConnection.create({
+          userId: user.id, agentMktrUserId: String(agentMktrUserId),
+          status: 'awaiting_callback', stateNonce: nonce, stateExpiresAt: expires,
+        }, { transaction: t });
       });
-    } else {
-      row = await d.MetaAgentConnection.create({
-        userId: user.id, agentMktrUserId: String(agentMktrUserId),
-        status: 'awaiting_callback', stateNonce: nonce,
-      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        const e = new AppError('A connection attempt is already in progress', 409);
+        e.code = 'in_progress';
+        throw e;
+      }
+      throw err;
     }
 
     const params = new URLSearchParams({
@@ -136,53 +181,79 @@ export function makeMetaConnectService(overrides = {}) {
     return { startUrl: `https://www.facebook.com/dialog/oauth?${params}`, connectionId: row.id };
   }
 
-  // ── callback (public GET — MINIMUM work, no Graph calls) ─────────────────
+  // ── callback (public GET — one conditional transition, no Graph work) ────
+
+  /** Terminal for a failed dialog: restore 'connected' when assets exist. */
+  function dialogFailurePatch(row, detail) {
+    return wasConnected(row)
+      ? { status: 'connected', statusDetail: detail, stateNonce: null, stateExpiresAt: null, oauthCodeEnc: null, secretKind: null }
+      : { status: 'failed', statusDetail: detail, stateNonce: null, stateExpiresAt: null, oauthCodeEnc: null, secretKind: null };
+  }
 
   async function handleOAuthCallback({ code, state, error, errorDescription }) {
+    if (!isMetaOauthArmed()) return { redirect: 'error', code: 'not_armed' };
     if (!state) return { redirect: 'error', code: 'bad_state' };
-    // Locate by nonce, then consume ATOMICALLY by id+nonce — a concurrent
-    // duplicate callback loses the conditional update and gets bad_state.
     const row = await d.MetaAgentConnection.findOne({
       where: { stateNonce: String(state), status: 'awaiting_callback' },
     });
     if (!row) return { redirect: 'error', code: 'bad_state' };
-    const [n] = await d.MetaAgentConnection.update(
-      { stateNonce: null },
-      { where: { id: row.id, stateNonce: String(state) } }
-    );
-    if (n === 0) return { redirect: 'error', code: 'bad_state' };
-    row.stateNonce = null;
+
+    const expired = !row.stateExpiresAt || new Date(row.stateExpiresAt).getTime() < Date.now();
+    if (expired) {
+      await d.MetaAgentConnection.update(dialogFailurePatch(row, 'state_expired'), {
+        where: { id: row.id, stateNonce: String(state) },
+      });
+      return { redirect: 'error', code: 'state_expired' };
+    }
 
     if (error || !code) {
-      await row.update({
-        status: 'failed',
-        statusDetail: error === 'access_denied' ? 'user_denied' : `dialog_error:${redactGraphError(errorDescription || error || 'no_code')}`,
-        oauthCodeEnc: null,
+      const detail = error === 'access_denied' ? 'user_denied' : `dialog_error:${redactGraphError(errorDescription || error || 'no_code')}`;
+      await d.MetaAgentConnection.update(dialogFailurePatch(row, detail), {
+        where: { id: row.id, stateNonce: String(state) },
       });
       return { redirect: 'denied', code: error === 'access_denied' ? 'user_denied' : 'dialog_error' };
     }
 
-    await row.update({
+    // ONE conditional transition (F8): nonce consume + phase-tagged secret
+    // stash + provisioning flip, atomically — a raced duplicate loses.
+    const [n] = await d.MetaAgentConnection.update({
+      stateNonce: null, stateExpiresAt: null,
       status: 'provisioning',
       oauthCodeEnc: d.sealPageToken(String(code), cxAad(row)),
-      attempts: 0,
-      nextAttemptAt: null,
-      lastError: null,
+      secretKind: 'oauth_code',
+      attempts: 0, nextAttemptAt: null, lastError: null,
+    }, {
+      where: { id: row.id, stateNonce: String(state), status: 'awaiting_callback' },
     });
+    if (n === 0) return { redirect: 'error', code: 'bad_state' };
+
     setImmediate(() => drainMetaConnections().catch((err2) =>
       d.logger.error('[MetaConnect] drain kick failed', { error: err2?.message })));
     return { redirect: 'pending' };
   }
 
-  // ── worker (claim-fenced, backoff — the inbox pattern) ───────────────────
+  // ── worker plumbing (claim, fences, retry, cleanup) ──────────────────────
 
-  async function terminalize(row, patch, { transaction = null } = {}) {
+  async function fencedPatch(row, patch) {
     const [n] = await d.MetaAgentConnection.update(patch, {
       where: { id: row.id, status: 'provisioning', attempts: row.attempts },
-      transaction,
     });
-    if (n === 0) throw new GraphError('claim fence lost', { retryable: true });
+    if (n === 0) throw new FenceLost();
     Object.assign(row, patch);
+  }
+
+  /** After a lost fence: if the row was disconnected under us, deactivate
+   *  anything this run just wired so intake can't outlive the disconnect. */
+  async function cleanupAfterFenceLoss(row, receipts) {
+    const current = await d.MetaAgentConnection.findByPk(row.id).catch(() => null);
+    if (!current || current.status !== 'disconnected') return;
+    if (receipts.mappingId) {
+      await d.MetaFormMapping.update({ isActive: false }, { where: { id: receipts.mappingId } }).catch(() => {});
+    }
+    if (receipts.metaPageRowId) {
+      await d.MetaPage.update({ isActive: false, accessTokenEnc: null }, { where: { id: receipts.metaPageRowId } }).catch(() => {});
+    }
+    d.logger.warn('[MetaConnect] fence lost to disconnect — cleaned freshly wired assets', { connectionId: row.id });
   }
 
   async function claimDue(limit) {
@@ -190,7 +261,7 @@ export function makeMetaConnectService(overrides = {}) {
       const now = new Date();
       const rows = await d.MetaAgentConnection.findAll({
         where: {
-          status: 'provisioning',
+          status: { [Op.in]: ['provisioning', 'waiting_for_agent'] },
           [Op.or]: [{ nextAttemptAt: null }, { nextAttemptAt: { [Op.lte]: now } }],
         },
         order: [['createdAt', 'ASC']],
@@ -202,35 +273,59 @@ export function makeMetaConnectService(overrides = {}) {
       const claimed = [];
       for (const row of rows) {
         if (row.attempts >= MAX_ATTEMPTS) {
-          await row.update({ status: 'failed', statusDetail: 'max_attempts', oauthCodeEnc: null }, { transaction: t });
+          await row.update({
+            status: 'failed', statusDetail: 'max_attempts', oauthCodeEnc: null, secretKind: null,
+          }, { transaction: t });
           d.logger.error('[MetaConnect] provisioning failed after max attempts', { connectionId: row.id });
           continue;
         }
-        await row.update(
-          { attempts: row.attempts + 1, nextAttemptAt: new Date(now.getTime() + CLAIM_LEASE_MS) },
-          { transaction: t }
-        );
+        // waiting_for_agent re-enters the run here (F13) — never a sink.
+        await row.update({
+          status: 'provisioning',
+          attempts: row.attempts + 1,
+          nextAttemptAt: new Date(now.getTime() + CLAIM_LEASE_MS),
+        }, { transaction: t });
         claimed.push(row);
       }
       return claimed;
     });
   }
 
-  async function markRetry(row, err) {
+  async function markRetry(row, err, { waiting = false } = {}) {
     const redacted = redactGraphError(err?.message);
     if (row.attempts >= MAX_ATTEMPTS) {
       await d.MetaAgentConnection.update(
-        { status: 'failed', statusDetail: 'max_attempts', lastError: redacted, oauthCodeEnc: null },
+        { status: 'failed', statusDetail: 'max_attempts', lastError: redacted, oauthCodeEnc: null, secretKind: null },
         { where: { id: row.id, status: 'provisioning', attempts: row.attempts } }
       ).catch(() => {});
       return;
     }
-    const backoffMin = Math.min(2 ** row.attempts, 32);
+    const backoffMin = waiting ? 30 : Math.min(2 ** row.attempts, 32);
     await d.MetaAgentConnection.update(
-      { nextAttemptAt: new Date(Date.now() + backoffMin * 60_000), lastError: redacted },
+      {
+        ...(waiting ? { status: 'waiting_for_agent' } : {}),
+        nextAttemptAt: new Date(Date.now() + backoffMin * 60_000),
+        lastError: redacted,
+      },
       { where: { id: row.id, status: 'provisioning', attempts: row.attempts } }
     ).catch(() => {});
-    d.logger.warn('[MetaConnect] provisioning retry scheduled', { connectionId: row.id, attempts: row.attempts, backoffMin, error: redacted });
+    d.logger.warn('[MetaConnect] provisioning retry scheduled', {
+      connectionId: row.id, attempts: row.attempts, backoffMin, waiting, error: redacted,
+    });
+  }
+
+  /** Map a permanent GraphError to the right terminal (F16). */
+  async function graphTerminal(row, err, phase) {
+    const detail = `${phase}:graph_${err.code ?? err.kind ?? 'permanent'}`;
+    if (err.code === 190) {
+      await fencedPatch(row, {
+        status: wasConnected(row) ? 'reauth_required' : 'failed',
+        statusDetail: detail, oauthCodeEnc: null, secretKind: null,
+      });
+    } else {
+      await fencedPatch(row, { status: 'failed', statusDetail: detail, oauthCodeEnc: null, secretKind: null });
+    }
+    return { status: row.status };
   }
 
   /** Deterministic per-agent form name — the duplicate-create guard key. */
@@ -239,7 +334,14 @@ export function makeMetaConnectService(overrides = {}) {
     return `MKTR Leads — ${name}`.slice(0, 90);
   }
 
-  async function ensureMetaAgentQr({ userId, campaignId }) {
+  /** Receipt QR must still be OURS and live (F14) — else a fresh one. */
+  async function ensureMetaAgentQr({ userId, campaignId, receiptQrId }) {
+    if (receiptQrId) {
+      const qr = await d.QrTag.findByPk(receiptQrId);
+      if (qr && qr.type === 'meta_agent' && qr.active === true
+        && String(qr.assignedAgentId) === String(userId)
+        && String(qr.campaignId) === String(campaignId)) return qr;
+    }
     const existing = await d.QrTag.findOne({
       where: { campaignId, assignedAgentId: userId, type: 'meta_agent', active: true },
     });
@@ -256,95 +358,172 @@ export function makeMetaConnectService(overrides = {}) {
     });
   }
 
+  // ── the provisioning run ─────────────────────────────────────────────────
+
   async function processConnection(row) {
+    const receipts = {};
+    try {
+      return await runProvisioning(row, receipts);
+    } catch (err) {
+      if (err instanceof FenceLost) {
+        await cleanupAfterFenceLoss(row, receipts);
+        return { status: 'fence_lost' };
+      }
+      throw err;
+    }
+  }
+
+  async function runProvisioning(row, receipts) {
     const campaignId = agentAdsCampaignId();
     if (!campaignId) throw new GraphError('META_AGENT_ADS_CAMPAIGN_ID unset', { retryable: true });
 
     const user = await d.User.findOne({ where: { id: row.userId, isActive: true, role: 'agent' } });
     if (!user) {
-      await terminalize(row, { status: 'waiting_for_agent', statusDetail: 'agent_mirror_missing' });
+      // Mirror lag / deactivation (F13): waiting re-enters the claim query on
+      // a slower cadence; markRetry's cap eventually fails + wipes.
+      await markRetry(row, new Error('agent_mirror_missing'), { waiting: true });
       return { status: 'waiting_for_agent' };
     }
 
-    if (!row.oauthCodeEnc) {
-      await terminalize(row, { status: 'failed', statusDetail: 'missing_oauth_secret' });
+    if (!row.oauthCodeEnc || !row.secretKind) {
+      await fencedPatch(row, { status: 'failed', statusDetail: 'missing_oauth_secret', oauthCodeEnc: null, secretKind: null });
       return { status: 'failed' };
     }
 
-    // Exchange exactly once: the code is single-use at Meta, so the sealed
-    // slot is REPLACED by the sealed long-lived user token on first success
-    // (marked by fbUserIdAppScoped being set).
+    // ── credential phase (F1/F2) ──
     let userToken;
-    if (!row.fbUserIdAppScoped) {
+    if (row.secretKind === 'oauth_code') {
       const code = d.openPageToken(row.oauthCodeEnc, cxAad(row));
       let exchanged;
       try {
         exchanged = await graph.exchangeCodeForLongLivedToken(code, callbackUri());
       } catch (err) {
-        if (err instanceof GraphError && !err.retryable) {
-          await terminalize(row, { status: 'failed', statusDetail: `oauth_exchange:${err.code ?? 'permanent'}`, oauthCodeEnc: null });
-          return { status: 'failed' };
-        }
-        throw err;
+        // The code is single-use: ANY failure here (including an ambiguous
+        // timeout that may have consumed it) demands a fresh dialog.
+        await fencedPatch(row, {
+          status: wasConnected(row) ? 'reauth_required' : 'failed',
+          statusDetail: 'oauth_exchange_failed',
+          oauthCodeEnc: null, secretKind: null,
+        });
+        return { status: row.status };
       }
       userToken = exchanged.token;
-      const me = await graph.call('me', { token: userToken, params: { fields: 'id' } });
-      const perms = await graph.callAllPages('me/permissions', { token: userToken });
-      const granted = perms.filter((p) => p.status === 'granted').map((p) => p.permission);
-      await terminalize(row, {
-        fbUserIdAppScoped: String(me.id),
-        grantedScopes: granted,
+      // Persist the token IMMEDIATELY (F2) — before any further Graph call.
+      await fencedPatch(row, {
         oauthCodeEnc: d.sealPageToken(userToken, cxAad(row)),
+        secretKind: 'long_token',
         tokenExpiresAt: exchanged.expiresIn ? new Date(Date.now() + exchanged.expiresIn * 1000) : null,
       });
     } else {
       userToken = d.openPageToken(row.oauthCodeEnc, cxAad(row));
     }
 
-    // Pages the agent granted — full pagination, tokens NEVER stored in JSONB.
-    const pages = await graph.callAllPages('me/accounts', {
-      token: userToken, params: { fields: 'id,name,access_token,tasks' },
-    });
+    // ── identity + scopes (F10: enforced, not just stored) ──
+    let me, granted;
+    try {
+      me = await graph.call('me', { token: userToken, params: { fields: 'id' } });
+      const perms = await graph.callAllPages('me/permissions', { token: userToken });
+      granted = perms.filter((p) => p.status === 'granted').map((p) => p.permission);
+    } catch (err) {
+      if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'identity');
+      throw err;
+    }
+    const missing = REQUIRED_SCOPES.filter((s) => !granted.includes(s));
+    if (missing.length > 0) {
+      await fencedPatch(row, {
+        status: 'failed', statusDetail: `missing_permissions:${missing.join('+')}`,
+        grantedScopes: granted, oauthCodeEnc: null, secretKind: null,
+      });
+      return { status: 'failed' };
+    }
+    await fencedPatch(row, { fbUserIdAppScoped: String(me.id), grantedScopes: granted });
+
+    // ── pages ──
+    let pages;
+    try {
+      pages = await graph.callAllPages('me/accounts', {
+        token: userToken, params: { fields: 'id,name,access_token,tasks' },
+      });
+    } catch (err) {
+      if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'pages');
+      throw err;
+    }
     if (pages.length === 0) {
-      await terminalize(row, { status: 'failed', statusDetail: 'no_pages', oauthCodeEnc: null });
+      await fencedPatch(row, { status: 'failed', statusDetail: 'no_pages', oauthCodeEnc: null, secretKind: null });
       return { status: 'failed' };
     }
 
     let page = row.pageId ? pages.find((p) => String(p.id) === String(row.pageId)) : null;
     if (!page && pages.length === 1) page = pages[0];
     if (!page && !row.pageId) {
-      await terminalize(row, {
+      await fencedPatch(row, {
         status: 'needs_page_selection',
         candidatePages: pages.map((p) => ({ id: String(p.id), name: p.name })),
       });
       return { status: 'needs_page_selection' };
     }
     if (!page) {
-      await terminalize(row, { status: 'failed', statusDetail: 'page_not_granted', oauthCodeEnc: null });
+      await fencedPatch(row, { status: 'failed', statusDetail: 'page_not_granted', oauthCodeEnc: null, secretKind: null });
       return { status: 'failed' };
     }
 
-    // Usability validation (permission ≠ usable): page TOS for leadgen.
+    // ── RESERVE the page before ANY side effect (F3) ──
+    if (String(row.pageId || '') !== String(page.id)) {
+      try {
+        await fencedPatch(row, { pageId: String(page.id) });
+      } catch (err) {
+        if (err?.name === 'SequelizeUniqueConstraintError') {
+          await fencedPatch(row, { status: 'failed', statusDetail: 'page_in_use', oauthCodeEnc: null, secretKind: null });
+          return { status: 'failed' };
+        }
+        throw err;
+      }
+    }
+
+    // ── usability validation (F10) ──
+    if (Array.isArray(page.tasks) && page.tasks.length > 0
+      && !page.tasks.some((task) => LEAD_CAPABLE_TASKS.includes(String(task).toUpperCase()))) {
+      await fencedPatch(row, {
+        status: 'failed', statusDetail: 'page_task_missing', pageTasks: page.tasks,
+        oauthCodeEnc: null, secretKind: null,
+      });
+      return { status: 'failed' };
+    }
     let leadsAccessOk = null;
     try {
       const pageInfo = await graph.call(String(page.id), {
         token: page.access_token, params: { fields: 'leadgen_tos_accepted' },
       });
-      leadsAccessOk = pageInfo.leadgen_tos_accepted !== false;
       if (pageInfo.leadgen_tos_accepted === false) {
-        await terminalize(row, {
+        await fencedPatch(row, {
           status: 'failed', statusDetail: 'leadgen_tos_required',
-          pageId: String(page.id), pageTasks: page.tasks || null, leadsAccessOk: false, oauthCodeEnc: null,
+          pageTasks: page.tasks || null, leadsAccessOk: false, oauthCodeEnc: null, secretKind: null,
         });
         return { status: 'failed' };
       }
+      leadsAccessOk = pageInfo.leadgen_tos_accepted === true ? true : null;
     } catch (err) {
-      // Field drift must not brick connects — log and continue.
-      d.logger.warn('[MetaConnect] leadgen TOS check skipped', { error: redactGraphError(err?.message) });
+      if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'tos');
+      throw err; // transport errors retry — drift must not bypass the gate silently
     }
 
-    // ── idempotent wiring, receipts on the row ──
+    // ── meta_pages provenance (F3): never take over someone else's page ──
     let metaPageRow = await d.MetaPage.findOne({ where: { pageId: String(page.id) } });
+    if (metaPageRow) {
+      if (metaPageRow.connectionId && metaPageRow.connectionId !== row.id) {
+        const owner = await d.MetaAgentConnection.findByPk(metaPageRow.connectionId);
+        if (owner && LIVE.includes(owner.status)) {
+          await fencedPatch(row, { status: 'failed', statusDetail: 'page_in_use', oauthCodeEnc: null, secretKind: null });
+          return { status: 'failed' };
+        }
+      }
+      if (!metaPageRow.connectionId && !metaPageRow.connectedVia) {
+        // Admin-registered page: explicit policy — self-serve never silently
+        // takes it over (the admin can hand it off by deleting the row).
+        await fencedPatch(row, { status: 'failed', statusDetail: 'page_admin_managed', oauthCodeEnc: null, secretKind: null });
+        return { status: 'failed' };
+      }
+    }
     const sealedPageToken = d.sealPageToken(page.access_token, String(page.id));
     if (metaPageRow) {
       await metaPageRow.update({
@@ -357,69 +536,93 @@ export function makeMetaConnectService(overrides = {}) {
         isActive: true, connectionId: row.id, connectedVia: 'oauth',
       });
     }
+    receipts.metaPageRowId = metaPageRow.id;
+    await fencedPatch(row, { metaPageRowId: metaPageRow.id });
 
-    await graph.call(`${page.id}/subscribed_apps`, {
-      method: 'POST', token: page.access_token, params: { subscribed_fields: 'leadgen' },
-    });
-    const subs = await graph.call(`${page.id}/subscribed_apps`, { token: page.access_token });
-    const appId = process.env.META_APP_ID;
-    const subscribed = (subs?.data || []).some((a) => String(a.id) === String(appId));
-    if (!subscribed) throw new GraphError('subscription read-back missing our app', { retryable: true });
+    // ── subscribe + read-back ──
+    try {
+      await graph.call(`${page.id}/subscribed_apps`, {
+        method: 'POST', token: page.access_token, params: { subscribed_fields: 'leadgen' },
+      });
+      const subs = await graph.call(`${page.id}/subscribed_apps`, { token: page.access_token });
+      const subscribed = (subs?.data || []).some((a) => String(a.id) === String(process.env.META_APP_ID));
+      if (!subscribed) throw new GraphError('subscription read-back missing our app', { retryable: true });
+    } catch (err) {
+      if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'subscribe');
+      throw err;
+    }
 
-    const qr = row.qrTagId
-      ? await d.QrTag.findByPk(row.qrTagId)
-      : await ensureMetaAgentQr({ userId: user.id, campaignId });
+    // ── QR (F14 re-validated) + form + mapping ──
+    const qr = await ensureMetaAgentQr({ userId: user.id, campaignId, receiptQrId: row.qrTagId });
+    await fencedPatch(row, { qrTagId: qr.id });
 
     let formId = row.formId;
     if (!formId) {
       const wantedName = formNameFor(user);
-      const forms = await graph.callAllPages(`${page.id}/leadgen_forms`, {
-        token: page.access_token, params: { fields: 'id,name,status' },
-      });
+      let forms;
+      try {
+        forms = await graph.callAllPages(`${page.id}/leadgen_forms`, {
+          token: page.access_token, params: { fields: 'id,name,status' },
+        });
+      } catch (err) {
+        if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'forms');
+        throw err;
+      }
       const existingForm = forms.find((f) => f.name === wantedName);
       if (existingForm) {
         formId = String(existingForm.id);
       } else {
-        const created = await graph.call(`${page.id}/leadgen_forms`, {
-          method: 'POST',
-          token: page.access_token,
-          params: {
-            name: wantedName,
-            questions: JSON.stringify([{ type: 'FULL_NAME' }, { type: 'PHONE' }, { type: 'EMAIL' }]),
-            privacy_policy: JSON.stringify({ url: 'https://redeem.sg/personal-data-policy', link_text: 'Redeem Personal Data Policy' }),
-            custom_disclaimer: JSON.stringify({
-              title: 'Your consent',
-              body: { text: 'Before you submit:' },
-              checkboxes: [{ key: 'mktr_pdpa_consent', is_required: false, text: META_LEADGEN_CONTACT_COPY }],
-            }),
-            follow_up_action_url: 'https://redeem.sg',
-          },
-        });
-        formId = String(created.id);
+        try {
+          const created = await graph.call(`${page.id}/leadgen_forms`, {
+            method: 'POST',
+            token: page.access_token,
+            params: {
+              name: wantedName,
+              questions: JSON.stringify([{ type: 'FULL_NAME' }, { type: 'PHONE' }, { type: 'EMAIL' }]),
+              privacy_policy: JSON.stringify({ url: 'https://redeem.sg/personal-data-policy', link_text: 'Redeem Personal Data Policy' }),
+              custom_disclaimer: JSON.stringify({
+                title: 'Your consent',
+                body: { text: 'Before you submit:' },
+                checkboxes: [{ key: 'mktr_pdpa_consent', is_required: false, text: META_LEADGEN_CONTACT_COPY }],
+              }),
+              follow_up_action_url: 'https://redeem.sg',
+            },
+          });
+          formId = String(created.id);
+        } catch (err) {
+          if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'form_create');
+          throw err;
+        }
       }
+      await fencedPatch(row, { formId: String(formId) });
     }
 
     let mapping = await d.MetaFormMapping.findOne({ where: { formId: String(formId) } });
+    if (mapping && mapping.isActive && mapping.qrTagId && mapping.qrTagId !== qr.id) {
+      const otherQr = await d.QrTag.findByPk(mapping.qrTagId);
+      if (otherQr && otherQr.assignedAgentId && String(otherQr.assignedAgentId) !== String(user.id)) {
+        await fencedPatch(row, { status: 'failed', statusDetail: 'mapping_conflict', oauthCodeEnc: null, secretKind: null });
+        return { status: 'failed' };
+      }
+    }
     if (mapping) {
-      await mapping.update({ campaignId, qrTagId: qr?.id || null, isActive: true, formName: formNameFor(user) });
+      await mapping.update({ campaignId, qrTagId: qr.id, isActive: true, formName: formNameFor(user) });
     } else {
       mapping = await d.MetaFormMapping.create({
-        formId: String(formId), formName: formNameFor(user), campaignId, qrTagId: qr?.id || null, isActive: true,
+        formId: String(formId), formName: formNameFor(user), campaignId, qrTagId: qr.id, isActive: true,
       });
     }
+    receipts.mappingId = mapping.id;
 
-    await terminalize(row, {
+    await fencedPatch(row, {
       status: 'connected',
       connectedAt: new Date(),
-      pageId: String(page.id),
-      metaPageRowId: metaPageRow.id,
-      qrTagId: qr?.id || null,
-      formId: String(formId),
       mappingId: mapping.id,
       pageTasks: page.tasks || null,
       leadsAccessOk,
       candidatePages: null,
       oauthCodeEnc: null,
+      secretKind: null,
       lastError: null,
       statusDetail: null,
     });
@@ -456,6 +659,7 @@ export function makeMetaConnectService(overrides = {}) {
   // ── broker-facing actions ────────────────────────────────────────────────
 
   async function selectPage({ agentMktrUserId, pageId }) {
+    requireArmed();
     const user = await resolveLocalAgent(agentMktrUserId, { allowSync: false });
     if (!user) { const e = new AppError('agent not found', 503); e.code = 'agent_sync_pending'; throw e; }
     const row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: 'needs_page_selection' } });
@@ -464,26 +668,43 @@ export function makeMetaConnectService(overrides = {}) {
     if (!candidates.some((p) => String(p.id) === String(pageId))) {
       const e = new AppError('page not in the granted set', 422); e.code = 'invalid_page'; throw e;
     }
-    await row.update({ status: 'provisioning', pageId: String(pageId), attempts: 0, nextAttemptAt: null });
+    try {
+      const [n] = await d.MetaAgentConnection.update(
+        { status: 'provisioning', pageId: String(pageId), attempts: 0, nextAttemptAt: null },
+        { where: { id: row.id, status: 'needs_page_selection' } }
+      );
+      if (n === 0) { const e = new AppError('no selection pending', 409); e.code = 'no_selection_pending'; throw e; }
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        await d.MetaAgentConnection.update(
+          { status: 'failed', statusDetail: 'page_in_use', oauthCodeEnc: null, secretKind: null },
+          { where: { id: row.id } }
+        );
+        const e = new AppError('page already connected by another agent', 409); e.code = 'page_in_use'; throw e;
+      }
+      throw err;
+    }
     setImmediate(() => drainMetaConnections().catch(() => {}));
     return { ok: true };
   }
 
   async function getConnectionStatus({ agentMktrUserId }) {
     const user = await d.User.findOne({ where: { mktrLeadsId: String(agentMktrUserId) } });
-    if (!user) return { status: 'none' };
+    if (!user) return { enabled: true, status: 'none' };
     const row = await d.MetaAgentConnection.findOne({
       where: { userId: user.id },
       order: [['updatedAt', 'DESC']],
     });
-    if (!row) return { status: 'none' };
+    if (!row) return { enabled: true, status: 'none' };
     const dto = {
-      status: LIVE.includes(row.status) || ['disconnected', 'failed'].includes(row.status) ? row.status : 'none',
+      enabled: true,
+      status: row.status,
       statusDetail: row.statusDetail || null,
       pageId: row.pageId || null,
       pageName: null,
       formName: null,
       connectedAt: row.connectedAt || null,
+      lastLeadAt: null,
       needsSelection: row.status === 'needs_page_selection' ? (row.candidatePages || []) : null,
     };
     if (row.metaPageRowId) {
@@ -494,12 +715,46 @@ export function makeMetaConnectService(overrides = {}) {
       const mapping = await d.MetaFormMapping.findByPk(row.mappingId);
       dto.formName = mapping?.formName || null;
     }
+    const campaignId = agentAdsCampaignId();
+    if (campaignId && row.status === 'connected') {
+      const last = await d.Prospect.findOne({
+        where: { assignedAgentId: user.id, campaignId },
+        order: [['createdAt', 'DESC']],
+        attributes: ['createdAt'],
+      }).catch(() => null);
+      dto.lastLeadAt = last?.createdAt || null;
+    }
     return dto;
   }
 
+  /**
+   * Disconnect ordering (F11): (1) ONE txn disables local intake — status,
+   * mapping, page-inactive — while KEEPING the token; (2) best-effort remote
+   * unsubscribe with that token; (3) wipe the token. A crash mid-sequence
+   * leaves intake locally DEAD (the tombstone DENY) — never a silent
+   * Meta-side black hole. The attempts bump invalidates in-flight claims (F4).
+   */
   async function disconnectConnection(row, { reason, remote = true } = {}) {
-    // Remote unsubscribe BEFORE the token wipe (we need the token to do it);
-    // best-effort — access may already be revoked.
+    const disconnected = await d.sequelize.transaction(async (t) => {
+      const [n] = await d.MetaAgentConnection.update(
+        {
+          status: 'disconnected', disconnectedAt: new Date(), disconnectReason: reason,
+          oauthCodeEnc: null, secretKind: null, candidatePages: null,
+          attempts: d.sequelize.literal('attempts + 1'),
+        },
+        { where: { id: row.id, status: { [Op.in]: LIVE } }, transaction: t }
+      );
+      if (n === 0) return false;
+      if (row.mappingId) {
+        await d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId }, transaction: t });
+      }
+      if (row.metaPageRowId) {
+        await d.MetaPage.update({ isActive: false }, { where: { id: row.metaPageRowId }, transaction: t });
+      }
+      return true;
+    });
+    if (!disconnected) return false;
+
     if (remote && row.metaPageRowId) {
       try {
         const pageRow = await d.MetaPage.findByPk(row.metaPageRowId);
@@ -511,32 +766,33 @@ export function makeMetaConnectService(overrides = {}) {
         d.logger.warn('[MetaConnect] remote unsubscribe failed (continuing)', { error: redactGraphError(err?.message) });
       }
     }
-    await d.sequelize.transaction(async (t) => {
-      await d.MetaAgentConnection.update(
-        { status: 'disconnected', disconnectedAt: new Date(), disconnectReason: reason, oauthCodeEnc: null, candidatePages: null },
-        { where: { id: row.id }, transaction: t }
-      );
-      if (row.mappingId) {
-        await d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId }, transaction: t });
-      }
-      if (row.metaPageRowId) {
-        // Tombstone DENY: inactive + token wiped; the row must SURVIVE so the
-        // env fallback can never silently revive intake for this pageId.
-        await d.MetaPage.update(
-          { isActive: false, accessTokenEnc: null },
-          { where: { id: row.metaPageRowId }, transaction: t }
-        );
-      }
-    });
+    if (row.metaPageRowId) {
+      await d.MetaPage.update({ accessTokenEnc: null }, { where: { id: row.metaPageRowId } }).catch(() => {});
+    }
+    return true;
   }
 
   async function disconnect({ agentMktrUserId }) {
+    requireArmed();
     const user = await d.User.findOne({ where: { mktrLeadsId: String(agentMktrUserId) } });
     if (!user) { const e = new AppError('agent not found', 404); e.code = 'not_found'; throw e; }
     const row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: { [Op.in]: LIVE } } });
     if (!row) { const e = new AppError('no live connection', 404); e.code = 'not_connected'; throw e; }
     await disconnectConnection(row, { reason: 'agent_request' });
     return { ok: true };
+  }
+
+  /** Agent-sync hook (F9): deactivated/removed agents lose live connections. */
+  async function disconnectForUsers(userIds, { reason = 'agent_deactivated' } = {}) {
+    if (!Array.isArray(userIds) || userIds.length === 0) return 0;
+    const rows = await d.MetaAgentConnection.findAll({
+      where: { userId: { [Op.in]: userIds }, status: { [Op.in]: LIVE } },
+    });
+    let done = 0;
+    for (const row of rows) {
+      if (await disconnectConnection(row, { reason, remote: true })) done += 1;
+    }
+    return done;
   }
 
   // ── Meta platform callbacks ──────────────────────────────────────────────
@@ -548,27 +804,45 @@ export function makeMetaConnectService(overrides = {}) {
       where: { fbUserIdAppScoped: String(payload.user_id), status: { [Op.in]: LIVE } },
     });
     for (const row of rows) {
-      // Access is already revoked at Meta — skip the remote unsubscribe.
       await disconnectConnection(row, { reason: 'fb_deauthorized', remote: false });
     }
     return { ok: true, disconnected: rows.length };
   }
 
+  /**
+   * Data deletion (F12): scrub EVERY Facebook identifier and secret across
+   * ALL statuses, deactivate any still-active assets terminal rows point at,
+   * and answer with an OPAQUE stored confirmation code — never the row PK.
+   */
   async function handleDataDeletion(signedRequest) {
     const payload = parseSignedRequest(signedRequest);
     if (!payload?.user_id) return null;
     const rows = await d.MetaAgentConnection.findAll({
       where: { fbUserIdAppScoped: String(payload.user_id) },
     });
+    const code = crypto.randomBytes(16).toString('hex');
     for (const row of rows) {
-      if (LIVE.includes(row.status)) await disconnectConnection(row, { reason: 'fb_data_deletion', remote: false });
-      await row.update({ statusDetail: 'data_deletion', candidatePages: null, grantedScopes: null, pageTasks: null, lastError: null });
+      if (LIVE.includes(row.status)) {
+        await disconnectConnection(row, { reason: 'fb_data_deletion', remote: false });
+      } else {
+        // Terminal rows can still point at active assets — kill those too.
+        if (row.mappingId) await d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId } }).catch(() => {});
+        if (row.metaPageRowId) {
+          await d.MetaPage.update({ isActive: false, accessTokenEnc: null }, { where: { id: row.metaPageRowId } }).catch(() => {});
+        }
+      }
+      await row.update({
+        fbUserIdAppScoped: null, agentMktrUserId: null,
+        pageId: null, formId: null, mappingId: null, qrTagId: null, metaPageRowId: null,
+        oauthCodeEnc: null, secretKind: null, candidatePages: null,
+        grantedScopes: null, pageTasks: null, lastError: null,
+        statusDetail: 'data_deletion', deletionCode: code,
+      }).catch(() => {});
     }
-    const code = rows[0]?.id || crypto.randomBytes(8).toString('hex');
-    return { url: `https://redeem.sg/fb-data-deletion?code=${code}`, confirmation_code: String(code) };
+    return { url: `https://redeem.sg/fb-data-deletion?code=${code}`, confirmation_code: code };
   }
 
-  // ── daily token health probe ─────────────────────────────────────────────
+  // ── daily health probe + janitor (F17) ───────────────────────────────────
 
   async function probeConnectionsHealth({ batch = 20 } = {}) {
     const appId = process.env.META_APP_ID;
@@ -602,6 +876,14 @@ export function makeMetaConnectService(overrides = {}) {
         if (info.is_valid === false) {
           patch.status = 'reauth_required';
           patch.statusDetail = 'token_invalid';
+        } else {
+          // Subscription drift check (F17): a page whose subscription vanished
+          // silently delivers nothing — surface it as reauth_required.
+          const subs = await graph.call(`${pageRow.pageId}/subscribed_apps`, { token }).catch(() => null);
+          if (subs && !(subs.data || []).some((a) => String(a.id) === String(appId))) {
+            patch.status = 'reauth_required';
+            patch.statusDetail = 'subscription_lost';
+          }
         }
         await row.update(patch);
         probed += 1;
@@ -610,13 +892,19 @@ export function makeMetaConnectService(overrides = {}) {
         await row.update({ lastTokenCheckAt: new Date() }).catch(() => {});
       }
     }
+    // Janitor (F11): inactive pages must not retain tokens.
+    await d.MetaPage.update(
+      { accessTokenEnc: null },
+      { where: { isActive: false, accessTokenEnc: { [Op.ne]: null }, connectedVia: 'oauth' } }
+    ).catch(() => {});
     return { probed };
   }
 
   return {
     startConnect, handleOAuthCallback, drainMetaConnections, processConnection,
-    selectPage, getConnectionStatus, disconnect, handleDeauthorize,
-    handleDataDeletion, probeConnectionsHealth, ensureMetaAgentQr, formNameFor,
+    selectPage, getConnectionStatus, disconnect, disconnectForUsers,
+    handleDeauthorize, handleDataDeletion, probeConnectionsHealth,
+    ensureMetaAgentQr, formNameFor,
   };
 }
 
@@ -628,6 +916,7 @@ export const drainMetaConnections = _default.drainMetaConnections;
 export const selectPage = _default.selectPage;
 export const getConnectionStatus = _default.getConnectionStatus;
 export const disconnect = _default.disconnect;
+export const disconnectForUsers = _default.disconnectForUsers;
 export const handleDeauthorize = _default.handleDeauthorize;
 export const handleDataDeletion = _default.handleDataDeletion;
 export const probeConnectionsHealth = _default.probeConnectionsHealth;

--- a/backend/src/services/metaConnectService.js
+++ b/backend/src/services/metaConnectService.js
@@ -1,0 +1,633 @@
+import crypto from 'crypto';
+import { Op } from 'sequelize';
+import {
+  sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection,
+} from '../models/index.js';
+import { sealPageToken, openPageToken } from './metaPageTokens.js';
+import { makeMetaGraphClient, GraphError, redactGraphError } from './metaGraphClient.js';
+import { META_LEADGEN_CONTACT_COPY } from './contactConsent.js';
+import { AppError } from '../middleware/appError.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Connect-Facebook state machine (docs/plans/facebook-connect-self-serve.md).
+ *
+ * Journey: awaiting_callback → provisioning → (needs_page_selection |
+ * waiting_for_agent) → connected → (reauth_required | disconnected | failed).
+ * The public OAuth callback does the MINIMUM (consume nonce, stash sealed
+ * code, kick); ALL Graph work happens here in the claim-fenced worker —
+ * the leadgen-inbox pattern, reused.
+ *
+ * Secrets custody: the OAuth code, then (during provisioning only) the
+ * long-lived USER token, live sealed in `oauthCodeEnc` (AAD = `cx:<row id>`)
+ * and are WIPED at every terminal state. Steady state stores PAGE tokens
+ * only, in meta_pages (existing envelope, AAD = pageId).
+ */
+
+const MAX_ATTEMPTS = 8;
+const CLAIM_LEASE_MS = 5 * 60 * 1000;
+const LIVE = ['awaiting_callback', 'provisioning', 'needs_page_selection', 'waiting_for_agent', 'connected', 'reauth_required'];
+
+const cxAad = (row) => `cx:${row.id}`;
+
+export function callbackUri() {
+  const origin = process.env.META_OAUTH_CALLBACK_ORIGIN || 'https://api.mktr.sg';
+  return `${origin.replace(/\/$/, '')}/api/meta/oauth/callback`;
+}
+
+/** Verify a Meta signed_request (deauthorize / data-deletion callbacks). */
+export function parseSignedRequest(signedRequest, secret = process.env.META_APP_SECRET) {
+  if (!signedRequest || !secret) return null;
+  const [sigB64, payloadB64] = String(signedRequest).split('.', 2);
+  if (!sigB64 || !payloadB64) return null;
+  const fromB64url = (s) => Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+  const expected = crypto.createHmac('sha256', secret).update(payloadB64).digest();
+  const given = fromB64url(sigB64);
+  try {
+    if (given.length !== expected.length || !crypto.timingSafeEqual(given, expected)) return null;
+  } catch {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(fromB64url(payloadB64).toString('utf8'));
+    if (payload.algorithm && String(payload.algorithm).toUpperCase() !== 'HMAC-SHA256') return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export function makeMetaConnectService(overrides = {}) {
+  const graph = overrides.graph || makeMetaGraphClient(overrides.graphDeps || {});
+  const d = {
+    sequelize, User, Campaign, QrTag, MetaPage, MetaFormMapping, MetaAgentConnection,
+    sealPageToken, openPageToken,
+    syncAgents: async () => (await import('./agentSyncService.js')).syncAgentsFromMktrLeads(),
+    logger,
+    ...overrides,
+  };
+
+  const agentAdsCampaignId = () => process.env.META_AGENT_ADS_CAMPAIGN_ID || null;
+
+  async function resolveLocalAgent(agentMktrUserId, { allowSync = true } = {}) {
+    const where = { mktrLeadsId: String(agentMktrUserId), isActive: true, role: 'agent' };
+    let user = await d.User.findOne({ where });
+    if (!user && allowSync) {
+      // Mirror lag: one targeted sync attempt, then re-look. Still missing is
+      // NOT "not linked" — the app-side gate already proved linkage.
+      try { await d.syncAgents(); } catch (err) {
+        d.logger.warn('[MetaConnect] mirror sync attempt failed', { error: err?.message });
+      }
+      user = await d.User.findOne({ where });
+    }
+    return user;
+  }
+
+  // ── start ────────────────────────────────────────────────────────────────
+
+  async function startConnect({ agentMktrUserId }) {
+    const user = await resolveLocalAgent(agentMktrUserId);
+    if (!user) {
+      const err = new AppError('Agent mirror row not available yet', 503);
+      err.code = 'agent_sync_pending';
+      throw err;
+    }
+    const appId = process.env.META_APP_ID;
+    const configId = process.env.FB_LOGIN_CONFIG_ID;
+    if (!appId || !configId) {
+      const err = new AppError('Facebook connect not configured', 503);
+      err.code = 'not_configured';
+      throw err;
+    }
+
+    let row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: { [Op.in]: LIVE } } });
+    if (row && row.status === 'provisioning') {
+      const fresh = row.nextAttemptAt && new Date(row.nextAttemptAt).getTime() > Date.now() - CLAIM_LEASE_MS;
+      if (fresh) {
+        const err = new AppError('A connection attempt is already in progress', 409);
+        err.code = 'in_progress';
+        throw err;
+      }
+    }
+
+    const nonce = crypto.randomBytes(24).toString('hex');
+    if (row) {
+      // Restart / reauth: same row, fresh journey. Receipts (qr/form/mapping)
+      // survive so re-provisioning is idempotent.
+      await row.update({
+        status: 'awaiting_callback', stateNonce: nonce, oauthCodeEnc: null,
+        attempts: 0, nextAttemptAt: null, lastError: null, statusDetail: null,
+        agentMktrUserId: String(agentMktrUserId),
+      });
+    } else {
+      row = await d.MetaAgentConnection.create({
+        userId: user.id, agentMktrUserId: String(agentMktrUserId),
+        status: 'awaiting_callback', stateNonce: nonce,
+      });
+    }
+
+    const params = new URLSearchParams({
+      client_id: appId,
+      config_id: configId,
+      redirect_uri: callbackUri(),
+      state: nonce,
+      response_type: 'code',
+    });
+    return { startUrl: `https://www.facebook.com/dialog/oauth?${params}`, connectionId: row.id };
+  }
+
+  // ── callback (public GET — MINIMUM work, no Graph calls) ─────────────────
+
+  async function handleOAuthCallback({ code, state, error, errorDescription }) {
+    if (!state) return { redirect: 'error', code: 'bad_state' };
+    // Locate by nonce, then consume ATOMICALLY by id+nonce — a concurrent
+    // duplicate callback loses the conditional update and gets bad_state.
+    const row = await d.MetaAgentConnection.findOne({
+      where: { stateNonce: String(state), status: 'awaiting_callback' },
+    });
+    if (!row) return { redirect: 'error', code: 'bad_state' };
+    const [n] = await d.MetaAgentConnection.update(
+      { stateNonce: null },
+      { where: { id: row.id, stateNonce: String(state) } }
+    );
+    if (n === 0) return { redirect: 'error', code: 'bad_state' };
+    row.stateNonce = null;
+
+    if (error || !code) {
+      await row.update({
+        status: 'failed',
+        statusDetail: error === 'access_denied' ? 'user_denied' : `dialog_error:${redactGraphError(errorDescription || error || 'no_code')}`,
+        oauthCodeEnc: null,
+      });
+      return { redirect: 'denied', code: error === 'access_denied' ? 'user_denied' : 'dialog_error' };
+    }
+
+    await row.update({
+      status: 'provisioning',
+      oauthCodeEnc: d.sealPageToken(String(code), cxAad(row)),
+      attempts: 0,
+      nextAttemptAt: null,
+      lastError: null,
+    });
+    setImmediate(() => drainMetaConnections().catch((err2) =>
+      d.logger.error('[MetaConnect] drain kick failed', { error: err2?.message })));
+    return { redirect: 'pending' };
+  }
+
+  // ── worker (claim-fenced, backoff — the inbox pattern) ───────────────────
+
+  async function terminalize(row, patch, { transaction = null } = {}) {
+    const [n] = await d.MetaAgentConnection.update(patch, {
+      where: { id: row.id, status: 'provisioning', attempts: row.attempts },
+      transaction,
+    });
+    if (n === 0) throw new GraphError('claim fence lost', { retryable: true });
+    Object.assign(row, patch);
+  }
+
+  async function claimDue(limit) {
+    return d.sequelize.transaction(async (t) => {
+      const now = new Date();
+      const rows = await d.MetaAgentConnection.findAll({
+        where: {
+          status: 'provisioning',
+          [Op.or]: [{ nextAttemptAt: null }, { nextAttemptAt: { [Op.lte]: now } }],
+        },
+        order: [['createdAt', 'ASC']],
+        limit,
+        lock: t.LOCK.UPDATE,
+        skipLocked: true,
+        transaction: t,
+      });
+      const claimed = [];
+      for (const row of rows) {
+        if (row.attempts >= MAX_ATTEMPTS) {
+          await row.update({ status: 'failed', statusDetail: 'max_attempts', oauthCodeEnc: null }, { transaction: t });
+          d.logger.error('[MetaConnect] provisioning failed after max attempts', { connectionId: row.id });
+          continue;
+        }
+        await row.update(
+          { attempts: row.attempts + 1, nextAttemptAt: new Date(now.getTime() + CLAIM_LEASE_MS) },
+          { transaction: t }
+        );
+        claimed.push(row);
+      }
+      return claimed;
+    });
+  }
+
+  async function markRetry(row, err) {
+    const redacted = redactGraphError(err?.message);
+    if (row.attempts >= MAX_ATTEMPTS) {
+      await d.MetaAgentConnection.update(
+        { status: 'failed', statusDetail: 'max_attempts', lastError: redacted, oauthCodeEnc: null },
+        { where: { id: row.id, status: 'provisioning', attempts: row.attempts } }
+      ).catch(() => {});
+      return;
+    }
+    const backoffMin = Math.min(2 ** row.attempts, 32);
+    await d.MetaAgentConnection.update(
+      { nextAttemptAt: new Date(Date.now() + backoffMin * 60_000), lastError: redacted },
+      { where: { id: row.id, status: 'provisioning', attempts: row.attempts } }
+    ).catch(() => {});
+    d.logger.warn('[MetaConnect] provisioning retry scheduled', { connectionId: row.id, attempts: row.attempts, backoffMin, error: redacted });
+  }
+
+  /** Deterministic per-agent form name — the duplicate-create guard key. */
+  function formNameFor(user) {
+    const name = [user.firstName, user.lastName].filter(Boolean).join(' ').trim() || 'Agent';
+    return `MKTR Leads — ${name}`.slice(0, 90);
+  }
+
+  async function ensureMetaAgentQr({ userId, campaignId }) {
+    const existing = await d.QrTag.findOne({
+      where: { campaignId, assignedAgentId: userId, type: 'meta_agent', active: true },
+    });
+    if (existing) return existing;
+    return d.QrTag.create({
+      slug: `meta-${crypto.randomBytes(4).toString('hex')}`,
+      label: 'Meta ads — agent routing',
+      type: 'meta_agent',
+      campaignId,
+      ownerUserId: userId,
+      assignedAgentId: userId,
+      active: true,
+      agentAssignmentMode: 'direct',
+    });
+  }
+
+  async function processConnection(row) {
+    const campaignId = agentAdsCampaignId();
+    if (!campaignId) throw new GraphError('META_AGENT_ADS_CAMPAIGN_ID unset', { retryable: true });
+
+    const user = await d.User.findOne({ where: { id: row.userId, isActive: true, role: 'agent' } });
+    if (!user) {
+      await terminalize(row, { status: 'waiting_for_agent', statusDetail: 'agent_mirror_missing' });
+      return { status: 'waiting_for_agent' };
+    }
+
+    if (!row.oauthCodeEnc) {
+      await terminalize(row, { status: 'failed', statusDetail: 'missing_oauth_secret' });
+      return { status: 'failed' };
+    }
+
+    // Exchange exactly once: the code is single-use at Meta, so the sealed
+    // slot is REPLACED by the sealed long-lived user token on first success
+    // (marked by fbUserIdAppScoped being set).
+    let userToken;
+    if (!row.fbUserIdAppScoped) {
+      const code = d.openPageToken(row.oauthCodeEnc, cxAad(row));
+      let exchanged;
+      try {
+        exchanged = await graph.exchangeCodeForLongLivedToken(code, callbackUri());
+      } catch (err) {
+        if (err instanceof GraphError && !err.retryable) {
+          await terminalize(row, { status: 'failed', statusDetail: `oauth_exchange:${err.code ?? 'permanent'}`, oauthCodeEnc: null });
+          return { status: 'failed' };
+        }
+        throw err;
+      }
+      userToken = exchanged.token;
+      const me = await graph.call('me', { token: userToken, params: { fields: 'id' } });
+      const perms = await graph.callAllPages('me/permissions', { token: userToken });
+      const granted = perms.filter((p) => p.status === 'granted').map((p) => p.permission);
+      await terminalize(row, {
+        fbUserIdAppScoped: String(me.id),
+        grantedScopes: granted,
+        oauthCodeEnc: d.sealPageToken(userToken, cxAad(row)),
+        tokenExpiresAt: exchanged.expiresIn ? new Date(Date.now() + exchanged.expiresIn * 1000) : null,
+      });
+    } else {
+      userToken = d.openPageToken(row.oauthCodeEnc, cxAad(row));
+    }
+
+    // Pages the agent granted — full pagination, tokens NEVER stored in JSONB.
+    const pages = await graph.callAllPages('me/accounts', {
+      token: userToken, params: { fields: 'id,name,access_token,tasks' },
+    });
+    if (pages.length === 0) {
+      await terminalize(row, { status: 'failed', statusDetail: 'no_pages', oauthCodeEnc: null });
+      return { status: 'failed' };
+    }
+
+    let page = row.pageId ? pages.find((p) => String(p.id) === String(row.pageId)) : null;
+    if (!page && pages.length === 1) page = pages[0];
+    if (!page && !row.pageId) {
+      await terminalize(row, {
+        status: 'needs_page_selection',
+        candidatePages: pages.map((p) => ({ id: String(p.id), name: p.name })),
+      });
+      return { status: 'needs_page_selection' };
+    }
+    if (!page) {
+      await terminalize(row, { status: 'failed', statusDetail: 'page_not_granted', oauthCodeEnc: null });
+      return { status: 'failed' };
+    }
+
+    // Usability validation (permission ≠ usable): page TOS for leadgen.
+    let leadsAccessOk = null;
+    try {
+      const pageInfo = await graph.call(String(page.id), {
+        token: page.access_token, params: { fields: 'leadgen_tos_accepted' },
+      });
+      leadsAccessOk = pageInfo.leadgen_tos_accepted !== false;
+      if (pageInfo.leadgen_tos_accepted === false) {
+        await terminalize(row, {
+          status: 'failed', statusDetail: 'leadgen_tos_required',
+          pageId: String(page.id), pageTasks: page.tasks || null, leadsAccessOk: false, oauthCodeEnc: null,
+        });
+        return { status: 'failed' };
+      }
+    } catch (err) {
+      // Field drift must not brick connects — log and continue.
+      d.logger.warn('[MetaConnect] leadgen TOS check skipped', { error: redactGraphError(err?.message) });
+    }
+
+    // ── idempotent wiring, receipts on the row ──
+    let metaPageRow = await d.MetaPage.findOne({ where: { pageId: String(page.id) } });
+    const sealedPageToken = d.sealPageToken(page.access_token, String(page.id));
+    if (metaPageRow) {
+      await metaPageRow.update({
+        accessTokenEnc: sealedPageToken, isActive: true, name: page.name,
+        connectionId: row.id, connectedVia: 'oauth',
+      });
+    } else {
+      metaPageRow = await d.MetaPage.create({
+        pageId: String(page.id), name: page.name, accessTokenEnc: sealedPageToken,
+        isActive: true, connectionId: row.id, connectedVia: 'oauth',
+      });
+    }
+
+    await graph.call(`${page.id}/subscribed_apps`, {
+      method: 'POST', token: page.access_token, params: { subscribed_fields: 'leadgen' },
+    });
+    const subs = await graph.call(`${page.id}/subscribed_apps`, { token: page.access_token });
+    const appId = process.env.META_APP_ID;
+    const subscribed = (subs?.data || []).some((a) => String(a.id) === String(appId));
+    if (!subscribed) throw new GraphError('subscription read-back missing our app', { retryable: true });
+
+    const qr = row.qrTagId
+      ? await d.QrTag.findByPk(row.qrTagId)
+      : await ensureMetaAgentQr({ userId: user.id, campaignId });
+
+    let formId = row.formId;
+    if (!formId) {
+      const wantedName = formNameFor(user);
+      const forms = await graph.callAllPages(`${page.id}/leadgen_forms`, {
+        token: page.access_token, params: { fields: 'id,name,status' },
+      });
+      const existingForm = forms.find((f) => f.name === wantedName);
+      if (existingForm) {
+        formId = String(existingForm.id);
+      } else {
+        const created = await graph.call(`${page.id}/leadgen_forms`, {
+          method: 'POST',
+          token: page.access_token,
+          params: {
+            name: wantedName,
+            questions: JSON.stringify([{ type: 'FULL_NAME' }, { type: 'PHONE' }, { type: 'EMAIL' }]),
+            privacy_policy: JSON.stringify({ url: 'https://redeem.sg/personal-data-policy', link_text: 'Redeem Personal Data Policy' }),
+            custom_disclaimer: JSON.stringify({
+              title: 'Your consent',
+              body: { text: 'Before you submit:' },
+              checkboxes: [{ key: 'mktr_pdpa_consent', is_required: false, text: META_LEADGEN_CONTACT_COPY }],
+            }),
+            follow_up_action_url: 'https://redeem.sg',
+          },
+        });
+        formId = String(created.id);
+      }
+    }
+
+    let mapping = await d.MetaFormMapping.findOne({ where: { formId: String(formId) } });
+    if (mapping) {
+      await mapping.update({ campaignId, qrTagId: qr?.id || null, isActive: true, formName: formNameFor(user) });
+    } else {
+      mapping = await d.MetaFormMapping.create({
+        formId: String(formId), formName: formNameFor(user), campaignId, qrTagId: qr?.id || null, isActive: true,
+      });
+    }
+
+    await terminalize(row, {
+      status: 'connected',
+      connectedAt: new Date(),
+      pageId: String(page.id),
+      metaPageRowId: metaPageRow.id,
+      qrTagId: qr?.id || null,
+      formId: String(formId),
+      mappingId: mapping.id,
+      pageTasks: page.tasks || null,
+      leadsAccessOk,
+      candidatePages: null,
+      oauthCodeEnc: null,
+      lastError: null,
+      statusDetail: null,
+    });
+    d.logger.info('[MetaConnect] agent connected', {
+      connectionId: row.id, userId: user.id, pageId: String(page.id), formId,
+    });
+    return { status: 'connected' };
+  }
+
+  let draining = false;
+  async function drainMetaConnections({ batchSize = 5, maxBatches = 4 } = {}) {
+    if (draining) return { drained: 0, note: 'already draining' };
+    draining = true;
+    let drained = 0;
+    try {
+      for (let i = 0; i < maxBatches; i += 1) {
+        const rows = await claimDue(batchSize);
+        if (rows.length === 0) break;
+        for (const row of rows) {
+          try {
+            await processConnection(row);
+            drained += 1;
+          } catch (err) {
+            await markRetry(row, err);
+          }
+        }
+      }
+    } finally {
+      draining = false;
+    }
+    return { drained };
+  }
+
+  // ── broker-facing actions ────────────────────────────────────────────────
+
+  async function selectPage({ agentMktrUserId, pageId }) {
+    const user = await resolveLocalAgent(agentMktrUserId, { allowSync: false });
+    if (!user) { const e = new AppError('agent not found', 503); e.code = 'agent_sync_pending'; throw e; }
+    const row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: 'needs_page_selection' } });
+    if (!row) { const e = new AppError('no selection pending', 409); e.code = 'no_selection_pending'; throw e; }
+    const candidates = Array.isArray(row.candidatePages) ? row.candidatePages : [];
+    if (!candidates.some((p) => String(p.id) === String(pageId))) {
+      const e = new AppError('page not in the granted set', 422); e.code = 'invalid_page'; throw e;
+    }
+    await row.update({ status: 'provisioning', pageId: String(pageId), attempts: 0, nextAttemptAt: null });
+    setImmediate(() => drainMetaConnections().catch(() => {}));
+    return { ok: true };
+  }
+
+  async function getConnectionStatus({ agentMktrUserId }) {
+    const user = await d.User.findOne({ where: { mktrLeadsId: String(agentMktrUserId) } });
+    if (!user) return { status: 'none' };
+    const row = await d.MetaAgentConnection.findOne({
+      where: { userId: user.id },
+      order: [['updatedAt', 'DESC']],
+    });
+    if (!row) return { status: 'none' };
+    const dto = {
+      status: LIVE.includes(row.status) || ['disconnected', 'failed'].includes(row.status) ? row.status : 'none',
+      statusDetail: row.statusDetail || null,
+      pageId: row.pageId || null,
+      pageName: null,
+      formName: null,
+      connectedAt: row.connectedAt || null,
+      needsSelection: row.status === 'needs_page_selection' ? (row.candidatePages || []) : null,
+    };
+    if (row.metaPageRowId) {
+      const pageRow = await d.MetaPage.findByPk(row.metaPageRowId);
+      dto.pageName = pageRow?.name || null;
+    }
+    if (row.mappingId) {
+      const mapping = await d.MetaFormMapping.findByPk(row.mappingId);
+      dto.formName = mapping?.formName || null;
+    }
+    return dto;
+  }
+
+  async function disconnectConnection(row, { reason, remote = true } = {}) {
+    // Remote unsubscribe BEFORE the token wipe (we need the token to do it);
+    // best-effort — access may already be revoked.
+    if (remote && row.metaPageRowId) {
+      try {
+        const pageRow = await d.MetaPage.findByPk(row.metaPageRowId);
+        if (pageRow?.accessTokenEnc) {
+          const token = d.openPageToken(pageRow.accessTokenEnc, pageRow.pageId);
+          await graph.call(`${pageRow.pageId}/subscribed_apps`, { method: 'DELETE', token });
+        }
+      } catch (err) {
+        d.logger.warn('[MetaConnect] remote unsubscribe failed (continuing)', { error: redactGraphError(err?.message) });
+      }
+    }
+    await d.sequelize.transaction(async (t) => {
+      await d.MetaAgentConnection.update(
+        { status: 'disconnected', disconnectedAt: new Date(), disconnectReason: reason, oauthCodeEnc: null, candidatePages: null },
+        { where: { id: row.id }, transaction: t }
+      );
+      if (row.mappingId) {
+        await d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId }, transaction: t });
+      }
+      if (row.metaPageRowId) {
+        // Tombstone DENY: inactive + token wiped; the row must SURVIVE so the
+        // env fallback can never silently revive intake for this pageId.
+        await d.MetaPage.update(
+          { isActive: false, accessTokenEnc: null },
+          { where: { id: row.metaPageRowId }, transaction: t }
+        );
+      }
+    });
+  }
+
+  async function disconnect({ agentMktrUserId }) {
+    const user = await d.User.findOne({ where: { mktrLeadsId: String(agentMktrUserId) } });
+    if (!user) { const e = new AppError('agent not found', 404); e.code = 'not_found'; throw e; }
+    const row = await d.MetaAgentConnection.findOne({ where: { userId: user.id, status: { [Op.in]: LIVE } } });
+    if (!row) { const e = new AppError('no live connection', 404); e.code = 'not_connected'; throw e; }
+    await disconnectConnection(row, { reason: 'agent_request' });
+    return { ok: true };
+  }
+
+  // ── Meta platform callbacks ──────────────────────────────────────────────
+
+  async function handleDeauthorize(signedRequest) {
+    const payload = parseSignedRequest(signedRequest);
+    if (!payload?.user_id) return { ok: false };
+    const rows = await d.MetaAgentConnection.findAll({
+      where: { fbUserIdAppScoped: String(payload.user_id), status: { [Op.in]: LIVE } },
+    });
+    for (const row of rows) {
+      // Access is already revoked at Meta — skip the remote unsubscribe.
+      await disconnectConnection(row, { reason: 'fb_deauthorized', remote: false });
+    }
+    return { ok: true, disconnected: rows.length };
+  }
+
+  async function handleDataDeletion(signedRequest) {
+    const payload = parseSignedRequest(signedRequest);
+    if (!payload?.user_id) return null;
+    const rows = await d.MetaAgentConnection.findAll({
+      where: { fbUserIdAppScoped: String(payload.user_id) },
+    });
+    for (const row of rows) {
+      if (LIVE.includes(row.status)) await disconnectConnection(row, { reason: 'fb_data_deletion', remote: false });
+      await row.update({ statusDetail: 'data_deletion', candidatePages: null, grantedScopes: null, pageTasks: null, lastError: null });
+    }
+    const code = rows[0]?.id || crypto.randomBytes(8).toString('hex');
+    return { url: `https://redeem.sg/fb-data-deletion?code=${code}`, confirmation_code: String(code) };
+  }
+
+  // ── daily token health probe ─────────────────────────────────────────────
+
+  async function probeConnectionsHealth({ batch = 20 } = {}) {
+    const appId = process.env.META_APP_ID;
+    const secret = process.env.META_APP_SECRET;
+    if (!appId || !secret) return { probed: 0 };
+    const appToken = `${appId}|${secret}`;
+    const stale = new Date(Date.now() - 24 * 3600 * 1000);
+    const rows = await d.MetaAgentConnection.findAll({
+      where: {
+        status: 'connected',
+        [Op.or]: [{ lastTokenCheckAt: null }, { lastTokenCheckAt: { [Op.lte]: stale } }],
+      },
+      limit: batch,
+    });
+    let probed = 0;
+    for (const row of rows) {
+      try {
+        const pageRow = row.metaPageRowId ? await d.MetaPage.findByPk(row.metaPageRowId) : null;
+        if (!pageRow?.accessTokenEnc) {
+          await row.update({ status: 'reauth_required', statusDetail: 'token_missing', lastTokenCheckAt: new Date() });
+          continue;
+        }
+        const token = d.openPageToken(pageRow.accessTokenEnc, pageRow.pageId);
+        const dbg = await graph.call('debug_token', { token: appToken, params: { input_token: token }, proof: false });
+        const info = dbg?.data || {};
+        const patch = {
+          lastTokenCheckAt: new Date(),
+          dataAccessExpiresAt: info.data_access_expires_at ? new Date(info.data_access_expires_at * 1000) : row.dataAccessExpiresAt,
+          tokenExpiresAt: info.expires_at ? (info.expires_at === 0 ? null : new Date(info.expires_at * 1000)) : row.tokenExpiresAt,
+        };
+        if (info.is_valid === false) {
+          patch.status = 'reauth_required';
+          patch.statusDetail = 'token_invalid';
+        }
+        await row.update(patch);
+        probed += 1;
+      } catch (err) {
+        d.logger.warn('[MetaConnect] health probe failed for connection', { connectionId: row.id, error: redactGraphError(err?.message) });
+        await row.update({ lastTokenCheckAt: new Date() }).catch(() => {});
+      }
+    }
+    return { probed };
+  }
+
+  return {
+    startConnect, handleOAuthCallback, drainMetaConnections, processConnection,
+    selectPage, getConnectionStatus, disconnect, handleDeauthorize,
+    handleDataDeletion, probeConnectionsHealth, ensureMetaAgentQr, formNameFor,
+  };
+}
+
+// ── default-wired exports ──
+const _default = makeMetaConnectService();
+export const startConnect = _default.startConnect;
+export const handleOAuthCallback = _default.handleOAuthCallback;
+export const drainMetaConnections = _default.drainMetaConnections;
+export const selectPage = _default.selectPage;
+export const getConnectionStatus = _default.getConnectionStatus;
+export const disconnect = _default.disconnect;
+export const handleDeauthorize = _default.handleDeauthorize;
+export const handleDataDeletion = _default.handleDataDeletion;
+export const probeConnectionsHealth = _default.probeConnectionsHealth;

--- a/backend/src/services/metaConnectService.js
+++ b/backend/src/services/metaConnectService.js
@@ -390,16 +390,18 @@ export function makeMetaConnectService(overrides = {}) {
       return { status: 'failed' };
     }
 
-    // ── credential phase (F1/F2) ──
+    // ── credential phase (F1/F2 + round-2 #2) ──
     let userToken;
     if (row.secretKind === 'oauth_code') {
       const code = d.openPageToken(row.oauthCodeEnc, cxAad(row));
+      // Mark the code CONSUMED before touching the token endpoint: a crash or
+      // lost lease during the exchange must resume as "ambiguous — fresh
+      // dialog required", never as a replay of a possibly-spent code.
+      await fencedPatch(row, { secretKind: 'exchanging' });
       let exchanged;
       try {
         exchanged = await graph.exchangeCodeForLongLivedToken(code, callbackUri());
       } catch (err) {
-        // The code is single-use: ANY failure here (including an ambiguous
-        // timeout that may have consumed it) demands a fresh dialog.
         await fencedPatch(row, {
           status: wasConnected(row) ? 'reauth_required' : 'failed',
           statusDetail: 'oauth_exchange_failed',
@@ -414,6 +416,14 @@ export function makeMetaConnectService(overrides = {}) {
         secretKind: 'long_token',
         tokenExpiresAt: exchanged.expiresIn ? new Date(Date.now() + exchanged.expiresIn * 1000) : null,
       });
+    } else if (row.secretKind === 'exchanging') {
+      // A previous run died mid-exchange — the code may or may not be spent.
+      await fencedPatch(row, {
+        status: wasConnected(row) ? 'reauth_required' : 'failed',
+        statusDetail: 'code_ambiguous',
+        oauthCodeEnc: null, secretKind: null,
+      });
+      return { status: row.status };
     } else {
       userToken = d.openPageToken(row.oauthCodeEnc, cxAad(row));
     }
@@ -481,8 +491,10 @@ export function makeMetaConnectService(overrides = {}) {
     }
 
     // ── usability validation (F10) ──
-    if (Array.isArray(page.tasks) && page.tasks.length > 0
-      && !page.tasks.some((task) => LEAD_CAPABLE_TASKS.includes(String(task).toUpperCase()))) {
+    // Round-2 #10: MISSING/empty tasks are as disqualifying as wrong ones —
+    // /me/accounts always reports tasks for real page roles.
+    if (!Array.isArray(page.tasks) || page.tasks.length === 0
+      || !page.tasks.some((task) => LEAD_CAPABLE_TASKS.includes(String(task).toUpperCase()))) {
       await fencedPatch(row, {
         status: 'failed', statusDetail: 'page_task_missing', pageTasks: page.tasks,
         oauthCodeEnc: null, secretKind: null,
@@ -676,9 +688,11 @@ export function makeMetaConnectService(overrides = {}) {
       if (n === 0) { const e = new AppError('no selection pending', 409); e.code = 'no_selection_pending'; throw e; }
     } catch (err) {
       if (err?.name === 'SequelizeUniqueConstraintError') {
+        // Status-conditioned (round-2 NEW-4): a disconnect that landed first
+        // must not be overwritten back to 'failed'.
         await d.MetaAgentConnection.update(
           { status: 'failed', statusDetail: 'page_in_use', oauthCodeEnc: null, secretKind: null },
-          { where: { id: row.id } }
+          { where: { id: row.id, status: 'needs_page_selection' } }
         );
         const e = new AppError('page already connected by another agent', 409); e.code = 'page_in_use'; throw e;
       }
@@ -755,9 +769,14 @@ export function makeMetaConnectService(overrides = {}) {
     });
     if (!disconnected) return false;
 
+    // Ownership-conditioned teardown (round-2 NEW-1): the moment our row went
+    // terminal, the page reservation is free — a reconnect can re-own this
+    // MetaPage row and store a NEW token. Every post-txn read/wipe therefore
+    // predicates on connectionId still being OURS; a takeover makes both a
+    // clean no-op instead of unsubscribing/wiping the new owner.
     if (remote && row.metaPageRowId) {
       try {
-        const pageRow = await d.MetaPage.findByPk(row.metaPageRowId);
+        const pageRow = await d.MetaPage.findOne({ where: { id: row.metaPageRowId, connectionId: row.id } });
         if (pageRow?.accessTokenEnc) {
           const token = d.openPageToken(pageRow.accessTokenEnc, pageRow.pageId);
           await graph.call(`${pageRow.pageId}/subscribed_apps`, { method: 'DELETE', token });
@@ -767,7 +786,10 @@ export function makeMetaConnectService(overrides = {}) {
       }
     }
     if (row.metaPageRowId) {
-      await d.MetaPage.update({ accessTokenEnc: null }, { where: { id: row.metaPageRowId } }).catch(() => {});
+      await d.MetaPage.update(
+        { accessTokenEnc: null },
+        { where: { id: row.metaPageRowId, connectionId: row.id } }
+      ).catch(() => {});
     }
     return true;
   }
@@ -821,23 +843,36 @@ export function makeMetaConnectService(overrides = {}) {
       where: { fbUserIdAppScoped: String(payload.user_id) },
     });
     const code = crypto.randomBytes(16).toString('hex');
+    // Round-2 #12: a scrub step that fails must be LOUD — Meta gets its
+    // confirmation either way (their contract demands a response), but a
+    // silent partial deletion is a compliance lie we refuse to tell quietly.
+    let scrubFailures = 0;
+    const attempt = async (label, fn) => {
+      try { await fn(); } catch (err) {
+        scrubFailures += 1;
+        d.logger.error('[MetaConnect] DATA-DELETION SCRUB STEP FAILED', { step: label, error: redactGraphError(err?.message) });
+      }
+    };
     for (const row of rows) {
       if (LIVE.includes(row.status)) {
-        await disconnectConnection(row, { reason: 'fb_data_deletion', remote: false });
+        await attempt('disconnect', () => disconnectConnection(row, { reason: 'fb_data_deletion', remote: false }));
       } else {
         // Terminal rows can still point at active assets — kill those too.
-        if (row.mappingId) await d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId } }).catch(() => {});
+        if (row.mappingId) await attempt('mapping', () => d.MetaFormMapping.update({ isActive: false }, { where: { id: row.mappingId } }));
         if (row.metaPageRowId) {
-          await d.MetaPage.update({ isActive: false, accessTokenEnc: null }, { where: { id: row.metaPageRowId } }).catch(() => {});
+          await attempt('page', () => d.MetaPage.update({ isActive: false, accessTokenEnc: null }, { where: { id: row.metaPageRowId } }));
         }
       }
-      await row.update({
+      await attempt('scrub', () => row.update({
         fbUserIdAppScoped: null, agentMktrUserId: null,
         pageId: null, formId: null, mappingId: null, qrTagId: null, metaPageRowId: null,
         oauthCodeEnc: null, secretKind: null, candidatePages: null,
         grantedScopes: null, pageTasks: null, lastError: null,
         statusDetail: 'data_deletion', deletionCode: code,
-      }).catch(() => {});
+      }));
+    }
+    if (scrubFailures > 0) {
+      d.logger.error('[MetaConnect] data deletion INCOMPLETE — manual follow-up required', { scrubFailures, confirmationCode: code });
     }
     return { url: `https://redeem.sg/fb-data-deletion?code=${code}`, confirmation_code: code };
   }

--- a/backend/src/services/metaGraphClient.js
+++ b/backend/src/services/metaGraphClient.js
@@ -3,15 +3,19 @@ import { logger } from '../utils/logger.js';
 
 /**
  * Minimal Graph API client for the Connect-Facebook flow
- * (docs/plans/facebook-connect-self-serve.md §0/§2.3).
+ * (docs/plans/facebook-connect-self-serve.md §0/§2.3 + review round 1).
  *
- * One place owns: the API version (env `META_GRAPH_API_VERSION`, single
- * source), strict timeouts, `appsecret_proof` on user/page-token calls, a
- * retryable-vs-permanent error taxonomy, full pagination, and token
- * redaction in every error that can be persisted or logged.
+ * Transport security (F6): access tokens travel as `Authorization: Bearer`
+ * headers, OAuth exchanges as POST form bodies — credentials NEVER ride the
+ * URL, so pino/Sentry URL logging can't capture them (only appsecret_proof —
+ * a non-reusable HMAC — remains a query param, and redactTokens masks it).
+ * Pagination (F15): `paging.next` is host-validated and re-issued through
+ * this client (token + proof re-applied); overflowing the page cap THROWS —
+ * never a silent partial result.
  */
 
 const FETCH_TIMEOUT_MS = 10_000;
+const GRAPH_HOST = 'graph.facebook.com';
 
 export function graphVersion() {
   return process.env.META_GRAPH_API_VERSION || 'v23.0';
@@ -21,18 +25,21 @@ export function redactGraphError(message) {
   return String(message || '')
     .replace(/access_token=[^&\s]+/gi, 'access_token=REDACTED')
     .replace(/appsecret_proof=[^&\s]+/gi, 'appsecret_proof=REDACTED')
+    .replace(/fb_exchange_token=[^&\s]+/gi, 'fb_exchange_token=REDACTED')
+    .replace(/client_secret=[^&\s]+/gi, 'client_secret=REDACTED')
     .replace(/code=[^&\s]+/gi, 'code=REDACTED')
     .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer REDACTED')
     .slice(0, 500);
 }
 
 export class GraphError extends Error {
-  constructor(message, { retryable = true, status = null, code = null, subcode = null } = {}) {
+  constructor(message, { retryable = true, status = null, code = null, subcode = null, kind = null } = {}) {
     super(redactGraphError(message));
     this.retryable = retryable;
     this.status = status;
     this.code = code;
     this.subcode = subcode;
+    this.kind = kind; // e.g. 'pagination_overflow' — stable taxonomy handles
   }
 }
 
@@ -49,93 +56,121 @@ export function makeMetaGraphClient(overrides = {}) {
     ...overrides,
   };
 
-  async function call(path, { method = 'GET', token = null, params = {}, proof = true } = {}) {
-    const qs = new URLSearchParams();
-    for (const [k, v] of Object.entries(params)) {
-      if (v !== undefined && v !== null) qs.set(k, String(v));
-    }
-    if (token) {
-      qs.set('access_token', token);
-      const p = proof ? appsecretProof(token) : null;
-      if (p) qs.set('appsecret_proof', p);
-    }
-    const url = `https://graph.facebook.com/${graphVersion()}/${path}${qs.size ? `?${qs}` : ''}`;
-
+  async function rawFetch(url, init) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
       let response;
       try {
-        response = await d.fetch(url, { method, signal: controller.signal });
+        response = await d.fetch(url, { ...init, signal: controller.signal });
       } catch (err) {
         throw new GraphError(`Graph fetch failed: ${err.message}`, { retryable: true });
       }
       // Body consumed inside the abort window (the leadgen-inbox lesson).
-      let body;
+      let body = null;
       try {
         body = await response.json();
       } catch (err) {
         if (response.ok) throw new GraphError(`Graph body read failed: ${err.message}`, { retryable: true });
-        body = null;
       }
-      if (response.ok) return body;
-
-      const fbError = body?.error || {};
-      // Permanent (fix requires a HUMAN act, retrying cannot help): OAuth
-      // errors where the user/permission/token is the problem. Everything
-      // else (rate limits, 5xx, transient code 2) retries with backoff.
-      const permanent =
-        response.status === 404
-        || (fbError.type === 'OAuthException' && [100, 190, 102, 10].includes(fbError.code));
-      throw new GraphError(
-        `Graph ${response.status} code=${fbError.code ?? '?'} sub=${fbError.error_subcode ?? '?'}: ${fbError.message || 'unknown'}`,
-        { retryable: !permanent, status: response.status, code: fbError.code ?? null, subcode: fbError.error_subcode ?? null }
-      );
+      return { response, body };
     } finally {
       clearTimeout(timer);
     }
   }
 
-  /** Follow `paging.next` to exhaustion (bounded — Meta pages are small). */
-  async function callAllPages(path, opts = {}, { maxPages = 20 } = {}) {
-    const out = [];
-    let body = await call(path, opts);
-    for (let i = 0; i < maxPages; i += 1) {
-      out.push(...(body?.data || []));
-      const next = body?.paging?.next;
-      if (!next) break;
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-      try {
-        let response;
-        try {
-          response = await d.fetch(next, { signal: controller.signal });
-        } catch (err) {
-          throw new GraphError(`Graph pagination failed: ${err.message}`, { retryable: true });
-        }
-        body = await response.json().catch(() => null);
-        if (!response.ok) {
-          throw new GraphError(`Graph pagination ${response.status}`, { retryable: response.status >= 500 || response.status === 429 });
-        }
-      } finally {
-        clearTimeout(timer);
-      }
-    }
-    return out;
+  function throwGraphError(response, body) {
+    const fbError = body?.error || {};
+    // Permanent = a HUMAN act is needed (re-auth, permission, TOS). 190 =
+    // token dead; 10/102 = permission; 100 = bad request/param — permanent
+    // for WRITE/OAuth ops. Callers with softer semantics (e.g. reads that an
+    // operator can fix) override via their own catch on `.code`.
+    const permanent =
+      response.status === 404
+      || (fbError.type === 'OAuthException' && [100, 190, 102, 10].includes(fbError.code));
+    throw new GraphError(
+      `Graph ${response.status} code=${fbError.code ?? '?'} sub=${fbError.error_subcode ?? '?'}: ${fbError.message || 'unknown'}`,
+      { retryable: !permanent, status: response.status, code: fbError.code ?? null, subcode: fbError.error_subcode ?? null }
+    );
   }
 
-  /** OAuth code → short-lived user token → long-lived user token. */
+  /**
+   * options: { method, token, params (query), formBody (POST form — for
+   * OAuth exchanges), proof }. Tokens go to the Authorization header; only
+   * proof (non-reusable) is a query param.
+   */
+  async function call(path, { method = 'GET', token = null, params = {}, formBody = null, proof = true } = {}) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== null) qs.set(k, String(v));
+    }
+    const headers = {};
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+      const p = proof ? appsecretProof(token) : null;
+      if (p) qs.set('appsecret_proof', p);
+    }
+    let bodyInit;
+    if (formBody) {
+      const form = new URLSearchParams();
+      for (const [k, v] of Object.entries(formBody)) {
+        if (v !== undefined && v !== null) form.set(k, String(v));
+      }
+      headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      bodyInit = form.toString();
+    }
+    const url = `https://${GRAPH_HOST}/${graphVersion()}/${path}${qs.size ? `?${qs}` : ''}`;
+    const { response, body } = await rawFetch(url, { method, headers, body: bodyInit });
+    if (response.ok) return body;
+    return throwGraphError(response, body);
+  }
+
+  /**
+   * Follow cursor pagination to exhaustion. `paging.next` is only TRUSTED as
+   * a signal — the actual continuation is re-issued through call() with the
+   * extracted `after` cursor (token + proof re-applied, host never followed
+   * blindly). Cap overflow THROWS (`kind: 'pagination_overflow'`).
+   */
+  async function callAllPages(path, opts = {}, { maxPages = 25 } = {}) {
+    const out = [];
+    let after = null;
+    for (let i = 0; i < maxPages; i += 1) {
+      const params = { ...(opts.params || {}), ...(after ? { after } : {}) };
+      const body = await call(path, { ...opts, params });
+      out.push(...(body?.data || []));
+      const next = body?.paging?.next;
+      const cursor = body?.paging?.cursors?.after;
+      if (!next) return out;
+      let nextUrl;
+      try { nextUrl = new URL(next); } catch { return out; }
+      if (nextUrl.protocol !== 'https:' || nextUrl.hostname !== GRAPH_HOST) {
+        throw new GraphError(`pagination next host rejected: ${nextUrl.hostname}`, { retryable: false, kind: 'pagination_host' });
+      }
+      after = cursor || nextUrl.searchParams.get('after');
+      if (!after) return out;
+    }
+    throw new GraphError(`pagination exceeded ${maxPages} pages for ${path}`, { retryable: false, kind: 'pagination_overflow' });
+  }
+
+  /**
+   * OAuth code → short-lived user token → long-lived user token.
+   * POST form bodies (credentials never in URLs). NOTE (review F2): the code
+   * is single-use at Meta — the CALLER must persist the result immediately;
+   * any ambiguous failure here means "get a fresh code", never re-exchange.
+   */
   async function exchangeCodeForLongLivedToken(code, redirectUri) {
     const appId = process.env.META_APP_ID;
     const secret = process.env.META_APP_SECRET;
     if (!appId || !secret) throw new GraphError('META_APP_ID/META_APP_SECRET not configured', { retryable: true });
     const short = await call('oauth/access_token', {
-      params: { client_id: appId, client_secret: secret, redirect_uri: redirectUri, code },
+      method: 'POST',
+      formBody: { client_id: appId, client_secret: secret, redirect_uri: redirectUri, code },
       proof: false,
     });
     if (!short?.access_token) throw new GraphError('code exchange returned no token', { retryable: false });
     const long = await call('oauth/access_token', {
-      params: {
+      method: 'POST',
+      formBody: {
         grant_type: 'fb_exchange_token',
         client_id: appId,
         client_secret: secret,
@@ -143,7 +178,7 @@ export function makeMetaGraphClient(overrides = {}) {
       },
       proof: false,
     });
-    if (!long?.access_token) throw new GraphError('long-lived exchange returned no token', { retryable: true });
+    if (!long?.access_token) throw new GraphError('long-lived exchange returned no token', { retryable: false });
     return { token: long.access_token, expiresIn: long.expires_in ?? null };
   }
 

--- a/backend/src/services/metaGraphClient.js
+++ b/backend/src/services/metaGraphClient.js
@@ -1,0 +1,156 @@
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Minimal Graph API client for the Connect-Facebook flow
+ * (docs/plans/facebook-connect-self-serve.md §0/§2.3).
+ *
+ * One place owns: the API version (env `META_GRAPH_API_VERSION`, single
+ * source), strict timeouts, `appsecret_proof` on user/page-token calls, a
+ * retryable-vs-permanent error taxonomy, full pagination, and token
+ * redaction in every error that can be persisted or logged.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+export function graphVersion() {
+  return process.env.META_GRAPH_API_VERSION || 'v23.0';
+}
+
+export function redactGraphError(message) {
+  return String(message || '')
+    .replace(/access_token=[^&\s]+/gi, 'access_token=REDACTED')
+    .replace(/appsecret_proof=[^&\s]+/gi, 'appsecret_proof=REDACTED')
+    .replace(/code=[^&\s]+/gi, 'code=REDACTED')
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer REDACTED')
+    .slice(0, 500);
+}
+
+export class GraphError extends Error {
+  constructor(message, { retryable = true, status = null, code = null, subcode = null } = {}) {
+    super(redactGraphError(message));
+    this.retryable = retryable;
+    this.status = status;
+    this.code = code;
+    this.subcode = subcode;
+  }
+}
+
+/** HMAC-SHA256(token, app secret) — Meta's server-to-server proof-of-secret. */
+export function appsecretProof(token, secret = process.env.META_APP_SECRET) {
+  if (!secret) return null;
+  return crypto.createHmac('sha256', secret).update(token).digest('hex');
+}
+
+export function makeMetaGraphClient(overrides = {}) {
+  const d = {
+    fetch: (...args) => globalThis.fetch(...args),
+    logger,
+    ...overrides,
+  };
+
+  async function call(path, { method = 'GET', token = null, params = {}, proof = true } = {}) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined && v !== null) qs.set(k, String(v));
+    }
+    if (token) {
+      qs.set('access_token', token);
+      const p = proof ? appsecretProof(token) : null;
+      if (p) qs.set('appsecret_proof', p);
+    }
+    const url = `https://graph.facebook.com/${graphVersion()}/${path}${qs.size ? `?${qs}` : ''}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      let response;
+      try {
+        response = await d.fetch(url, { method, signal: controller.signal });
+      } catch (err) {
+        throw new GraphError(`Graph fetch failed: ${err.message}`, { retryable: true });
+      }
+      // Body consumed inside the abort window (the leadgen-inbox lesson).
+      let body;
+      try {
+        body = await response.json();
+      } catch (err) {
+        if (response.ok) throw new GraphError(`Graph body read failed: ${err.message}`, { retryable: true });
+        body = null;
+      }
+      if (response.ok) return body;
+
+      const fbError = body?.error || {};
+      // Permanent (fix requires a HUMAN act, retrying cannot help): OAuth
+      // errors where the user/permission/token is the problem. Everything
+      // else (rate limits, 5xx, transient code 2) retries with backoff.
+      const permanent =
+        response.status === 404
+        || (fbError.type === 'OAuthException' && [100, 190, 102, 10].includes(fbError.code));
+      throw new GraphError(
+        `Graph ${response.status} code=${fbError.code ?? '?'} sub=${fbError.error_subcode ?? '?'}: ${fbError.message || 'unknown'}`,
+        { retryable: !permanent, status: response.status, code: fbError.code ?? null, subcode: fbError.error_subcode ?? null }
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Follow `paging.next` to exhaustion (bounded — Meta pages are small). */
+  async function callAllPages(path, opts = {}, { maxPages = 20 } = {}) {
+    const out = [];
+    let body = await call(path, opts);
+    for (let i = 0; i < maxPages; i += 1) {
+      out.push(...(body?.data || []));
+      const next = body?.paging?.next;
+      if (!next) break;
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      try {
+        let response;
+        try {
+          response = await d.fetch(next, { signal: controller.signal });
+        } catch (err) {
+          throw new GraphError(`Graph pagination failed: ${err.message}`, { retryable: true });
+        }
+        body = await response.json().catch(() => null);
+        if (!response.ok) {
+          throw new GraphError(`Graph pagination ${response.status}`, { retryable: response.status >= 500 || response.status === 429 });
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    return out;
+  }
+
+  /** OAuth code → short-lived user token → long-lived user token. */
+  async function exchangeCodeForLongLivedToken(code, redirectUri) {
+    const appId = process.env.META_APP_ID;
+    const secret = process.env.META_APP_SECRET;
+    if (!appId || !secret) throw new GraphError('META_APP_ID/META_APP_SECRET not configured', { retryable: true });
+    const short = await call('oauth/access_token', {
+      params: { client_id: appId, client_secret: secret, redirect_uri: redirectUri, code },
+      proof: false,
+    });
+    if (!short?.access_token) throw new GraphError('code exchange returned no token', { retryable: false });
+    const long = await call('oauth/access_token', {
+      params: {
+        grant_type: 'fb_exchange_token',
+        client_id: appId,
+        client_secret: secret,
+        fb_exchange_token: short.access_token,
+      },
+      proof: false,
+    });
+    if (!long?.access_token) throw new GraphError('long-lived exchange returned no token', { retryable: true });
+    return { token: long.access_token, expiresIn: long.expires_in ?? null };
+  }
+
+  return { call, callAllPages, exchangeCodeForLongLivedToken };
+}
+
+const _default = makeMetaGraphClient();
+export const graphCall = _default.call;
+export const graphCallAllPages = _default.callAllPages;
+export const exchangeCodeForLongLivedToken = _default.exchangeCodeForLongLivedToken;

--- a/backend/src/services/metaGraphClient.js
+++ b/backend/src/services/metaGraphClient.js
@@ -28,6 +28,7 @@ export function redactGraphError(message) {
     .replace(/fb_exchange_token=[^&\s]+/gi, 'fb_exchange_token=REDACTED')
     .replace(/client_secret=[^&\s]+/gi, 'client_secret=REDACTED')
     .replace(/code=[^&\s]+/gi, 'code=REDACTED')
+    .replace(/input_token=[^&\s]+/gi, 'input_token=REDACTED')
     .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer REDACTED')
     .slice(0, 500);
 }

--- a/backend/src/services/metaLeadService.js
+++ b/backend/src/services/metaLeadService.js
@@ -19,6 +19,7 @@ import {
 } from './prospectHelpers.js';
 import { sendLeadAssignmentEmail } from './mailer.js';
 import { resolvePageAccessToken } from './metaPageTokens.js';
+import { appsecretProof } from './metaGraphClient.js';
 import { META_LEADGEN_CONSENT_VERSION } from './contactConsent.js';
 import { logger } from '../utils/logger.js';
 
@@ -135,7 +136,10 @@ export function makeMetaLeadService(overrides = {}) {
   }
 
   async function fetchLeadFromGraph(leadgenId, accessToken) {
-    const url = `https://graph.facebook.com/${graphVersion()}/${leadgenId}?fields=${GRAPH_FIELDS}`;
+    // appsecret_proof (review F5): with Meta's "Require App Secret" setting
+    // on, an unproofed server call is rejected — every lead would dead-letter.
+    const proof = appsecretProof(accessToken);
+    const url = `https://graph.facebook.com/${graphVersion()}/${leadgenId}?fields=${GRAPH_FIELDS}${proof ? `&appsecret_proof=${proof}` : ''}`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     // Body consumption stays INSIDE the abort window — Meta can send headers

--- a/backend/src/utils/redactTokens.js
+++ b/backend/src/utils/redactTokens.js
@@ -24,7 +24,7 @@ const TOKEN_PATH_RE = /(\/(?:api\/reward-claim|r|api\/screening-callback|api\/re
 // (docs/plans/facebook-connect-self-serve.md §4): the FB callback carries
 // code+state; Graph URLs can carry access_token/appsecret_proof and the
 // exchange parameters. Any of these in a logged URL is a live credential.
-const TOKEN_QUERY_RE = /([?&](?:t|code|state|access_token|fb_exchange_token|client_secret|appsecret_proof|signed_request)=)[^&#\s]+/gi;
+const TOKEN_QUERY_RE = /([?&](?:t|code|state|access_token|fb_exchange_token|client_secret|appsecret_proof|input_token|signed_request)=)[^&#\s]+/gi;
 
 export function maskTokenUrl(url) {
   if (typeof url !== 'string' || url.length === 0) return url;

--- a/backend/src/utils/redactTokens.js
+++ b/backend/src/utils/redactTokens.js
@@ -20,7 +20,11 @@
  *   ?t= / &t=                                    redeem.sg/callback?t=<screening token>
  */
 const TOKEN_PATH_RE = /(\/(?:api\/reward-claim|r|api\/screening-callback|api\/redeem-ops\/discovery\/webhook|api\/auth\/(?:verify-email|reset-password|invite-info)|api\/provision\/check)\/)[^/?#\s]+/gi;
-const TOKEN_QUERY_RE = /([?&]t=)[^&#\s]+/gi;
+// ?t= (screening token) + the OAuth/Graph credential family
+// (docs/plans/facebook-connect-self-serve.md §4): the FB callback carries
+// code+state; Graph URLs can carry access_token/appsecret_proof and the
+// exchange parameters. Any of these in a logged URL is a live credential.
+const TOKEN_QUERY_RE = /([?&](?:t|code|state|access_token|fb_exchange_token|client_secret|appsecret_proof|signed_request)=)[^&#\s]+/gi;
 
 export function maskTokenUrl(url) {
   if (typeof url !== 'string' || url.length === 0) return url;

--- a/backend/test/metaConnect.test.js
+++ b/backend/test/metaConnect.test.js
@@ -193,8 +193,8 @@ describe('Connect Facebook (integration)', () => {
       }
       if (path === 'me/accounts') {
         return [
-          { id: pageA, name: 'Page A', access_token: `PT-${pageA}` },
-          { id: pageB, name: 'Page B', access_token: `PT-${pageB}` },
+          { id: pageA, name: 'Page A', access_token: `PT-${pageA}`, tasks: ['MANAGE'] },
+          { id: pageB, name: 'Page B', access_token: `PT-${pageB}`, tasks: ['MANAGE'] },
         ];
       }
       if (String(path).endsWith('/leadgen_forms')) return [];

--- a/backend/test/metaConnect.test.js
+++ b/backend/test/metaConnect.test.js
@@ -23,7 +23,7 @@ import {
   MetaAgentConnection, MetaPage, MetaFormMapping, QrTag, Prospect,
   MetaLeadgenEvent, WebhookSubscriber, WebhookDelivery,
 } from '../src/models/index.js';
-import { makeMetaConnectService } from '../src/services/metaConnectService.js';
+import { makeMetaConnectService, armMetaOauth } from '../src/services/metaConnectService.js';
 import { makeMetaLeadService } from '../src/services/metaLeadService.js';
 
 let app, admin, agent;
@@ -53,7 +53,10 @@ function stubbedGraph({ pageId, formIdOnCreate = `form-${uid()}` }) {
       return {};
     }),
     callAllPages: jest.fn(async (path) => {
-      if (path === 'me/permissions') return [{ permission: 'leads_retrieval', status: 'granted' }];
+      if (path === 'me/permissions') {
+        return ['leads_retrieval', 'pages_show_list', 'pages_manage_metadata', 'pages_read_engagement', 'pages_manage_ads']
+          .map((p) => ({ permission: p, status: 'granted' }));
+      }
       if (path === 'me/accounts') return [{ id: pageId, name: `Page ${pageId}`, access_token: `PAGETOK-${pageId}`, tasks: ['MANAGE'] }];
       if (String(path).endsWith('/leadgen_forms')) return [];
       return [];
@@ -63,6 +66,7 @@ function stubbedGraph({ pageId, formIdOnCreate = `form-${uid()}` }) {
 
 beforeAll(async () => {
   app = await getApp();
+  armMetaOauth(); // bootstrap soft-skips fixtures in test env — arm manually
   ({ user: admin } = await createTestUser({ role: 'admin' }));
   ({ user: agent } = await createTestUser({
     role: 'agent',
@@ -183,7 +187,10 @@ describe('Connect Facebook (integration)', () => {
     const pageB = `72${uid()}`.slice(0, 15);
     const graph = stubbedGraph({ pageId: pageA });
     graph.callAllPages = jest.fn(async (path) => {
-      if (path === 'me/permissions') return [];
+      if (path === 'me/permissions') {
+        return ['leads_retrieval', 'pages_show_list', 'pages_manage_metadata', 'pages_read_engagement', 'pages_manage_ads']
+          .map((p) => ({ permission: p, status: 'granted' }));
+      }
       if (path === 'me/accounts') {
         return [
           { id: pageA, name: 'Page A', access_token: `PT-${pageA}` },
@@ -217,5 +224,22 @@ describe('Connect Facebook (integration)', () => {
     row = await MetaAgentConnection.findOne({ where: { userId: agent2.id } });
     expect(row.status).toBe('connected');
     expect(row.pageId).toBe(pageB);
+
+    // ── page_in_use (review F3): a third agent granting the SAME page must
+    // terminal-fail against the live-page reservation, never wire anything.
+    const { user: agent3 } = await createTestUser({
+      role: 'agent', mktrLeadsId: '550e8400-e29b-41d4-a716-446655440999',
+      firstName: 'Late', lastName: 'Claimer',
+    });
+    const svc3 = makeMetaConnectService({ graph: stubbedGraph({ pageId: pageB }) });
+    const s3 = await svc3.startConnect({ agentMktrUserId: agent3.mktrLeadsId });
+    await svc3.handleOAuthCallback({ code: `code-${uid()}`, state: new URL(s3.startUrl).searchParams.get('state') });
+    await svc3.drainMetaConnections();
+    const row3 = await MetaAgentConnection.findOne({ where: { userId: agent3.id } });
+    expect(row3.status).toBe('failed');
+    expect(row3.statusDetail).toBe('page_in_use');
+    // The winner keeps the page.
+    const winner = await MetaAgentConnection.findOne({ where: { userId: agent2.id } });
+    expect(winner.status).toBe('connected');
   });
 });

--- a/backend/test/metaConnect.test.js
+++ b/backend/test/metaConnect.test.js
@@ -1,0 +1,221 @@
+/**
+ * Connect-Facebook INTEGRATION tests
+ * (docs/plans/facebook-connect-self-serve.md §6) — real Postgres, real
+ * models/migrations (116/117), real transactions; only the Graph client is
+ * DI-stubbed. The finale wires a provisioned connection into the LIVE lead
+ * pipe: a leadgen webhook for the connected page must route to the agent.
+ */
+import './setup.js';
+process.env.WEBHOOK_ENABLED = 'true';
+process.env.META_PAGE_TOKEN_ENC_KEY = 'b'.repeat(64);
+process.env.META_APP_ID = '1957456775175661';
+process.env.META_APP_SECRET = 'integration-app-secret';
+process.env.FB_LOGIN_CONFIG_ID = 'cfg-int';
+process.env.EXTERNAL_APP_SECRET = 'external-hmac-secret';
+process.env.META_OAUTH_ENABLED = 'true';
+process.env.META_LEAD_ADS_ENABLED = 'true';
+
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign } from './helpers.js';
+import {
+  MetaAgentConnection, MetaPage, MetaFormMapping, QrTag, Prospect,
+  MetaLeadgenEvent, WebhookSubscriber, WebhookDelivery,
+} from '../src/models/index.js';
+import { makeMetaConnectService } from '../src/services/metaConnectService.js';
+import { makeMetaLeadService } from '../src/services/metaLeadService.js';
+
+let app, admin, agent;
+let seq = 0;
+const uid = () => `${Date.now()}${++seq}`;
+
+const sign = (raw) => `sha256=${crypto.createHmac('sha256', process.env.EXTERNAL_APP_SECRET).update(raw).digest('hex')}`;
+function brokerPost(body) {
+  const raw = Buffer.from(JSON.stringify(body));
+  return request(app)
+    .post('/api/external/facebook-connect')
+    .set('Content-Type', 'application/json')
+    .set('X-Webhook-Signature', sign(raw))
+    .send(raw.toString());
+}
+
+function stubbedGraph({ pageId, formIdOnCreate = `form-${uid()}` }) {
+  return {
+    exchangeCodeForLongLivedToken: jest.fn().mockResolvedValue({ token: 'LL-TOKEN', expiresIn: 5184000 }),
+    call: jest.fn(async (path, opts = {}) => {
+      if (path === 'me') return { id: `fbu-${pageId}` };
+      if (String(path).endsWith('/subscribed_apps') && opts.method === 'POST') return { success: true };
+      if (String(path).endsWith('/subscribed_apps') && opts.method === 'DELETE') return { success: true };
+      if (String(path).endsWith('/subscribed_apps')) return { data: [{ id: process.env.META_APP_ID }] };
+      if (String(path) === String(pageId)) return { leadgen_tos_accepted: true };
+      if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') return { id: formIdOnCreate };
+      return {};
+    }),
+    callAllPages: jest.fn(async (path) => {
+      if (path === 'me/permissions') return [{ permission: 'leads_retrieval', status: 'granted' }];
+      if (path === 'me/accounts') return [{ id: pageId, name: `Page ${pageId}`, access_token: `PAGETOK-${pageId}`, tasks: ['MANAGE'] }];
+      if (String(path).endsWith('/leadgen_forms')) return [];
+      return [];
+    }),
+  };
+}
+
+beforeAll(async () => {
+  app = await getApp();
+  ({ user: admin } = await createTestUser({ role: 'admin' }));
+  ({ user: agent } = await createTestUser({
+    role: 'agent',
+    mktrLeadsId: '550e8400-e29b-41d4-a716-446655440777',
+    firstName: 'Connie', lastName: 'Agent',
+  }));
+  const campaign = await createTestCampaign(admin.id, { name: `Meta Agent Ads IT ${Date.now()}`, enforceLeadQuota: false });
+  process.env.META_AGENT_ADS_CAMPAIGN_ID = campaign.id;
+  await WebhookSubscriber.create({
+    name: `it-fbc-mktr-leads-${uid()}`,
+    url: 'http://127.0.0.1:9/webhook', secret: 's',
+    events: ['lead.created', 'lead.held'], enabled: true,
+    metadata: { destination: 'mktr_leads' },
+  });
+});
+
+afterAll(async () => { await closeDb(); });
+
+describe('Connect Facebook (integration)', () => {
+  test('full journey: start → callback → provision → connected, then a leadgen webhook routes to the agent', async () => {
+    const pageId = `77${uid()}`.slice(0, 15);
+    const svc = makeMetaConnectService({ graph: stubbedGraph({ pageId }) });
+
+    // start
+    const { startUrl } = await svc.startConnect({ agentMktrUserId: agent.mktrLeadsId });
+    const nonce = new URL(startUrl).searchParams.get('state');
+    expect(nonce).toHaveLength(48);
+
+    // callback (public GET semantics, service-level)
+    const cb = await svc.handleOAuthCallback({ code: `code-${uid()}`, state: nonce });
+    expect(cb.redirect).toBe('pending');
+
+    // worker
+    await svc.drainMetaConnections();
+    const row = await MetaAgentConnection.findOne({ where: { userId: agent.id } });
+    expect(row.status).toBe('connected');
+    expect(row.oauthCodeEnc).toBeNull();
+    expect(row.pageId).toBe(pageId);
+
+    const pageRow = await MetaPage.findByPk(row.metaPageRowId);
+    expect(pageRow).toMatchObject({ pageId, isActive: true, connectedVia: 'oauth' });
+    expect(pageRow.accessTokenEnc).not.toContain('PAGETOK');
+
+    const qr = await QrTag.findByPk(row.qrTagId);
+    expect(qr).toMatchObject({ assignedAgentId: agent.id, type: 'meta_agent', active: true });
+
+    const mapping = await MetaFormMapping.findByPk(row.mappingId);
+    expect(mapping).toMatchObject({ formId: row.formId, qrTagId: qr.id, isActive: true });
+
+    // ── the money shot: a lead on the connected page reaches THIS agent ──
+    const leadSvc = makeMetaLeadService({
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          field_data: [
+            { name: 'full_name', values: ['Self Serve Lead'] },
+            { name: 'phone_number', values: [`+65916${String(++seq).padStart(5, '0')}`] },
+            { name: 'email', values: [`fbc-${uid()}@test.com`] },
+          ],
+          form_id: row.formId, platform: 'fb', is_organic: false,
+          custom_disclaimer_responses: [{ checkbox_key: 'mktr_pdpa_consent', is_checked: true }],
+        }),
+      }),
+      flushDeliveries: jest.fn(),
+      sendLeadAssignmentEmail: jest.fn().mockResolvedValue({}),
+    });
+    const leadgenId = `88${uid()}`.slice(0, 15);
+    await leadSvc.enqueueLeadgenChanges([{ leadgen_id: leadgenId, page_id: pageId, form_id: row.formId, created_time: 1754500000 }]);
+    await leadSvc.drainMetaInbox({ batchSize: 5, maxBatches: 2 });
+
+    const inboxRow = await MetaLeadgenEvent.findOne({ where: { leadgenId } });
+    expect(inboxRow.status).toBe('completed');
+    const prospect = await Prospect.findByPk(inboxRow.prospectId);
+    expect(prospect.assignedAgentId).toBe(agent.id);
+    expect(prospect.quarantinedAt).toBeNull();
+    expect(prospect.sourceMetadata.utm.utm_source).toBe('fb');
+    const delivery = await WebhookDelivery.findOne({ where: { eventType: 'lead.created' }, order: [['createdAt', 'DESC']] });
+    expect(delivery.payload.data.routing.agentExternalId).toBe(agent.mktrLeadsId);
+  });
+
+  test('broker endpoint: HMAC gate + status + select_page validation + disconnect tombstone', async () => {
+    // Unsigned → 401 before anything else.
+    const raw = JSON.stringify({ action: 'status', agentMktrUserId: agent.mktrLeadsId, timestamp: new Date().toISOString() });
+    await request(app).post('/api/external/facebook-connect').set('Content-Type', 'application/json').send(raw).expect(401);
+
+    // Signed status → connected DTO from the previous journey.
+    const res = await brokerPost({ action: 'status', agentMktrUserId: agent.mktrLeadsId, timestamp: new Date().toISOString() }).expect(200);
+    expect(res.body.connection.status).toBe('connected');
+    expect(res.body.connection.pageName).toMatch(/^Page /);
+    expect(res.body.connection.formName).toContain('Connie');
+
+    // select_page with nothing pending → 409 taxonomy.
+    const sel = await brokerPost({ action: 'select_page', agentMktrUserId: agent.mktrLeadsId, pageId: '1', timestamp: new Date().toISOString() });
+    expect(sel.status).toBe(409);
+    expect(sel.body.error).toBe('no_selection_pending');
+
+    // Stale timestamp → 401 (freshness window).
+    const staleBody = { action: 'status', agentMktrUserId: agent.mktrLeadsId, timestamp: new Date(Date.now() - 10 * 60000).toISOString() };
+    await brokerPost(staleBody).expect(401);
+
+    // disconnect → tombstone semantics.
+    await brokerPost({ action: 'disconnect', agentMktrUserId: agent.mktrLeadsId, timestamp: new Date().toISOString() }).expect(200);
+    const row = await MetaAgentConnection.findOne({ where: { userId: agent.id } });
+    expect(row.status).toBe('disconnected');
+    const pageRow = await MetaPage.findByPk(row.metaPageRowId);
+    expect(pageRow.isActive).toBe(false);
+    expect(pageRow.accessTokenEnc).toBeNull();
+    const mapping = await MetaFormMapping.findByPk(row.mappingId);
+    expect(mapping.isActive).toBe(false);
+  });
+
+  test('two granted pages stop at needs_page_selection; select resumes to connected', async () => {
+    const { user: agent2 } = await createTestUser({
+      role: 'agent', mktrLeadsId: '550e8400-e29b-41d4-a716-446655440888',
+      firstName: 'Multi', lastName: 'Pager',
+    });
+    const pageA = `71${uid()}`.slice(0, 15);
+    const pageB = `72${uid()}`.slice(0, 15);
+    const graph = stubbedGraph({ pageId: pageA });
+    graph.callAllPages = jest.fn(async (path) => {
+      if (path === 'me/permissions') return [];
+      if (path === 'me/accounts') {
+        return [
+          { id: pageA, name: 'Page A', access_token: `PT-${pageA}` },
+          { id: pageB, name: 'Page B', access_token: `PT-${pageB}` },
+        ];
+      }
+      if (String(path).endsWith('/leadgen_forms')) return [];
+      return [];
+    });
+    graph.call = jest.fn(async (path, opts = {}) => {
+      if (path === 'me') return { id: `fbu-${pageB}` };
+      if (String(path).endsWith('/subscribed_apps') && opts.method === 'POST') return { success: true };
+      if (String(path).endsWith('/subscribed_apps')) return { data: [{ id: process.env.META_APP_ID }] };
+      if (String(path) === pageB || String(path) === pageA) return { leadgen_tos_accepted: true };
+      if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') return { id: `form-${uid()}` };
+      return {};
+    });
+    const svc = makeMetaConnectService({ graph });
+
+    const { startUrl } = await svc.startConnect({ agentMktrUserId: agent2.mktrLeadsId });
+    await svc.handleOAuthCallback({ code: `code-${uid()}`, state: new URL(startUrl).searchParams.get('state') });
+    await svc.drainMetaConnections();
+
+    let row = await MetaAgentConnection.findOne({ where: { userId: agent2.id } });
+    expect(row.status).toBe('needs_page_selection');
+    expect(row.candidatePages).toHaveLength(2);
+    expect(JSON.stringify(row.candidatePages)).not.toContain('PT-');
+
+    await svc.selectPage({ agentMktrUserId: agent2.mktrLeadsId, pageId: pageB });
+    await svc.drainMetaConnections();
+    row = await MetaAgentConnection.findOne({ where: { userId: agent2.id } });
+    expect(row.status).toBe('connected');
+    expect(row.pageId).toBe(pageB);
+  });
+});

--- a/backend/test/routeGateAudit.test.js
+++ b/backend/test/routeGateAudit.test.js
@@ -85,7 +85,10 @@ const PUBLIC_SURFACE = {
     "GET /campaigns/:slug"
   ],
   "meta.js": [
+    "GET /oauth/callback",
     "GET /webhook",
+    "POST /oauth/data-deletion",
+    "POST /oauth/deauthorize",
     "POST /webhook"
   ],
   "prospects.js": [

--- a/backend/test/unit/metaConnectService.test.js
+++ b/backend/test/unit/metaConnectService.test.js
@@ -1,0 +1,382 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import crypto from 'crypto';
+import { makeMetaConnectService, parseSignedRequest, callbackUri } from '../../src/services/metaConnectService.js';
+import { GraphError } from '../../src/services/metaGraphClient.js';
+
+process.env.META_PAGE_TOKEN_ENC_KEY = 'a'.repeat(64);
+process.env.META_APP_ID = '1957';
+process.env.FB_LOGIN_CONFIG_ID = 'cfg-1';
+process.env.META_AGENT_ADS_CAMPAIGN_ID = 'camp-agent-ads';
+process.env.META_APP_SECRET = 'app-secret-under-test';
+
+const USER = { id: 'user-1', mktrLeadsId: 'mk-uuid-1', isActive: true, role: 'agent', firstName: 'Lee', lastName: 'Yi Heng' };
+
+function fakeTx() {
+  const t = { LOCK: { UPDATE: 'UPDATE' }, finished: null };
+  t.commit = jest.fn(async () => { t.finished = 'commit'; });
+  t.rollback = jest.fn(async () => { t.finished = 'rollback'; });
+  return t;
+}
+function fakeSequelize() {
+  return {
+    transaction: jest.fn(async (fn) => {
+      const t = fakeTx();
+      if (typeof fn === 'function') { const r = await fn(t); t.finished = 'commit'; return r; }
+      return t;
+    }),
+  };
+}
+function rowify(fields) {
+  const row = { ...fields };
+  row.update = jest.fn(async (patch) => { Object.assign(row, patch); return row; });
+  return row;
+}
+
+function makeDeps(overrides = {}) {
+  const connections = [];
+  const deps = {
+    sequelize: fakeSequelize(),
+    User: { findOne: jest.fn().mockResolvedValue({ ...USER }), findByPk: jest.fn().mockResolvedValue({ ...USER }) },
+    Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'camp-agent-ads', status: 'active' }) },
+    QrTag: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'qr-1', ...f })), findByPk: jest.fn() },
+    MetaPage: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'mp-1', ...f, update: jest.fn() })), findByPk: jest.fn(), update: jest.fn().mockResolvedValue([1]) },
+    MetaFormMapping: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'map-1', ...f })), findByPk: jest.fn(), update: jest.fn().mockResolvedValue([1]) },
+    MetaAgentConnection: {
+      findOne: jest.fn().mockResolvedValue(null),
+      findAll: jest.fn().mockResolvedValue([]),
+      create: jest.fn(async (f) => { const r = rowify({ id: 'cx-1', attempts: 0, ...f }); connections.push(r); return r; }),
+      update: jest.fn().mockResolvedValue([1]),
+    },
+    syncAgents: jest.fn().mockResolvedValue({}),
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+    graph: {
+      call: jest.fn(),
+      callAllPages: jest.fn(),
+      exchangeCodeForLongLivedToken: jest.fn().mockResolvedValue({ token: 'LL-USER-TOKEN', expiresIn: 5184000 }),
+    },
+    ...overrides,
+  };
+  return { deps, connections };
+}
+
+describe('metaConnectService (unit)', () => {
+  describe('parseSignedRequest', () => {
+    const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const make = (payload, secret = process.env.META_APP_SECRET) => {
+      const p = b64url(Buffer.from(JSON.stringify(payload)));
+      const sig = b64url(crypto.createHmac('sha256', secret).update(p).digest());
+      return `${sig}.${p}`;
+    };
+    it('accepts a correctly signed request', () => {
+      expect(parseSignedRequest(make({ user_id: '42', algorithm: 'HMAC-SHA256' }))).toMatchObject({ user_id: '42' });
+    });
+    it('rejects tampering, wrong secret, and unknown algorithms', () => {
+      const good = make({ user_id: '42' });
+      expect(parseSignedRequest(`${good}x`)).toBeNull();
+      expect(parseSignedRequest(make({ user_id: '42' }, 'other'))).toBeNull();
+      expect(parseSignedRequest(make({ user_id: '42', algorithm: 'RSA' }))).toBeNull();
+    });
+  });
+
+  describe('startConnect', () => {
+    it('mirror miss → one sync attempt → agent_sync_pending 503', async () => {
+      const { deps } = makeDeps();
+      deps.User.findOne = jest.fn().mockResolvedValue(null);
+      const svc = makeMetaConnectService(deps);
+      await expect(svc.startConnect({ agentMktrUserId: 'mk-x' })).rejects.toMatchObject({ code: 'agent_sync_pending' });
+      expect(deps.syncAgents).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a row and a dialog URL carrying config_id + opaque state', async () => {
+      const { deps, connections } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const { startUrl } = await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(startUrl).toContain('facebook.com/dialog/oauth');
+      expect(startUrl).toContain('config_id=cfg-1');
+      expect(startUrl).toContain(encodeURIComponent(callbackUri()));
+      const nonce = new URL(startUrl).searchParams.get('state');
+      expect(nonce).toHaveLength(48);
+      expect(connections[0].stateNonce).toBe(nonce);
+      // Opaque: the state is the nonce and nothing else.
+      expect(nonce).not.toContain(USER.mktrLeadsId);
+    });
+
+    it('fresh in-flight provisioning → 409 in_progress; stale one restarts', async () => {
+      const { deps } = makeDeps();
+      const live = rowify({ id: 'cx-9', status: 'provisioning', nextAttemptAt: new Date(Date.now() + 240000), attempts: 1 });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(live);
+      const svc = makeMetaConnectService(deps);
+      await expect(svc.startConnect({ agentMktrUserId: USER.mktrLeadsId })).rejects.toMatchObject({ code: 'in_progress' });
+
+      live.nextAttemptAt = new Date(Date.now() - 10 * 60000);
+      const r = await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(r.startUrl).toContain('state=');
+      expect(live.status).toBe('awaiting_callback');
+    });
+
+    it('reauth on a connected row keeps receipts and refreshes the nonce', async () => {
+      const { deps } = makeDeps();
+      const live = rowify({ id: 'cx-2', status: 'connected', qrTagId: 'qr-1', formId: 'f-1', attempts: 3 });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(live);
+      const svc = makeMetaConnectService(deps);
+      await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(live.status).toBe('awaiting_callback');
+      expect(live.qrTagId).toBe('qr-1');
+      expect(live.formId).toBe('f-1');
+      expect(live.attempts).toBe(0);
+      expect(live.stateNonce).toHaveLength(48);
+    });
+  });
+
+  describe('handleOAuthCallback', () => {
+    it('unknown or replayed state → bad_state', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      expect(await svc.handleOAuthCallback({ code: 'c', state: 'nope' })).toMatchObject({ redirect: 'error', code: 'bad_state' });
+
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      deps.MetaAgentConnection.update = jest.fn().mockResolvedValue([0]); // raced consume
+      expect(await svc.handleOAuthCallback({ code: 'c', state: 'N1' })).toMatchObject({ redirect: 'error', code: 'bad_state' });
+    });
+
+    it('user denial fails the row without a code stash', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      const svc = makeMetaConnectService(deps);
+      const r = await svc.handleOAuthCallback({ state: 'N1', error: 'access_denied' });
+      expect(r).toMatchObject({ redirect: 'denied', code: 'user_denied' });
+      expect(row.status).toBe('failed');
+      expect(row.oauthCodeEnc).toBeNull();
+    });
+
+    it('happy path seals the code and enters provisioning', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      const svc = makeMetaConnectService(deps);
+      const r = await svc.handleOAuthCallback({ code: 'THE-CODE', state: 'N1' });
+      expect(r).toMatchObject({ redirect: 'pending' });
+      expect(row.status).toBe('provisioning');
+      expect(row.oauthCodeEnc).toBeTruthy();
+      expect(row.oauthCodeEnc).not.toContain('THE-CODE');
+    });
+  });
+
+  describe('processConnection', () => {
+    const baseRow = () => rowify({
+      id: 'cx-1', userId: USER.id, status: 'provisioning', attempts: 1,
+      oauthCodeEnc: null, fbUserIdAppScoped: null, pageId: null, qrTagId: null, formId: null,
+    });
+
+    function wireHappyGraph(deps, { pages }) {
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (path === 'me') return { id: 'fb-user-9' };
+        if (String(path).endsWith('/subscribed_apps') && opts.method === 'POST') return { success: true };
+        if (String(path).endsWith('/subscribed_apps')) return { data: [{ id: process.env.META_APP_ID }] };
+        if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: true };
+        if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') return { id: 'form-77' };
+        throw new Error(`unexpected graph call ${path}`);
+      });
+      deps.graph.callAllPages.mockImplementation(async (path) => {
+        if (path === 'me/permissions') return [{ permission: 'leads_retrieval', status: 'granted' }];
+        if (path === 'me/accounts') return pages;
+        if (String(path).endsWith('/leadgen_forms')) return [];
+        throw new Error(`unexpected paged call ${path}`);
+      });
+    }
+
+    async function sealCodeOnto(svc, deps, row) {
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      row.stateNonce = 'N1'; row.status = 'awaiting_callback';
+      await svc.handleOAuthCallback({ code: 'CODE-1', state: 'N1' });
+    }
+
+    it('happy path: exchange once, wire everything, wipe secrets, connect', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'Redeem SG', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
+
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'connected' });
+      expect(deps.graph.exchangeCodeForLongLivedToken).toHaveBeenCalledTimes(1);
+      expect(deps.MetaPage.create).toHaveBeenCalledWith(expect.objectContaining({
+        pageId: '111', isActive: true, connectedVia: 'oauth', connectionId: 'cx-1',
+      }));
+      const sealed = deps.MetaPage.create.mock.calls[0][0].accessTokenEnc;
+      expect(sealed).toBeTruthy();
+      expect(sealed).not.toContain('PAGE-TOK');
+      expect(deps.QrTag.create).toHaveBeenCalledWith(expect.objectContaining({
+        assignedAgentId: USER.id, ownerUserId: USER.id, type: 'meta_agent', campaignId: 'camp-agent-ads',
+      }));
+      expect(deps.MetaFormMapping.create).toHaveBeenCalledWith(expect.objectContaining({
+        formId: 'form-77', campaignId: 'camp-agent-ads', qrTagId: 'qr-1', isActive: true,
+      }));
+      expect(row.status).toBe('connected');
+      expect(row.oauthCodeEnc).toBeNull();
+      expect(row.formId).toBe('form-77');
+    });
+
+    it('two pages → needs_page_selection with NO tokens in the candidates', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      wireHappyGraph(deps, {
+        pages: [
+          { id: '111', name: 'Page A', access_token: 'TOK-A' },
+          { id: '222', name: 'Page B', access_token: 'TOK-B' },
+        ],
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'needs_page_selection' });
+      expect(row.candidatePages).toEqual([{ id: '111', name: 'Page A' }, { id: '222', name: 'Page B' }]);
+      expect(JSON.stringify(row.candidatePages)).not.toContain('TOK-');
+    });
+
+    it('zero pages → failed no_pages, secrets wiped', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      wireHappyGraph(deps, { pages: [] });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('no_pages');
+      expect(row.oauthCodeEnc).toBeNull();
+    });
+
+    it('leadgen TOS not accepted → failed leadgen_tos_required', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T' }] });
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (path === 'me') return { id: 'fb-user-9' };
+        if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: false };
+        return {};
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('leadgen_tos_required');
+    });
+
+    it('existing form with the deterministic name is reused, never duplicated', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T' }] });
+      deps.graph.callAllPages.mockImplementation(async (path) => {
+        if (path === 'me/permissions') return [];
+        if (path === 'me/accounts') return [{ id: '111', name: 'P', access_token: 'T' }];
+        if (String(path).endsWith('/leadgen_forms')) return [{ id: 'form-EXISTING', name: svc.formNameFor(USER) }];
+        return [];
+      });
+      await svc.processConnection(row);
+      expect(row.formId).toBe('form-EXISTING');
+      const formCreates = deps.graph.call.mock.calls.filter(([p, o]) => String(p).endsWith('/leadgen_forms') && o?.method === 'POST');
+      expect(formCreates).toHaveLength(0);
+    });
+
+    it('agent mirror vanished mid-flight → waiting_for_agent', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      deps.User.findOne = jest.fn().mockResolvedValue(null);
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'waiting_for_agent' });
+    });
+
+    it('permanent OAuth exchange error → failed with taxonomy, not a retry loop', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = baseRow();
+      await sealCodeOnto(svc, deps, row);
+      deps.graph.exchangeCodeForLongLivedToken = jest.fn().mockRejectedValue(new GraphError('bad code', { retryable: false, code: 100 }));
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toMatch(/oauth_exchange/);
+      expect(row.oauthCodeEnc).toBeNull();
+    });
+  });
+
+  describe('selectPage / disconnect', () => {
+    it('select validates against the stored candidate set', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'needs_page_selection', candidatePages: [{ id: '111', name: 'A' }] });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      const svc = makeMetaConnectService(deps);
+      await expect(svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '999' })).rejects.toMatchObject({ code: 'invalid_page' });
+      await svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '111' });
+      expect(row.status).toBe('provisioning');
+      expect(row.pageId).toBe('111');
+    });
+
+    it('disconnect: remote unsubscribe BEFORE token wipe, then tombstone + mapping off', async () => {
+      const { deps } = makeDeps();
+      const { sealPageToken } = await import('../../src/services/metaPageTokens.js');
+      const pageRow = { id: 'mp-1', pageId: '111', accessTokenEnc: sealPageToken('PAGE-TOK', '111') };
+      const row = rowify({ id: 'cx-1', userId: USER.id, status: 'connected', metaPageRowId: 'mp-1', mappingId: 'map-1' });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      deps.MetaPage.findByPk = jest.fn().mockResolvedValue(pageRow);
+      const calls = [];
+      deps.graph.call = jest.fn(async (path, opts) => { calls.push([path, opts?.method]); return {}; });
+      const svc = makeMetaConnectService(deps);
+
+      await svc.disconnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(calls).toContainEqual(['111/subscribed_apps', 'DELETE']);
+      expect(deps.MetaAgentConnection.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'disconnected', disconnectReason: 'agent_request', oauthCodeEnc: null }),
+        expect.objectContaining({ where: { id: 'cx-1' } })
+      );
+      expect(deps.MetaFormMapping.update).toHaveBeenCalledWith({ isActive: false }, expect.objectContaining({ where: { id: 'map-1' } }));
+      expect(deps.MetaPage.update).toHaveBeenCalledWith(
+        { isActive: false, accessTokenEnc: null },
+        expect.objectContaining({ where: { id: 'mp-1' } })
+      );
+    });
+  });
+
+  describe('platform callbacks', () => {
+    const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const signedFor = (userId) => {
+      const p = b64url(Buffer.from(JSON.stringify({ user_id: userId, algorithm: 'HMAC-SHA256' })));
+      const sig = b64url(crypto.createHmac('sha256', process.env.META_APP_SECRET).update(p).digest());
+      return `${sig}.${p}`;
+    };
+
+    it('deauthorize disconnects every live connection for the fb user WITHOUT a remote call', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'connected', metaPageRowId: 'mp-1', mappingId: null, fbUserIdAppScoped: 'fb-9' });
+      deps.MetaAgentConnection.findAll = jest.fn().mockResolvedValue([row]);
+      deps.MetaPage.findByPk = jest.fn().mockResolvedValue({ id: 'mp-1', pageId: '111', accessTokenEnc: 'sealed' });
+      const svc = makeMetaConnectService(deps);
+      const r = await svc.handleDeauthorize(signedFor('fb-9'));
+      expect(r).toEqual({ ok: true, disconnected: 1 });
+      expect(deps.graph.call).not.toHaveBeenCalled();
+    });
+
+    it('data deletion returns the Meta-required {url, confirmation_code} shape', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-77', status: 'disconnected', fbUserIdAppScoped: 'fb-9' });
+      deps.MetaAgentConnection.findAll = jest.fn().mockResolvedValue([row]);
+      const svc = makeMetaConnectService(deps);
+      const r = await svc.handleDataDeletion(signedFor('fb-9'));
+      expect(r.confirmation_code).toBe('cx-77');
+      expect(r.url).toContain('fb-data-deletion?code=cx-77');
+    });
+
+    it('bad signature yields null / not-ok', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      expect(await svc.handleDeauthorize('garbage.payload')).toEqual({ ok: false });
+      expect(await svc.handleDataDeletion('garbage.payload')).toBeNull();
+    });
+  });
+});

--- a/backend/test/unit/metaConnectService.test.js
+++ b/backend/test/unit/metaConnectService.test.js
@@ -1,7 +1,11 @@
 import { jest } from '@jest/globals';
 import '../setup.js';
 import crypto from 'crypto';
-import { makeMetaConnectService, parseSignedRequest, callbackUri } from '../../src/services/metaConnectService.js';
+import {
+  makeMetaConnectService, parseSignedRequest, callbackUri,
+  armMetaOauth, disarmMetaOauthForTests,
+} from '../../src/services/metaConnectService.js';
+import { sealPageToken } from '../../src/services/metaPageTokens.js';
 import { GraphError } from '../../src/services/metaGraphClient.js';
 
 process.env.META_PAGE_TOKEN_ENC_KEY = 'a'.repeat(64);
@@ -10,6 +14,7 @@ process.env.FB_LOGIN_CONFIG_ID = 'cfg-1';
 process.env.META_AGENT_ADS_CAMPAIGN_ID = 'camp-agent-ads';
 process.env.META_APP_SECRET = 'app-secret-under-test';
 
+const ALL_SCOPES = ['leads_retrieval', 'pages_show_list', 'pages_manage_metadata', 'pages_read_engagement', 'pages_manage_ads'];
 const USER = { id: 'user-1', mktrLeadsId: 'mk-uuid-1', isActive: true, role: 'agent', firstName: 'Lee', lastName: 'Yi Heng' };
 
 function fakeTx() {
@@ -20,6 +25,7 @@ function fakeTx() {
 }
 function fakeSequelize() {
   return {
+    literal: jest.fn((s) => s),
     transaction: jest.fn(async (fn) => {
       const t = fakeTx();
       if (typeof fn === 'function') { const r = await fn(t); t.finished = 'commit'; return r; }
@@ -32,6 +38,7 @@ function rowify(fields) {
   row.update = jest.fn(async (patch) => { Object.assign(row, patch); return row; });
   return row;
 }
+const sealFor = (row, value) => sealPageToken(value, `cx:${row.id}`);
 
 function makeDeps(overrides = {}) {
   const connections = [];
@@ -39,15 +46,17 @@ function makeDeps(overrides = {}) {
     sequelize: fakeSequelize(),
     User: { findOne: jest.fn().mockResolvedValue({ ...USER }), findByPk: jest.fn().mockResolvedValue({ ...USER }) },
     Campaign: { findByPk: jest.fn().mockResolvedValue({ id: 'camp-agent-ads', status: 'active' }) },
-    QrTag: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'qr-1', ...f })), findByPk: jest.fn() },
+    QrTag: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'qr-1', ...f })), findByPk: jest.fn().mockResolvedValue(null) },
     MetaPage: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'mp-1', ...f, update: jest.fn() })), findByPk: jest.fn(), update: jest.fn().mockResolvedValue([1]) },
     MetaFormMapping: { findOne: jest.fn().mockResolvedValue(null), create: jest.fn(async (f) => ({ id: 'map-1', ...f })), findByPk: jest.fn(), update: jest.fn().mockResolvedValue([1]) },
     MetaAgentConnection: {
       findOne: jest.fn().mockResolvedValue(null),
       findAll: jest.fn().mockResolvedValue([]),
+      findByPk: jest.fn().mockResolvedValue(null),
       create: jest.fn(async (f) => { const r = rowify({ id: 'cx-1', attempts: 0, ...f }); connections.push(r); return r; }),
       update: jest.fn().mockResolvedValue([1]),
     },
+    Prospect: { findOne: jest.fn().mockResolvedValue(null) },
     syncAgents: jest.fn().mockResolvedValue({}),
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
     graph: {
@@ -60,7 +69,54 @@ function makeDeps(overrides = {}) {
   return { deps, connections };
 }
 
+/**
+ * The service fences via MODEL update + Object.assign — the stub returning
+ * [1] keeps rows mutating exactly like the real conditional update would on
+ * an owned claim. Fence-loss cases override the stub to [0].
+ */
+function wireHappyGraph(deps, { pages }) {
+  deps.graph.call.mockImplementation(async (path, opts = {}) => {
+    if (path === 'me') return { id: 'fb-user-9' };
+    if (String(path).endsWith('/subscribed_apps') && opts.method === 'POST') return { success: true };
+    if (String(path).endsWith('/subscribed_apps')) return { data: [{ id: process.env.META_APP_ID }] };
+    if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: true };
+    if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') return { id: 'form-77' };
+    throw new Error(`unexpected graph call ${path}`);
+  });
+  deps.graph.callAllPages.mockImplementation(async (path) => {
+    if (path === 'me/permissions') return ALL_SCOPES.map((p) => ({ permission: p, status: 'granted' }));
+    if (path === 'me/accounts') return pages;
+    if (String(path).endsWith('/leadgen_forms')) return [];
+    throw new Error(`unexpected paged call ${path}`);
+  });
+}
+
+const provisioningRow = (over = {}) => {
+  const row = rowify({
+    id: 'cx-1', userId: USER.id, status: 'provisioning', attempts: 1,
+    fbUserIdAppScoped: null, pageId: null, qrTagId: null, formId: null,
+    connectedAt: null, ...over,
+  });
+  if (!('oauthCodeEnc' in over)) {
+    row.oauthCodeEnc = sealFor(row, 'CODE-1');
+    row.secretKind = 'oauth_code';
+  }
+  return row;
+};
+
+beforeEach(() => { armMetaOauth(); });
+
 describe('metaConnectService (unit)', () => {
+  describe('armed latch (F7)', () => {
+    it('startConnect and callback refuse until bootstrap arms the subsystem', async () => {
+      disarmMetaOauthForTests();
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      await expect(svc.startConnect({ agentMktrUserId: 'x' })).rejects.toMatchObject({ code: 'not_armed' });
+      expect(await svc.handleOAuthCallback({ code: 'c', state: 's' })).toMatchObject({ code: 'not_armed' });
+    });
+  });
+
   describe('parseSignedRequest', () => {
     const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
     const make = (payload, secret = process.env.META_APP_SECRET) => {
@@ -68,19 +124,16 @@ describe('metaConnectService (unit)', () => {
       const sig = b64url(crypto.createHmac('sha256', secret).update(p).digest());
       return `${sig}.${p}`;
     };
-    it('accepts a correctly signed request', () => {
+    it('accepts correct signatures, rejects tamper/wrong-secret/foreign algos', () => {
       expect(parseSignedRequest(make({ user_id: '42', algorithm: 'HMAC-SHA256' }))).toMatchObject({ user_id: '42' });
-    });
-    it('rejects tampering, wrong secret, and unknown algorithms', () => {
-      const good = make({ user_id: '42' });
-      expect(parseSignedRequest(`${good}x`)).toBeNull();
+      expect(parseSignedRequest(`${make({ user_id: '42' })}x`)).toBeNull();
       expect(parseSignedRequest(make({ user_id: '42' }, 'other'))).toBeNull();
       expect(parseSignedRequest(make({ user_id: '42', algorithm: 'RSA' }))).toBeNull();
     });
   });
 
-  describe('startConnect', () => {
-    it('mirror miss → one sync attempt → agent_sync_pending 503', async () => {
+  describe('startConnect (F8: serialized, expiring state)', () => {
+    it('mirror miss → one sync attempt → agent_sync_pending', async () => {
       const { deps } = makeDeps();
       deps.User.findOne = jest.fn().mockResolvedValue(null);
       const svc = makeMetaConnectService(deps);
@@ -88,7 +141,7 @@ describe('metaConnectService (unit)', () => {
       expect(deps.syncAgents).toHaveBeenCalledTimes(1);
     });
 
-    it('creates a row and a dialog URL carrying config_id + opaque state', async () => {
+    it('creates a row with an opaque expiring state and a config_id dialog URL', async () => {
       const { deps, connections } = makeDeps();
       const svc = makeMetaConnectService(deps);
       const { startUrl } = await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
@@ -98,244 +151,234 @@ describe('metaConnectService (unit)', () => {
       const nonce = new URL(startUrl).searchParams.get('state');
       expect(nonce).toHaveLength(48);
       expect(connections[0].stateNonce).toBe(nonce);
-      // Opaque: the state is the nonce and nothing else.
+      expect(new Date(connections[0].stateExpiresAt).getTime()).toBeGreaterThan(Date.now());
       expect(nonce).not.toContain(USER.mktrLeadsId);
     });
 
-    it('fresh in-flight provisioning → 409 in_progress; stale one restarts', async () => {
+    it('unique-create race maps to 409 in_progress', async () => {
       const { deps } = makeDeps();
-      const live = rowify({ id: 'cx-9', status: 'provisioning', nextAttemptAt: new Date(Date.now() + 240000), attempts: 1 });
-      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(live);
+      deps.MetaAgentConnection.create = jest.fn().mockRejectedValue(Object.assign(new Error('dup'), { name: 'SequelizeUniqueConstraintError' }));
       const svc = makeMetaConnectService(deps);
       await expect(svc.startConnect({ agentMktrUserId: USER.mktrLeadsId })).rejects.toMatchObject({ code: 'in_progress' });
-
-      live.nextAttemptAt = new Date(Date.now() - 10 * 60000);
-      const r = await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
-      expect(r.startUrl).toContain('state=');
-      expect(live.status).toBe('awaiting_callback');
     });
 
-    it('reauth on a connected row keeps receipts and refreshes the nonce', async () => {
+    it('reauth on a connected row keeps receipts + pageId and clears the secret phase', async () => {
       const { deps } = makeDeps();
-      const live = rowify({ id: 'cx-2', status: 'connected', qrTagId: 'qr-1', formId: 'f-1', attempts: 3 });
+      const live = rowify({ id: 'cx-2', status: 'connected', connectedAt: new Date(), pageId: '111', qrTagId: 'qr-1', formId: 'f-1', attempts: 3, secretKind: 'long_token', oauthCodeEnc: 'sealed' });
       deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(live);
       const svc = makeMetaConnectService(deps);
       await svc.startConnect({ agentMktrUserId: USER.mktrLeadsId });
       expect(live.status).toBe('awaiting_callback');
+      expect(live.pageId).toBe('111');
       expect(live.qrTagId).toBe('qr-1');
-      expect(live.formId).toBe('f-1');
-      expect(live.attempts).toBe(0);
-      expect(live.stateNonce).toHaveLength(48);
+      expect(live.secretKind).toBeNull();
+      expect(live.oauthCodeEnc).toBeNull();
     });
   });
 
-  describe('handleOAuthCallback', () => {
-    it('unknown or replayed state → bad_state', async () => {
+  describe('handleOAuthCallback (F1/F8)', () => {
+    it('unknown state → bad_state; expired state on a previously-connected row RESTORES connected', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
-      expect(await svc.handleOAuthCallback({ code: 'c', state: 'nope' })).toMatchObject({ redirect: 'error', code: 'bad_state' });
+      expect(await svc.handleOAuthCallback({ code: 'c', state: 'nope' })).toMatchObject({ code: 'bad_state' });
 
-      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1', stateExpiresAt: new Date(Date.now() - 1000), connectedAt: new Date() });
       deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
-      deps.MetaAgentConnection.update = jest.fn().mockResolvedValue([0]); // raced consume
-      expect(await svc.handleOAuthCallback({ code: 'c', state: 'N1' })).toMatchObject({ redirect: 'error', code: 'bad_state' });
+      const r = await svc.handleOAuthCallback({ code: 'c', state: 'N1' });
+      expect(r).toMatchObject({ code: 'state_expired' });
+      expect(deps.MetaAgentConnection.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'connected', statusDetail: 'state_expired' }),
+        expect.objectContaining({ where: expect.objectContaining({ id: 'cx-1' }) })
+      );
     });
 
-    it('user denial fails the row without a code stash', async () => {
+    it('denial on a FIRST connect fails; denial on reauth restores connected (assets never orphaned)', async () => {
       const { deps } = makeDeps();
-      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
-      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
       const svc = makeMetaConnectService(deps);
-      const r = await svc.handleOAuthCallback({ state: 'N1', error: 'access_denied' });
-      expect(r).toMatchObject({ redirect: 'denied', code: 'user_denied' });
-      expect(row.status).toBe('failed');
-      expect(row.oauthCodeEnc).toBeNull();
+      const fresh = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1', stateExpiresAt: new Date(Date.now() + 60000), connectedAt: null });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(fresh);
+      await svc.handleOAuthCallback({ state: 'N1', error: 'access_denied' });
+      expect(deps.MetaAgentConnection.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'failed', statusDetail: 'user_denied' }),
+        expect.anything()
+      );
+
+      const reauth = rowify({ id: 'cx-2', status: 'awaiting_callback', stateNonce: 'N2', stateExpiresAt: new Date(Date.now() + 60000), connectedAt: new Date() });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(reauth);
+      await svc.handleOAuthCallback({ state: 'N2', error: 'access_denied' });
+      expect(deps.MetaAgentConnection.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'connected', statusDetail: 'user_denied' }),
+        expect.anything()
+      );
     });
 
-    it('happy path seals the code and enters provisioning', async () => {
+    it('happy path: ONE conditional transition seals the code with secretKind oauth_code', async () => {
       const { deps } = makeDeps();
-      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1' });
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1', stateExpiresAt: new Date(Date.now() + 60000) });
       deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
       const svc = makeMetaConnectService(deps);
       const r = await svc.handleOAuthCallback({ code: 'THE-CODE', state: 'N1' });
       expect(r).toMatchObject({ redirect: 'pending' });
-      expect(row.status).toBe('provisioning');
-      expect(row.oauthCodeEnc).toBeTruthy();
-      expect(row.oauthCodeEnc).not.toContain('THE-CODE');
+      const [patch, where] = deps.MetaAgentConnection.update.mock.calls.at(-1);
+      expect(patch).toMatchObject({ status: 'provisioning', secretKind: 'oauth_code', stateNonce: null });
+      expect(patch.oauthCodeEnc).not.toContain('THE-CODE');
+      expect(where.where).toMatchObject({ id: 'cx-1', stateNonce: 'N1', status: 'awaiting_callback' });
+    });
+
+    it('a raced duplicate loses the conditional update → bad_state', async () => {
+      const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'awaiting_callback', stateNonce: 'N1', stateExpiresAt: new Date(Date.now() + 60000) });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      deps.MetaAgentConnection.update = jest.fn().mockResolvedValue([0]);
+      const svc = makeMetaConnectService(deps);
+      expect(await svc.handleOAuthCallback({ code: 'c', state: 'N1' })).toMatchObject({ code: 'bad_state' });
     });
   });
 
   describe('processConnection', () => {
-    const baseRow = () => rowify({
-      id: 'cx-1', userId: USER.id, status: 'provisioning', attempts: 1,
-      oauthCodeEnc: null, fbUserIdAppScoped: null, pageId: null, qrTagId: null, formId: null,
-    });
-
-    function wireHappyGraph(deps, { pages }) {
-      deps.graph.call.mockImplementation(async (path, opts = {}) => {
-        if (path === 'me') return { id: 'fb-user-9' };
-        if (String(path).endsWith('/subscribed_apps') && opts.method === 'POST') return { success: true };
-        if (String(path).endsWith('/subscribed_apps')) return { data: [{ id: process.env.META_APP_ID }] };
-        if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: true };
-        if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') return { id: 'form-77' };
-        throw new Error(`unexpected graph call ${path}`);
-      });
-      deps.graph.callAllPages.mockImplementation(async (path) => {
-        if (path === 'me/permissions') return [{ permission: 'leads_retrieval', status: 'granted' }];
-        if (path === 'me/accounts') return pages;
-        if (String(path).endsWith('/leadgen_forms')) return [];
-        throw new Error(`unexpected paged call ${path}`);
-      });
-    }
-
-    async function sealCodeOnto(svc, deps, row) {
-      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
-      row.stateNonce = 'N1'; row.status = 'awaiting_callback';
-      await svc.handleOAuthCallback({ code: 'CODE-1', state: 'N1' });
-    }
-
-    it('happy path: exchange once, wire everything, wipe secrets, connect', async () => {
+    it('happy path: exchange → token persisted IMMEDIATELY (F2) → scopes enforced → page reserved → wired → connected, secrets wiped', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
+      const row = provisioningRow();
       wireHappyGraph(deps, { pages: [{ id: '111', name: 'Redeem SG', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
 
       const r = await svc.processConnection(row);
       expect(r).toEqual({ status: 'connected' });
-      expect(deps.graph.exchangeCodeForLongLivedToken).toHaveBeenCalledTimes(1);
-      expect(deps.MetaPage.create).toHaveBeenCalledWith(expect.objectContaining({
-        pageId: '111', isActive: true, connectedVia: 'oauth', connectionId: 'cx-1',
-      }));
-      const sealed = deps.MetaPage.create.mock.calls[0][0].accessTokenEnc;
-      expect(sealed).toBeTruthy();
-      expect(sealed).not.toContain('PAGE-TOK');
-      expect(deps.QrTag.create).toHaveBeenCalledWith(expect.objectContaining({
-        assignedAgentId: USER.id, ownerUserId: USER.id, type: 'meta_agent', campaignId: 'camp-agent-ads',
-      }));
-      expect(deps.MetaFormMapping.create).toHaveBeenCalledWith(expect.objectContaining({
-        formId: 'form-77', campaignId: 'camp-agent-ads', qrTagId: 'qr-1', isActive: true,
-      }));
+      // F2: the very first fenced patch after the exchange carries the token phase.
+      const patches = deps.MetaAgentConnection.update.mock.calls.map(([p]) => p);
+      const tokenPatchIdx = patches.findIndex((p) => p.secretKind === 'long_token');
+      const identityPatchIdx = patches.findIndex((p) => p.fbUserIdAppScoped);
+      expect(tokenPatchIdx).toBeGreaterThanOrEqual(0);
+      expect(tokenPatchIdx).toBeLessThan(identityPatchIdx);
+      // Reservation happened before wiring; final state on the row:
+      expect(row.pageId).toBe('111');
       expect(row.status).toBe('connected');
       expect(row.oauthCodeEnc).toBeNull();
-      expect(row.formId).toBe('form-77');
+      expect(row.secretKind).toBeNull();
+      expect(deps.MetaPage.create).toHaveBeenCalledWith(expect.objectContaining({ pageId: '111', connectedVia: 'oauth' }));
+      expect(deps.MetaPage.create.mock.calls[0][0].accessTokenEnc).not.toContain('PAGE-TOK');
+      expect(deps.QrTag.create).toHaveBeenCalledWith(expect.objectContaining({ assignedAgentId: USER.id, type: 'meta_agent' }));
+      expect(deps.MetaFormMapping.create).toHaveBeenCalledWith(expect.objectContaining({ formId: 'form-77', qrTagId: 'qr-1' }));
     });
 
-    it('two pages → needs_page_selection with NO tokens in the candidates', async () => {
+    it('resume after crash-post-exchange does NOT re-exchange (secretKind long_token)', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
-      wireHappyGraph(deps, {
-        pages: [
-          { id: '111', name: 'Page A', access_token: 'TOK-A' },
-          { id: '222', name: 'Page B', access_token: 'TOK-B' },
-        ],
-      });
-      const r = await svc.processConnection(row);
-      expect(r).toEqual({ status: 'needs_page_selection' });
-      expect(row.candidatePages).toEqual([{ id: '111', name: 'Page A' }, { id: '222', name: 'Page B' }]);
-      expect(JSON.stringify(row.candidatePages)).not.toContain('TOK-');
+      const row = provisioningRow({ oauthCodeEnc: null });
+      row.oauthCodeEnc = sealFor(row, 'LL-USER-TOKEN');
+      row.secretKind = 'long_token';
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T', tasks: ['MANAGE'] }] });
+      await svc.processConnection(row);
+      expect(deps.graph.exchangeCodeForLongLivedToken).not.toHaveBeenCalled();
+      expect(row.status).toBe('connected');
     });
 
-    it('zero pages → failed no_pages, secrets wiped', async () => {
+    it('ANY exchange failure demands a fresh dialog — reauth_required when previously connected, failed otherwise (F1/F2)', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
+      deps.graph.exchangeCodeForLongLivedToken = jest.fn().mockRejectedValue(new GraphError('timeout', { retryable: true }));
+
+      const fresh = provisioningRow();
+      expect(await svc.processConnection(fresh)).toEqual({ status: 'failed' });
+      expect(fresh.statusDetail).toBe('oauth_exchange_failed');
+      expect(fresh.oauthCodeEnc).toBeNull();
+
+      const reauth = provisioningRow({ id: 'cx-9', connectedAt: new Date() });
+      expect(await svc.processConnection(reauth)).toEqual({ status: 'reauth_required' });
+    });
+
+    it('missing required scopes → terminal missing_permissions (F10)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
       wireHappyGraph(deps, { pages: [] });
-      const r = await svc.processConnection(row);
-      expect(r).toEqual({ status: 'failed' });
-      expect(row.statusDetail).toBe('no_pages');
-      expect(row.oauthCodeEnc).toBeNull();
-    });
-
-    it('leadgen TOS not accepted → failed leadgen_tos_required', async () => {
-      const { deps } = makeDeps();
-      const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
-      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T' }] });
-      deps.graph.call.mockImplementation(async (path, opts = {}) => {
-        if (path === 'me') return { id: 'fb-user-9' };
-        if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: false };
-        return {};
-      });
-      const r = await svc.processConnection(row);
-      expect(r).toEqual({ status: 'failed' });
-      expect(row.statusDetail).toBe('leadgen_tos_required');
-    });
-
-    it('existing form with the deterministic name is reused, never duplicated', async () => {
-      const { deps } = makeDeps();
-      const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
-      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T' }] });
       deps.graph.callAllPages.mockImplementation(async (path) => {
-        if (path === 'me/permissions') return [];
-        if (path === 'me/accounts') return [{ id: '111', name: 'P', access_token: 'T' }];
-        if (String(path).endsWith('/leadgen_forms')) return [{ id: 'form-EXISTING', name: svc.formNameFor(USER) }];
+        if (path === 'me/permissions') return [{ permission: 'leads_retrieval', status: 'granted' }];
         return [];
       });
       await svc.processConnection(row);
-      expect(row.formId).toBe('form-EXISTING');
-      const formCreates = deps.graph.call.mock.calls.filter(([p, o]) => String(p).endsWith('/leadgen_forms') && o?.method === 'POST');
-      expect(formCreates).toHaveLength(0);
+      expect(row.status).toBe('failed');
+      expect(row.statusDetail).toMatch(/^missing_permissions:/);
     });
 
-    it('agent mirror vanished mid-flight → waiting_for_agent', async () => {
+    it('two pages → needs_page_selection (no tokens in candidates); zero pages → no_pages', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
-      const row = baseRow();
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '1', name: 'A', access_token: 'TA' }, { id: '2', name: 'B', access_token: 'TB' }] });
+      expect(await svc.processConnection(row)).toEqual({ status: 'needs_page_selection' });
+      expect(JSON.stringify(row.candidatePages)).not.toContain('T');
+
+      const row2 = provisioningRow({ id: 'cx-2' });
+      wireHappyGraph(deps, { pages: [] });
+      await svc.processConnection(row2);
+      expect(row2.statusDetail).toBe('no_pages');
+    });
+
+    it('page reservation unique-conflict → terminal page_in_use, never a retry loop (F3)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T', tasks: ['MANAGE'] }] });
+      let call = 0;
+      deps.MetaAgentConnection.update = jest.fn(async (patch) => {
+        call += 1;
+        if (patch.pageId && !patch.status) {
+          const err = new Error('dup'); err.name = 'SequelizeUniqueConstraintError'; throw err;
+        }
+        return [1];
+      });
+      await svc.processConnection(row);
+      expect(row.status).toBe('failed');
+      expect(row.statusDetail).toBe('page_in_use');
+      expect(call).toBeGreaterThan(0);
+    });
+
+    it('admin-managed meta_pages row is never taken over (F3)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T', tasks: ['MANAGE'] }] });
+      deps.MetaPage.findOne = jest.fn().mockResolvedValue({ id: 'mp-adm', pageId: '111', connectionId: null, connectedVia: null });
+      await svc.processConnection(row);
+      expect(row.status).toBe('failed');
+      expect(row.statusDetail).toBe('page_admin_managed');
+    });
+
+    it('token-dead Graph error (190) on a reauth journey → reauth_required (F16)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow({ connectedAt: new Date(), oauthCodeEnc: null });
+      row.oauthCodeEnc = sealFor(row, 'LL'); row.secretKind = 'long_token';
+      deps.graph.call.mockRejectedValue(new GraphError('expired', { retryable: false, code: 190 }));
+      deps.graph.callAllPages.mockRejectedValue(new GraphError('expired', { retryable: false, code: 190 }));
+      await svc.processConnection(row);
+      expect(row.status).toBe('reauth_required');
+    });
+
+    it('agent mirror missing → waiting_for_agent via markRetry (requeued, F13)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
       deps.User.findOne = jest.fn().mockResolvedValue(null);
       const r = await svc.processConnection(row);
       expect(r).toEqual({ status: 'waiting_for_agent' });
-    });
-
-    it('permanent OAuth exchange error → failed with taxonomy, not a retry loop', async () => {
-      const { deps } = makeDeps();
-      const svc = makeMetaConnectService(deps);
-      const row = baseRow();
-      await sealCodeOnto(svc, deps, row);
-      deps.graph.exchangeCodeForLongLivedToken = jest.fn().mockRejectedValue(new GraphError('bad code', { retryable: false, code: 100 }));
-      const r = await svc.processConnection(row);
-      expect(r).toEqual({ status: 'failed' });
-      expect(row.statusDetail).toMatch(/oauth_exchange/);
-      expect(row.oauthCodeEnc).toBeNull();
-    });
-  });
-
-  describe('selectPage / disconnect', () => {
-    it('select validates against the stored candidate set', async () => {
-      const { deps } = makeDeps();
-      const row = rowify({ id: 'cx-1', status: 'needs_page_selection', candidatePages: [{ id: '111', name: 'A' }] });
-      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
-      const svc = makeMetaConnectService(deps);
-      await expect(svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '999' })).rejects.toMatchObject({ code: 'invalid_page' });
-      await svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '111' });
-      expect(row.status).toBe('provisioning');
-      expect(row.pageId).toBe('111');
-    });
-
-    it('disconnect: remote unsubscribe BEFORE token wipe, then tombstone + mapping off', async () => {
-      const { deps } = makeDeps();
-      const { sealPageToken } = await import('../../src/services/metaPageTokens.js');
-      const pageRow = { id: 'mp-1', pageId: '111', accessTokenEnc: sealPageToken('PAGE-TOK', '111') };
-      const row = rowify({ id: 'cx-1', userId: USER.id, status: 'connected', metaPageRowId: 'mp-1', mappingId: 'map-1' });
-      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
-      deps.MetaPage.findByPk = jest.fn().mockResolvedValue(pageRow);
-      const calls = [];
-      deps.graph.call = jest.fn(async (path, opts) => { calls.push([path, opts?.method]); return {}; });
-      const svc = makeMetaConnectService(deps);
-
-      await svc.disconnect({ agentMktrUserId: USER.mktrLeadsId });
-      expect(calls).toContainEqual(['111/subscribed_apps', 'DELETE']);
       expect(deps.MetaAgentConnection.update).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'disconnected', disconnectReason: 'agent_request', oauthCodeEnc: null }),
-        expect.objectContaining({ where: { id: 'cx-1' } })
+        expect.objectContaining({ status: 'waiting_for_agent' }),
+        expect.objectContaining({ where: expect.objectContaining({ id: row.id }) })
       );
-      expect(deps.MetaFormMapping.update).toHaveBeenCalledWith({ isActive: false }, expect.objectContaining({ where: { id: 'map-1' } }));
+    });
+
+    it('fence lost to a disconnect mid-run → freshly wired assets cleaned (F4)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T', tasks: ['MANAGE'] }] });
+      // Lose the fence at the metaPageRowId receipt (after MetaPage.create).
+      deps.MetaAgentConnection.update = jest.fn(async (patch) => (patch.metaPageRowId ? [0] : [1]));
+      deps.MetaAgentConnection.findByPk = jest.fn().mockResolvedValue({ id: row.id, status: 'disconnected' });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'fence_lost' });
       expect(deps.MetaPage.update).toHaveBeenCalledWith(
         { isActive: false, accessTokenEnc: null },
         expect.objectContaining({ where: { id: 'mp-1' } })
@@ -343,7 +386,26 @@ describe('metaConnectService (unit)', () => {
     });
   });
 
-  describe('platform callbacks', () => {
+  describe('disconnect ordering (F11) + platform callbacks (F12)', () => {
+    it('disconnect: local intake dies in one txn (token KEPT), then remote unsubscribe, then token wipe', async () => {
+      const { deps } = makeDeps();
+      const pageRow = { id: 'mp-1', pageId: '111', accessTokenEnc: sealPageToken('PAGE-TOK', '111') };
+      const row = rowify({ id: 'cx-1', userId: USER.id, status: 'connected', metaPageRowId: 'mp-1', mappingId: 'map-1' });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      deps.MetaPage.findByPk = jest.fn().mockResolvedValue(pageRow);
+      const order = [];
+      deps.MetaPage.update = jest.fn(async (patch) => { order.push(patch.accessTokenEnc === null && !('isActive' in patch) ? 'wipe' : 'deactivate'); return [1]; });
+      deps.graph.call = jest.fn(async (path, opts) => { order.push(`remote:${opts?.method}`); return {}; });
+      const svc = makeMetaConnectService(deps);
+
+      await svc.disconnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(order).toEqual(['deactivate', 'remote:DELETE', 'wipe']);
+      expect(deps.MetaAgentConnection.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'disconnected', disconnectReason: 'agent_request' }),
+        expect.objectContaining({ where: expect.objectContaining({ id: 'cx-1' }) })
+      );
+    });
+
     const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
     const signedFor = (userId) => {
       const p = b64url(Buffer.from(JSON.stringify({ user_id: userId, algorithm: 'HMAC-SHA256' })));
@@ -351,7 +413,7 @@ describe('metaConnectService (unit)', () => {
       return `${sig}.${p}`;
     };
 
-    it('deauthorize disconnects every live connection for the fb user WITHOUT a remote call', async () => {
+    it('deauthorize disconnects live connections WITHOUT a remote call', async () => {
       const { deps } = makeDeps();
       const row = rowify({ id: 'cx-1', status: 'connected', metaPageRowId: 'mp-1', mappingId: null, fbUserIdAppScoped: 'fb-9' });
       deps.MetaAgentConnection.findAll = jest.fn().mockResolvedValue([row]);
@@ -362,21 +424,39 @@ describe('metaConnectService (unit)', () => {
       expect(deps.graph.call).not.toHaveBeenCalled();
     });
 
-    it('data deletion returns the Meta-required {url, confirmation_code} shape', async () => {
+    it('data deletion scrubs EVERY identifier across all statuses and answers an opaque code (F12)', async () => {
       const { deps } = makeDeps();
-      const row = rowify({ id: 'cx-77', status: 'disconnected', fbUserIdAppScoped: 'fb-9' });
-      deps.MetaAgentConnection.findAll = jest.fn().mockResolvedValue([row]);
+      const terminal = rowify({
+        id: 'cx-77', status: 'failed', fbUserIdAppScoped: 'fb-9', agentMktrUserId: 'mk-1',
+        pageId: '111', formId: 'f-1', mappingId: 'map-1', metaPageRowId: 'mp-1', qrTagId: 'qr-1',
+      });
+      deps.MetaAgentConnection.findAll = jest.fn().mockResolvedValue([terminal]);
       const svc = makeMetaConnectService(deps);
       const r = await svc.handleDataDeletion(signedFor('fb-9'));
-      expect(r.confirmation_code).toBe('cx-77');
-      expect(r.url).toContain('fb-data-deletion?code=cx-77');
+      expect(r.confirmation_code).toHaveLength(32);
+      expect(r.confirmation_code).not.toBe('cx-77');
+      expect(terminal).toMatchObject({
+        fbUserIdAppScoped: null, agentMktrUserId: null, pageId: null, formId: null,
+        mappingId: null, qrTagId: null, metaPageRowId: null, statusDetail: 'data_deletion',
+      });
+      // Terminal rows' still-active assets are killed too.
+      expect(deps.MetaFormMapping.update).toHaveBeenCalledWith({ isActive: false }, expect.objectContaining({ where: { id: 'map-1' } }));
+      expect(deps.MetaPage.update).toHaveBeenCalledWith({ isActive: false, accessTokenEnc: null }, expect.objectContaining({ where: { id: 'mp-1' } }));
     });
+  });
 
-    it('bad signature yields null / not-ok', async () => {
+  describe('selectPage', () => {
+    it('validates against the stored candidates and maps a page-unique race to page_in_use', async () => {
       const { deps } = makeDeps();
+      const row = rowify({ id: 'cx-1', status: 'needs_page_selection', candidatePages: [{ id: '111', name: 'A' }] });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
       const svc = makeMetaConnectService(deps);
-      expect(await svc.handleDeauthorize('garbage.payload')).toEqual({ ok: false });
-      expect(await svc.handleDataDeletion('garbage.payload')).toBeNull();
+      await expect(svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '999' })).rejects.toMatchObject({ code: 'invalid_page' });
+
+      deps.MetaAgentConnection.update = jest.fn()
+        .mockRejectedValueOnce(Object.assign(new Error('dup'), { name: 'SequelizeUniqueConstraintError' }))
+        .mockResolvedValue([1]);
+      await expect(svc.selectPage({ agentMktrUserId: USER.mktrLeadsId, pageId: '111' })).rejects.toMatchObject({ code: 'page_in_use' });
     });
   });
 });

--- a/backend/test/unit/metaConnectService.test.js
+++ b/backend/test/unit/metaConnectService.test.js
@@ -287,6 +287,28 @@ describe('metaConnectService (unit)', () => {
       expect(await svc.processConnection(reauth)).toEqual({ status: 'reauth_required' });
     });
 
+    it('a row stranded mid-exchange resumes as code_ambiguous — the code is never replayed (round-2 #2)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow({ oauthCodeEnc: null });
+      row.oauthCodeEnc = sealFor(row, 'MAYBE-SPENT-CODE');
+      row.secretKind = 'exchanging';
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('code_ambiguous');
+      expect(deps.graph.exchangeCodeForLongLivedToken).not.toHaveBeenCalled();
+    });
+
+    it('a page with MISSING or empty tasks is terminal page_task_missing (round-2 #10)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'T' }] }); // no tasks at all
+      await svc.processConnection(row);
+      expect(row.status).toBe('failed');
+      expect(row.statusDetail).toBe('page_task_missing');
+    });
+
     it('missing required scopes → terminal missing_permissions (F10)', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);
@@ -389,10 +411,12 @@ describe('metaConnectService (unit)', () => {
   describe('disconnect ordering (F11) + platform callbacks (F12)', () => {
     it('disconnect: local intake dies in one txn (token KEPT), then remote unsubscribe, then token wipe', async () => {
       const { deps } = makeDeps();
-      const pageRow = { id: 'mp-1', pageId: '111', accessTokenEnc: sealPageToken('PAGE-TOK', '111') };
+      const pageRow = { id: 'mp-1', pageId: '111', connectionId: 'cx-1', accessTokenEnc: sealPageToken('PAGE-TOK', '111') };
       const row = rowify({ id: 'cx-1', userId: USER.id, status: 'connected', metaPageRowId: 'mp-1', mappingId: 'map-1' });
       deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
-      deps.MetaPage.findByPk = jest.fn().mockResolvedValue(pageRow);
+      // The teardown read is ownership-conditioned (round-2 NEW-1): findOne
+      // with {id, connectionId} — still OUR page here, so it resolves.
+      deps.MetaPage.findOne = jest.fn().mockResolvedValue(pageRow);
       const order = [];
       deps.MetaPage.update = jest.fn(async (patch) => { order.push(patch.accessTokenEnc === null && !('isActive' in patch) ? 'wipe' : 'deactivate'); return [1]; });
       deps.graph.call = jest.fn(async (path, opts) => { order.push(`remote:${opts?.method}`); return {}; });
@@ -404,6 +428,21 @@ describe('metaConnectService (unit)', () => {
         expect.objectContaining({ status: 'disconnected', disconnectReason: 'agent_request' }),
         expect.objectContaining({ where: expect.objectContaining({ id: 'cx-1' }) })
       );
+    });
+
+    it('a takeover by a reconnect makes the old disconnect a NO-OP on the page (round-2 NEW-1)', async () => {
+      const { deps } = makeDeps();
+      // The page row is now owned by a DIFFERENT connection — teardown reads
+      // are conditioned on ownership and must find nothing.
+      const row = rowify({ id: 'cx-OLD', userId: USER.id, status: 'connected', metaPageRowId: 'mp-1', mappingId: null });
+      deps.MetaAgentConnection.findOne = jest.fn().mockResolvedValue(row);
+      deps.MetaPage.findOne = jest.fn().mockResolvedValue(null); // ownership predicate misses
+      const svc = makeMetaConnectService(deps);
+      await svc.disconnect({ agentMktrUserId: USER.mktrLeadsId });
+      expect(deps.graph.call).not.toHaveBeenCalled(); // no unsubscribe of the new owner
+      // The token wipe carried the ownership predicate.
+      const wipe = deps.MetaPage.update.mock.calls.find(([p]) => p.accessTokenEnc === null && !('isActive' in p));
+      expect(wipe[1].where).toMatchObject({ id: 'mp-1', connectionId: 'cx-OLD' });
     });
 
     const b64url = (buf) => buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');

--- a/backend/test/unit/metaController.test.js
+++ b/backend/test/unit/metaController.test.js
@@ -1,8 +1,9 @@
 import { jest } from '@jest/globals';
 import crypto from 'crypto';
 import '../setup.js';
-import { verifyWebhook, handleWebhook } from '../../src/controllers/metaController.js';
+import { verifyWebhook, handleWebhook, oauthCallback } from '../../src/controllers/metaController.js';
 import { armMetaLeadAds, disarmMetaLeadAdsForTests } from '../../src/services/metaLeadService.js';
+import { disarmMetaOauthForTests } from '../../src/services/metaConnectService.js';
 
 const SECRET = 'meta-app-secret-under-test';
 
@@ -100,6 +101,17 @@ describe('metaController (unit)', () => {
       const res = mockRes();
       await handleWebhook(signedReq({ object: 'page', entry: [] }), res);
       expect(res.sendStatus).toHaveBeenCalledWith(503);
+    });
+  });
+
+  describe('GET /oauth/callback (armed latch, round-2 #7)', () => {
+    it('an unarmed OAuth subsystem answers 503, never an acknowledged redirect', async () => {
+      process.env.META_OAUTH_ENABLED = 'true';
+      disarmMetaOauthForTests();
+      const res = mockRes();
+      await oauthCallback({ query: { code: 'c', state: 's' } }, res);
+      expect(res.sendStatus).toHaveBeenCalledWith(503);
+      delete process.env.META_OAUTH_ENABLED;
     });
   });
 });

--- a/backend/test/unit/metaGraphClient.test.js
+++ b/backend/test/unit/metaGraphClient.test.js
@@ -1,0 +1,72 @@
+import { jest } from '@jest/globals';
+import '../setup.js';
+import crypto from 'crypto';
+import { makeMetaGraphClient, GraphError, appsecretProof, redactGraphError } from '../../src/services/metaGraphClient.js';
+
+process.env.META_APP_SECRET = 'proof-secret';
+process.env.META_APP_ID = '1957';
+
+const jsonResponse = (body, { ok = true, status = 200 } = {}) => ({
+  ok, status, json: async () => body, text: async () => JSON.stringify(body),
+});
+
+describe('metaGraphClient (unit)', () => {
+  it('appsecret_proof is HMAC-SHA256(token, app secret) and rides every token call', async () => {
+    const expected = crypto.createHmac('sha256', 'proof-secret').update('TOK').digest('hex');
+    expect(appsecretProof('TOK')).toBe(expected);
+
+    const fetch = jest.fn().mockResolvedValue(jsonResponse({ id: '1' }));
+    const client = makeMetaGraphClient({ fetch });
+    await client.call('me', { token: 'TOK' });
+    expect(fetch.mock.calls[0][0]).toContain(`appsecret_proof=${expected}`);
+  });
+
+  it('error taxonomy: 404 + OAuth 100/190/102/10 permanent; 429/5xx/network retryable', async () => {
+    const cases = [
+      [{ ok: false, status: 404, body: {} }, false],
+      [{ ok: false, status: 400, body: { error: { type: 'OAuthException', code: 190, message: 'expired' } } }, false],
+      [{ ok: false, status: 403, body: { error: { type: 'OAuthException', code: 10, message: 'perm' } } }, false],
+      [{ ok: false, status: 429, body: { error: { code: 4 } } }, true],
+      [{ ok: false, status: 500, body: { error: { code: 2 } } }, true],
+    ];
+    for (const [{ ok, status, body }, retryable] of cases) {
+      const client = makeMetaGraphClient({ fetch: jest.fn().mockResolvedValue(jsonResponse(body, { ok, status })) });
+      await expect(client.call('x', { token: 'T' })).rejects.toMatchObject({ retryable });
+    }
+    const network = makeMetaGraphClient({ fetch: jest.fn().mockRejectedValue(new Error('ECONNRESET')) });
+    await expect(network.call('x', {})).rejects.toMatchObject({ retryable: true });
+  });
+
+  it('errors never carry tokens/codes/proofs', () => {
+    const msg = redactGraphError('failed access_token=EAAB123 appsecret_proof=beef code=SECRET Bearer EAAB.99');
+    expect(msg).not.toMatch(/EAAB|beef|SECRET/);
+  });
+
+  it('callAllPages follows paging.next to exhaustion', async () => {
+    const fetch = jest.fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 1 }], paging: { next: 'https://graph.facebook.com/next1' } }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 2 }], paging: { next: 'https://graph.facebook.com/next2' } }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 3 }] }));
+    const client = makeMetaGraphClient({ fetch });
+    const all = await client.callAllPages('me/accounts', { token: 'T' });
+    expect(all.map((x) => x.id)).toEqual([1, 2, 3]);
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('exchangeCodeForLongLivedToken chains code → short → long-lived', async () => {
+    const fetch = jest.fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'SHORT' }))
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'LONG', expires_in: 5184000 }));
+    const client = makeMetaGraphClient({ fetch });
+    const r = await client.exchangeCodeForLongLivedToken('CODE', 'https://api.mktr.sg/api/meta/oauth/callback');
+    expect(r).toEqual({ token: 'LONG', expiresIn: 5184000 });
+    expect(fetch.mock.calls[0][0]).toContain('code=CODE');
+    expect(fetch.mock.calls[1][0]).toContain('fb_exchange_token=SHORT');
+  });
+
+  it('a GraphError message is pre-redacted at construction', () => {
+    const err = new GraphError('boom access_token=EAABxyz', { retryable: false });
+    expect(err.message).not.toContain('EAABxyz');
+    expect(err.retryable).toBe(false);
+  });
+});

--- a/backend/test/unit/metaGraphClient.test.js
+++ b/backend/test/unit/metaGraphClient.test.js
@@ -11,14 +11,17 @@ const jsonResponse = (body, { ok = true, status = 200 } = {}) => ({
 });
 
 describe('metaGraphClient (unit)', () => {
-  it('appsecret_proof is HMAC-SHA256(token, app secret) and rides every token call', async () => {
+  it('tokens ride the Authorization header (never the URL); only the proof is a query param', async () => {
     const expected = crypto.createHmac('sha256', 'proof-secret').update('TOK').digest('hex');
     expect(appsecretProof('TOK')).toBe(expected);
 
     const fetch = jest.fn().mockResolvedValue(jsonResponse({ id: '1' }));
     const client = makeMetaGraphClient({ fetch });
     await client.call('me', { token: 'TOK' });
-    expect(fetch.mock.calls[0][0]).toContain(`appsecret_proof=${expected}`);
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toContain(`appsecret_proof=${expected}`);
+    expect(url).not.toContain('TOK');
+    expect(init.headers.Authorization).toBe('Bearer TOK');
   });
 
   it('error taxonomy: 404 + OAuth 100/190/102/10 permanent; 429/5xx/network retryable', async () => {
@@ -42,26 +45,47 @@ describe('metaGraphClient (unit)', () => {
     expect(msg).not.toMatch(/EAAB|beef|SECRET/);
   });
 
-  it('callAllPages follows paging.next to exhaustion', async () => {
+  it('callAllPages re-issues cursors through the client (token+proof re-applied), never follows foreign hosts, throws on overflow', async () => {
     const fetch = jest.fn()
-      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 1 }], paging: { next: 'https://graph.facebook.com/next1' } }))
-      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 2 }], paging: { next: 'https://graph.facebook.com/next2' } }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 1 }], paging: { next: 'https://graph.facebook.com/v23.0/x?after=c1', cursors: { after: 'c1' } } }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: 2 }], paging: { next: 'https://graph.facebook.com/v23.0/x?after=c2', cursors: { after: 'c2' } } }))
       .mockResolvedValueOnce(jsonResponse({ data: [{ id: 3 }] }));
     const client = makeMetaGraphClient({ fetch });
     const all = await client.callAllPages('me/accounts', { token: 'T' });
     expect(all.map((x) => x.id)).toEqual([1, 2, 3]);
-    expect(fetch).toHaveBeenCalledTimes(3);
+    // Every continuation went through the client: token stays in the header.
+    for (const [url, init] of fetch.mock.calls) {
+      expect(url).toContain('graph.facebook.com');
+      expect(init.headers.Authorization).toBe('Bearer T');
+    }
+    expect(fetch.mock.calls[1][0]).toContain('after=c1');
+
+    const foreign = makeMetaGraphClient({
+      fetch: jest.fn().mockResolvedValue(jsonResponse({ data: [], paging: { next: 'https://evil.example.com/x', cursors: { after: 'c' } } })),
+    });
+    await expect(foreign.callAllPages('me/accounts', { token: 'T' })).rejects.toMatchObject({ kind: 'pagination_host' });
+
+    const endless = makeMetaGraphClient({
+      fetch: jest.fn().mockResolvedValue(jsonResponse({ data: [{ id: 9 }], paging: { next: 'https://graph.facebook.com/v23.0/x?after=c', cursors: { after: 'c' } } })),
+    });
+    await expect(endless.callAllPages('me/accounts', { token: 'T' }, { maxPages: 3 })).rejects.toMatchObject({ kind: 'pagination_overflow' });
   });
 
-  it('exchangeCodeForLongLivedToken chains code → short → long-lived', async () => {
+  it('exchangeCodeForLongLivedToken uses POST form bodies — credentials never in URLs', async () => {
     const fetch = jest.fn()
       .mockResolvedValueOnce(jsonResponse({ access_token: 'SHORT' }))
       .mockResolvedValueOnce(jsonResponse({ access_token: 'LONG', expires_in: 5184000 }));
     const client = makeMetaGraphClient({ fetch });
     const r = await client.exchangeCodeForLongLivedToken('CODE', 'https://api.mktr.sg/api/meta/oauth/callback');
     expect(r).toEqual({ token: 'LONG', expiresIn: 5184000 });
-    expect(fetch.mock.calls[0][0]).toContain('code=CODE');
-    expect(fetch.mock.calls[1][0]).toContain('fb_exchange_token=SHORT');
+    const [url1, init1] = fetch.mock.calls[0];
+    const [url2, init2] = fetch.mock.calls[1];
+    expect(url1).not.toContain('CODE');
+    expect(url1).not.toContain('client_secret');
+    expect(init1.method).toBe('POST');
+    expect(init1.body).toContain('code=CODE');
+    expect(url2).not.toContain('SHORT');
+    expect(init2.body).toContain('fb_exchange_token=SHORT');
   });
 
   it('a GraphError message is pre-redacted at construction', () => {

--- a/backend/test/unit/metaLeadService.test.js
+++ b/backend/test/unit/metaLeadService.test.js
@@ -110,6 +110,7 @@ describe('metaLeadService (unit)', () => {
   beforeEach(() => {
     for (const k of ['META_APP_SECRET', 'HELD_LEAD_PING_ENABLED']) envBackup[k] = process.env[k];
     delete process.env.HELD_LEAD_PING_ENABLED;
+    process.env.META_APP_SECRET = 'proof-secret-for-lead-fetch';
   });
   afterEach(() => {
     for (const [k, v] of Object.entries(envBackup)) {
@@ -292,6 +293,9 @@ describe('metaLeadService (unit)', () => {
       expect(row.status).toBe('completed');
       expect(seq.txs[0].commit).toHaveBeenCalled();
       expect(deps.flushDeliveries).toHaveBeenCalled();
+      // appsecret_proof on the live lead fetch (fb-connect round-2 F5 pin):
+      // without it, Meta's "Require App Secret" setting dead-letters leads.
+      expect(deps.fetch.mock.calls[0][0]).toContain('appsecret_proof=');
     });
 
     it('undeliverable fallback assignee (no provenance) re-routes to the unmapped pool and quarantines', async () => {

--- a/docs/plans/facebook-connect-self-serve.md
+++ b/docs/plans/facebook-connect-self-serve.md
@@ -1,0 +1,213 @@
+# Connect Facebook — self-serve agent onboarding (v2, post-codex)
+
+**Status: REVIEWED DESIGN — build from this.** v1 verdict: "should not start
+unchanged" (8 areas). v2 folds in every finding. Green-lit by Shawn
+2026-08-07; the ONE gate that stays human is the Tech Provider submission.
+Foundation: the live Meta pipe (`docs/plans/meta-lead-ads-native-pipe.md`).
+
+## 0. Constraints (recon + review, verified)
+
+- App side is OTA-only: `Linking.openURL` + existing `mktrleads://` scheme +
+  broker polling (HitPay precedent). NO new native deps, no scheme changes.
+- Brokers: signed raw-body POST to `/api/external/*` — body `timestamp`,
+  ≤5 min age, ≤2 min future skew, `X-Webhook-Signature: sha256=<hex>`
+  (`externalBillingController.js:40` is the reference). Shared HMAC
+  middleware gets EXTRACTED, not copied a fourth time.
+- Graph work NEVER runs synchronously inside a public GET — the callback
+  enqueues; a worker provisions (the leadgen-inbox lesson, reused).
+- `meta_form_mappings` POST is create-only (409 on dup) — provisioning uses
+  service-level idempotent upserts, not the admin HTTP surface.
+- QR creation via `qrCodeService` (phone-lookup, caller-owned) is NOT
+  reusable here — a trusted internal `ensureMetaAgentQr()` is new work.
+- `Meta — Agent Ads` exists only as data (created 2026-08-07, id
+  `6ff250ab-…`) — bootstrap must ensure/validate it like `[Meta] Unmapped`:
+  active + `is_active` + `enforceLeadQuota=false` + `leadPriceCents` null
+  (either quota trigger must be off for "agents pay with ad spend").
+
+## 1. Data model — a real connection entity (migrations 116+)
+
+### `meta_agent_connections` — the state machine row
+
+| column | notes |
+|---|---|
+| id UUID PK | |
+| userId UUID NOT NULL FK users ON DELETE RESTRICT | LOCAL identity is ownership; `mktrLeadsId` is only the lookup key at start-time |
+| agentMktrUserId STRING | audit snapshot of the app-side id |
+| status | `awaiting_callback → provisioning → needs_page_selection → waiting_for_agent → connected → reauth_required → disconnected → failed` |
+| statusDetail TEXT | taxonomy code + redacted context |
+| fbUserIdAppScoped STRING | Meta app-scoped user id — required to service deauth/data-deletion callbacks |
+| pageId STRING NULL | set on selection; UNIQUE WHERE status='connected' (one active connection per page) |
+| metaPageRowId UUID NULL FK meta_pages | |
+| qrTagId UUID NULL / formId STRING NULL / mappingId UUID NULL | step receipts |
+| stateNonce STRING UNIQUE | single-use; consumed at callback |
+| attempts INT / nextAttemptAt / lastError (redacted) | worker backoff, leadgen-inbox pattern |
+| grantedScopes JSONB / pageTasks JSONB / leadsAccessOk BOOL | validation receipts |
+| tokenExpiresAt / dataAccessExpiresAt / lastTokenCheckAt | health probe fields |
+| connectedAt / disconnectedAt / disconnectReason | lifecycle |
+| createdAt/updatedAt (DB defaults) | |
+
+Partial unique: one row per user WHERE status IN
+('awaiting_callback','provisioning','needs_page_selection',
+'waiting_for_agent','connected','reauth_required') — 1:1 v1 (one active
+connection per agent AND per page).
+
+### `meta_pages` deltas (migration)
+
+`accessTokenEnc` → NULLABLE (disconnect wipes the token; the inactive row
+stays as a tombstone DENY — deleting it would re-arm the env fallback);
+add `connectionId UUID NULL`, `connectedVia STRING NULL`. Page tokens ONLY
+are stored (no user token in v1 — smaller blast radius; long-lived page
+tokens from a long-lived-user exchange, but treated as REVOCABLE, see §6).
+
+## 2. Flow — enqueue, provision, select, connect
+
+### 2.1 `start` (broker EF `mktr-agent-facebook`, action `start`)
+
+EF: JWT + live-row gate (403 `not_linked` WITHOUT calling the platform);
+signed POST → platform `/api/external/facebook-connect` `{action:'start',
+timestamp, requestId, agentMktrUserId}` (EF injects the id — app body never
+controls it). Platform: resolve `users.mktrLeadsId = agentMktrUserId` — on
+miss, trigger a targeted mirror sync once; still missing → 503
+`agent_sync_pending` (NOT `not_linked`). On hit: create/reuse the
+connection row (`awaiting_callback`, fresh `stateNonce`), return
+`{startUrl}` where state is **OPAQUE** — the nonce only; everything else
+lives server-side on the row. Dialog URL built from centralized config:
+`META_APP_ID` + `FB_LOGIN_CONFIG_ID` + `META_GRAPH_API_VERSION` (ONE
+validated setting — env.example still says v21 elsewhere; unify) +
+`redirect_uri = https://api.mktr.sg/api/meta/oauth/callback`.
+
+### 2.2 `GET /api/meta/oauth/callback?code&state` (public, declared, rate-limited)
+
+Does the MINIMUM: look up connection by nonce (single-use — consume
+atomically), stash `code` on the row, flip to `provisioning`, kick the
+worker, **302 to the HTTPS completion page** — never Graph work inline, and
+the redirect carries NOTHING but a coarse status (no page names, no
+details: URLs leak via history/referrers). Error dialogs (user denied etc.)
+→ `failed` with taxonomy, same redirect shape.
+
+Completion page: `https://redeem.sg/fb-connected` (tiny static page):
+"Return to the MKTR Leads app" **button** (`mktrleads://facebook`) +
+manual instructions — because a direct 302 to a custom scheme is unreliable
+on Android browsers, and another app could squat the scheme. The deep link
+is ONLY a "go refresh" prompt; the app renders state exclusively from the
+authenticated broker.
+
+### 2.3 Provisioning worker (SKIP LOCKED claims, fenced, backoff — the inbox pattern)
+
+Per `provisioning` row: code→token→long-lived exchange (with
+`appsecret_proof`), fetch `/me` (store `fbUserIdAppScoped`), paginate
+`/me/accounts` FULLY. Then:
+
+- 0 pages → `failed: no_pages`.
+- ≥2 pages → `needs_page_selection` (store the candidate list server-side;
+  the app screen shows it; broker action `select_page` — signed, validates
+  the choice against the stored list — resumes provisioning).
+- exactly 1 → auto-select.
+
+For the selected page, VALIDATE before wiring (permission ≠ usability):
+granted granular scopes cover the page; page `tasks` include lead-management
+/ advertising; `has_lead_access` / Lead Generation Terms accepted (surface a
+taxonomy code telling the agent exactly what to accept where if not).
+Then idempotent steps, each with a receipt on the row, each resumable:
+
+1. upsert `meta_pages` (page token sealed, `connectionId` linked).
+2. `POST /{page}/subscribed_apps?subscribed_fields=leadgen` — verify by
+   reading back.
+3. `ensureMetaAgentQr({userId, campaignId})` — NEW trusted service: sets
+   `assignedAgentId` directly (no phone lookup), explicit owner, idempotent
+   per (userId, campaignId), asserts the QR resolves to that exact agent.
+4. Form: search the page's existing forms for our deterministic marker
+   (name prefix + connectionId in a field) BEFORE creating — an uncertain
+   Graph response on retry must never mint duplicates. Create with the full
+   payload (questions, locale, privacy_policy, pinned PDPA disclaimer).
+5. Mapping upsert (service-level, not the 409-ing admin POST).
+6. `connected` + notify the agent (existing push machinery, type
+   `facebook_connected`).
+
+If at any step the local user has vanished (mirror hard-delete/deactivate):
+`waiting_for_agent` with bounded retries; provenance conflict or upstream
+deactivation → terminal. Agent deactivation/deletion flows gain a hook:
+active connections auto-disconnect first (and hard-delete eligibility
+refuses users with active connections until then).
+
+### 2.4 `status` / `disconnect` (broker actions)
+
+`status` → `{enabled, status, pageName, formName, lastLeadAt,
+needsSelection?: candidates}` — `enabled:false` when `META_OAUTH_ENABLED`
+off (screen hides itself; stop polling on blur/unmount/backoff — an old
+deep link must not strand a hidden screen polling 404s).
+`disconnect` → ONE transaction: connection `disconnected`, mapping
+inactive, `meta_pages.isActive=false` (tombstone DENY stays), THEN
+best-effort `DELETE /{page}/subscribed_apps` and token wipe
+(`accessTokenEnc=NULL`). Defined semantics for in-flight leads: inbox rows
+for a disconnected page dead-letter with `page_disconnected` (deliberate,
+documented — "no black hole" becomes "no SILENT black hole"); the app copy
+tells the agent that disconnecting MKTR does not stop their Meta ads or the
+form itself.
+
+## 3. App (mktr-leads repo — all OTA-safe)
+
+Profile row + `app/(tabs)/profile/facebook.tsx` (+ layout entry + typed
+routes regen). States mirror the connection machine incl.
+`needs_page_selection` (radio list → broker `select_page`) and
+`reauth_required` ([Reconnect]). `hooks/useFacebookReturnLink.ts` — screen-
+scoped `Linking.useURL()`, treated purely as refresh trigger; cold-start
+deep link routes Profile→facebook with `withAnchor`. Component tests per
+house pattern (react-test-renderer).
+
+## 4. Meta app config + review pack (all drafted in-repo)
+
+FB Login for Business **configuration** (config_id; user-access-token type)
+with the 5 permissions; Valid OAuth Redirect URI = the callback; **App
+domains + the completion-page domain registered**. NEW in v2 (review
+finding): **Deauthorize callback URL + Data Deletion Request URL** —
+`POST /api/meta/oauth/deauthorize` + `/data-deletion` (signed_request
+verified with app secret; locate by `fbUserIdAppScoped`; deauth →
+auto-disconnect; deletion → confirmation-code response + connection scrub
+job). `docs/reference/meta-app-review-pack.md` (CREATED with this feature,
+not referenced-only): per-permission justification ↔ screencast step map,
+test credentials + scratch Page, data-retention/deletion answers, exact
+domains. Review-pack lint test: every requested permission appears in the
+pack.
+
+## 5. Config
+
+`META_OAUTH_ENABLED` (boolean-flag audited; prod-on requires ALL OF:
+`META_LEAD_ADS_ENABLED=true`, `META_APP_ID`, `META_APP_SECRET`,
+`FB_LOGIN_CONFIG_ID`, `META_STATE_SECRET` (dedicated — not
+EXTERNAL_APP_SECRET reuse), `META_PAGE_TOKEN_ENC_KEY`,
+`META_AGENT_ADS_CAMPAIGN_ID`, `EXTERNAL_APP_SECRET`,
+`META_OAUTH_CALLBACK_ORIGIN` exact-https). EF env: `MKTR_FACEBOOK_URL`.
+Graph version: single source (`META_GRAPH_API_VERSION`), env.example
+unified.
+
+## 6. Token health + reconciliation (new section, review finding)
+
+Daily probe job over `connected` rows: `debug_token` (validity,
+`data_access_expires_at`, scopes drift) + subscription read-back + page
+tasks re-check. Failing → `reauth_required` + push to the agent + admin
+visibility (existing inbox-ops pattern: `GET /api/meta/connections?status=`).
+Metrics/logs: stuck `provisioning` age alarm, orphan-form detector, invalid
+token count, `page_disconnected` dead-letters.
+
+## 7. Tests
+
+State machine unit (every transition + fences + nonce single-use + expiry);
+Graph client (timeouts, error taxonomy, appsecret_proof, pagination);
+provisioning idempotency (every step crash-resumed; duplicate-form guard);
+page-selection matrix (0/1/N + invalid select); mirror-lag
+(`agent_sync_pending`, `waiting_for_agent`, deactivation mid-flight);
+disconnect transactionality + tombstone DENY + in-flight dead-letter
+taxonomy; deauth/data-deletion callbacks (signed_request fixtures); broker
+gate matrix; envValidation matrix; route-gate snapshot additions
+(callback + deauth + data-deletion under meta.js). Integration: full
+provision → simulated leadgen webhook for that page → routes to the agent.
+
+## 8. Delivery plan
+
+PR A (platform): schema + state machine + worker + broker endpoint + Graph
+client + bootstrap ensure + deauth/deletion + tests (flag off, inert).
+PR B (mktr-leads): EF broker + app screen + hook + tests; EF deploy;
+OTA after PR A is live. Then: dev-mode e2e on a scratch Page → screencast →
+review pack final → Shawn's ONE approval click for App Review → on grant,
+flag on → **Tech Provider submission: Shawn's explicit final confirm**.

--- a/docs/plans/fb-connect-review-round1.md
+++ b/docs/plans/fb-connect-review-round1.md
@@ -104,3 +104,35 @@ now rebased onto #434; the rest of 14 stands.
     connected; disconnect-vs-worker; sync hard-delete with connections;
     armed-latch 503s; appsecret_proof asserted on lead fetch; money-shot
     asserts sourceMetadata.utm + proof param; pagination host validation.
+
+---
+
+# Round 2 (2026-08-08) — verdict + disposition
+
+Round-2 codex: 4/19 fully fixed, 14 partial, 5 new findings. Disposition:
+
+**Fixed in the round-2 commit:** NEW-1 disconnect/reconnect ownership race
+(teardown reads/wipes conditioned on `meta_pages.connectionId` = ours) ·
+NEW-2 sync hard-delete = one txn over the EXACT candidate set (all
+predicates incl. live connections; terminal history scrubbed only for real
+deletees) · NEW-3 admin tombstone reactivation converts ownership to admin
+(live owner → 409) · NEW-4 selectPage conflict patch is status-conditioned ·
+NEW-5 117 down() prechecks before any DDL + single txn · round-2 #2
+`secretKind:'exchanging'` marks the code consumed BEFORE the token endpoint
+(resume ⇒ `code_ambiguous`, never a replay) · #7 HTTP callback answers 503
+when unarmed · #10 missing/empty page tasks now terminal · #12 scrub steps
+fail LOUD (error log + incomplete marker) · #6 `input_token` added to both
+redaction layers. New pins: exchanging-resume, tasks-missing, ownership
+no-op disconnect, lead-fetch `appsecret_proof`, callback-latch 503.
+
+**Accepted residuals for flag-off v1** (revisit before Advanced-Access
+launch, not before merge): real-DB two-worker/crash test rigs (deployment is
+single-instance; logical paths are pinned) · Sentry span/breadcrumb
+scrubbers beyond URL redaction (tokens no longer ride URLs) · per-operation
+Graph taxonomy splits (all client ops are our own writes/reads where 100 =
+our bug) · deep health drift (scopes/page-tasks re-verify on the daily
+probe; subscription drift IS probed) · form connection-marker beyond the
+deterministic name (page ownership already reserved) · `metaPageRowId` FK ·
+frontend sentryScrub mirror (completion page URLs carry only s/c) ·
+reauth-failure asset-cleanup nuance beyond restore-to-connected · TOS field
+absent tolerated with warn (explicit false is terminal).

--- a/docs/plans/fb-connect-review-round1.md
+++ b/docs/plans/fb-connect-review-round1.md
@@ -1,0 +1,106 @@
+# Connect Facebook backend — codex round 1 worklist (2026-08-08)
+
+**Verdict: not ship-ready.** Happy path works; restart/fencing/credential-
+custody/lifecycle paths can strand or misroute. Fix ALL below before PR.
+(Original review: session artifact; evidence line numbers are pre-rebase.)
+Finding 14's "label regression" sub-claim was a STALE-BASE artifact — branch
+now rebased onto #434; the rest of 14 stands.
+
+## Critical
+1. **Reauth treats the new OAuth code as a user token.** startConnect keeps
+   `fbUserIdAppScoped` → processConnection assumes sealed value is a token.
+   FIX: explicit secret PHASE (`oauth_code` | `long_token`) on the row (new
+   column `secretKind`); reauth is its own journey that only swaps
+   credentials on success; denial on reauth returns to `connected`, never
+   `failed`-orphaning live assets; disconnect must also find non-live rows'
+   assets.
+2. **Exchange-once isn't crash-safe.** Token persisted only after /me +
+   /me/permissions; a crash between exchange and persist re-uses the
+   consumed code → permanent fail. FIX: persist the long-lived token
+   IMMEDIATELY after exchange (fenced), THEN identity/permissions in a
+   separate resumable step; ambiguous exchange failure ⇒ require fresh code
+   (fail to reauth_required taxonomy `code_ambiguous`), never re-exchange.
+3. **Page not reserved before side effects.** pageId set only at connect;
+   partial-unique excludes awaiting; another connection / admin-managed page
+   can be overwritten. FIX: fenced-reserve pageId (status provisioning +
+   pageId set + unique check) BEFORE subscribe/form/mapping; meta_pages
+   upsert must reject rows owned by a DIFFERENT live connection
+   (`page_in_use` terminal taxonomy) and never silently take over
+   admin-registered (`connectedVia` null) pages without explicit policy;
+   include awaiting-with-page in the partial unique.
+4. **Disconnect/worker race.** Wiring writes aren't fence-checked; disconnect
+   updates by id only. FIX: check the claim fence (attempts) before EVERY
+   receipt write; disconnect flips status via conditional update and bumps
+   attempts (invalidates any in-flight claim); worker on fence loss runs
+   cleanup (deactivate page/mapping it just wrote if the row is now
+   disconnected).
+
+## High
+5. **Live lead fetch lacks appsecret_proof.** metaLeadService fetch uses
+   Bearer only → "Require App Secret" setting would dead-letter every lead.
+   FIX: add appsecret_proof to the leadgen fetch (derive from page token).
+6. **Secrets in query strings/logs.** client_secret/code/tokens ride URLs;
+   pino/Sentry see them; redactTokens.js misses these keys. FIX: send OAuth
+   exchanges as POST form bodies; access_token via Bearer header everywhere;
+   extend redactTokens (code, state, access_token, fb_exchange_token,
+   client_secret, appsecret_proof); scrub Sentry spans/breadcrumbs.
+7. **No armed latch for OAuth.** ensureMetaOauth failure leaves callable
+   surface. FIX: `metaOauthArmed` latch (same pattern as lead pipe);
+   start/callback/select/disconnect fail closed (503) until armed.
+8. **start/callback races + immortal nonce.** FIX: `stateExpiresAt`
+   (10 min) enforced at callback; nonce consume + status flip + code stash
+   in ONE conditional UPDATE (status='awaiting_callback' predicate);
+   serialize startConnect per user (row lock or upsert-on-conflict);
+   duplicate-create unique error → mapped 409.
+9. **RESTRICT FK breaks agent-sync hard delete forever.** FIX: sync's
+   delete path excludes users with connection rows + deactivation hook
+   auto-disconnects live connections; terminal-history policy: on user
+   hard-delete, scrub+delete terminal connection rows first (explicit
+   service), keep RESTRICT as the backstop.
+10. **Scopes/tasks/lead-access stored but not ENFORCED.** FIX: require the
+    granted set ⊇ required five; page tasks must include lead access
+    (MANAGE/ADVERTISE per Meta semantics); TOS check failure taxonomy
+    instead of silent skip (transient transport errors retry; explicit
+    false/missing → terminal `leadgen_tos_required` / `page_task_missing`).
+11. **Remote-first disconnect black-hole window.** Unsubscribe-then-crash =
+    UI says connected, Meta delivers nothing. FIX order: txn-disable local
+    intake FIRST (mapping+page inactive, status disconnected, token KEPT),
+    then best-effort remote unsubscribe, then wipe token (second update);
+    plus a repair sweep: inactive pages still holding tokens → wipe.
+12. **Data deletion doesn't delete.** FIX: scrub fbUserIdAppScoped,
+    agentMktrUserId, pageId/formId receipts, oauthCodeEnc across ALL
+    statuses; disconnect terminal rows' still-active assets too; opaque
+    confirmation code (random, stored) not the row PK.
+
+## Medium
+13. **waiting_for_agent is a sink holding secrets.** FIX: it re-enters the
+    claim query (bounded, longer backoff); on exhaustion → failed + secret
+    wipe.
+14. **Receipt/mapping trust.** FIX: re-validate receipt QR (type/status/
+    campaign/assigned agent) on reuse; form marker = deterministic name AND
+    connection check; mapping update refuses rows whose qrTag belongs to a
+    different live connection.
+15. **Pagination truncation + SSRF via paging.next.** FIX: validate next URL
+    host === graph.facebook.com + https; follow via the client (token+proof
+    re-applied); cap hit ⇒ throw `pagination_overflow`, never partial.
+16. **Taxonomy ignored outside exchange.** FIX: processConnection catches
+    GraphError: retryable → rethrow (backoff); permanent 190 →
+    reauth_required; permanent 100/10/102 → terminal taxonomy; also make
+    client taxonomy per-operation (code 100 permanent for oauth/forms, NOT
+    for reads).
+17. **Broker/app contract.** FIX: keep the broker route mounted whenever
+    META_LEAD_ADS_ENABLED (inner `enabled:false` response when OAuth off);
+    status DTO gains `enabled` + `lastLeadAt`; health probe adds
+    subscription read-back + scopes drift → reauth_required; admin
+    upsertPage refuses reactivating a tombstone without a fresh token
+    (`isActive ⇒ token present` invariant).
+18. **Config/schema gaps.** FIX: envValidation requires
+    META_OAUTH_CALLBACK_ORIGIN explicitly in prod; unify Graph version env
+    default (env.example v21 note → v23); model mirrors for the two partial
+    uniques (116) + FK; 117 down(): refuse (throw) when NULL-token rows
+    exist, else restore NOT NULL.
+19. **Test hardening.** Real-DB fence/concurrency tests (two workers, one
+    row); exchange-success-then-crash resume; reauth denial keeps
+    connected; disconnect-vs-worker; sync hard-delete with connections;
+    armed-latch 503s; appsecret_proof asserted on lead fetch; money-shot
+    asserts sourceMetadata.utm + proof param; pagination host validation.

--- a/src/pages/FbConnected.jsx
+++ b/src/pages/FbConnected.jsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+
+/**
+ * OAuth completion page (docs/plans/facebook-connect-self-serve.md §2.2).
+ *
+ * Facebook's dialog 302s the agent's browser here — NEVER directly to the
+ * mktrleads:// scheme (unreliable on Android; the scheme can be squatted).
+ * The page's only job: a user-tapped "Return to the app" button plus a
+ * coarse status line. All real state comes from the app's authenticated
+ * broker poll — the URL deliberately carries nothing but ?s= and ?c=.
+ */
+const COPY = {
+  pending: {
+    title: 'Almost done',
+    body: 'We are wiring your Facebook Page to MKTR Leads. Return to the app — your connection status will update there in a few seconds.',
+  },
+  denied: {
+    title: 'Connection cancelled',
+    body: 'You did not grant access, so nothing was connected. You can try again anytime from the app.',
+  },
+  error: {
+    title: 'Something went wrong',
+    body: 'The connection could not be started. Return to the app and try again — if it keeps happening, contact MKTR support.',
+  },
+};
+
+const wrap = {
+  minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+  background: '#f6f6f4', padding: 24, fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+const card = {
+  maxWidth: 420, width: '100%', background: '#fff', borderRadius: 16,
+  padding: '32px 28px', boxShadow: '0 8px 30px rgba(0,0,0,0.08)', textAlign: 'center',
+};
+const btn = {
+  display: 'inline-block', marginTop: 24, padding: '14px 28px', borderRadius: 12,
+  background: '#111', color: '#fff', textDecoration: 'none', fontWeight: 600, fontSize: 16,
+};
+
+export default function FbConnected() {
+  const status = useMemo(() => {
+    const s = new URLSearchParams(window.location.search).get('s');
+    return COPY[s] ? s : 'error';
+  }, []);
+  const { title, body } = COPY[status];
+  return (
+    <div style={wrap}>
+      <div style={card}>
+        <div style={{ fontSize: 40 }}>{status === 'pending' ? '✅' : status === 'denied' ? '↩️' : '⚠️'}</div>
+        <h1 style={{ fontSize: 22, margin: '12px 0 8px' }}>{title}</h1>
+        <p style={{ color: '#555', lineHeight: 1.5, margin: 0 }}>{body}</p>
+        <a style={btn} href="mktrleads://facebook">Return to the MKTR Leads app</a>
+        <p style={{ color: '#999', fontSize: 13, marginTop: 16 }}>
+          Button not working? Open the MKTR Leads app yourself — Profile → Facebook ads.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FbDataDeletion.jsx
+++ b/src/pages/FbDataDeletion.jsx
@@ -1,0 +1,29 @@
+import { useMemo } from 'react';
+
+/**
+ * Meta data-deletion status page (docs/plans/facebook-connect-self-serve.md §4).
+ * Facebook requires the data-deletion callback to return a URL where the
+ * person can check the request's status — this is that URL. The confirmation
+ * code is the connection id; deletion is synchronous (tokens wiped, connection
+ * scrubbed on callback), so the status is always "done".
+ */
+export default function FbDataDeletion() {
+  const code = useMemo(() => new URLSearchParams(window.location.search).get('code') || '', []);
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#f6f6f4', padding: 24, fontFamily: 'system-ui, -apple-system, sans-serif' }}>
+      <div style={{ maxWidth: 420, width: '100%', background: '#fff', borderRadius: 16, padding: '32px 28px', boxShadow: '0 8px 30px rgba(0,0,0,0.08)' }}>
+        <h1 style={{ fontSize: 22, margin: '0 0 8px' }}>Facebook data deletion</h1>
+        <p style={{ color: '#555', lineHeight: 1.5 }}>
+          Your Facebook data-deletion request has been completed: the connection between your
+          Facebook account and MKTR Leads was removed and its access tokens were destroyed.
+        </p>
+        {code ? (
+          <p style={{ color: '#555' }}>Confirmation code: <code style={{ background: '#f0f0ee', padding: '2px 6px', borderRadius: 6 }}>{code}</code></p>
+        ) : null}
+        <p style={{ color: '#999', fontSize: 13 }}>
+          Questions? Contact MKTR PTE. LTD. via the details in our Personal Data Policy.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -55,6 +55,8 @@ const Onboarding = lazy(() => import('./Onboarding'));
 const PendingApproval = lazy(() => import('./PendingApproval'));
 const ForgotPassword = lazy(() => import('./ForgotPassword'));
 const PersonalDataPolicy = lazy(() => import('./PersonalDataPolicy'));
+const FbConnected = lazy(() => import('./FbConnected'));
+const FbDataDeletion = lazy(() => import('./FbDataDeletion'));
 const LeadsPrivacy = lazy(() => import('./LeadsPrivacy'));
 const DevRoutes = lazy(() => import('../dev/DevRoutes'));
 
@@ -256,6 +258,8 @@ function PagesContent() {
  <Route path="/about" element={brand.showAbout ? <About /> : MARKETPLACE_ON ? <MarketplaceStatic mode="about" /> : <NotFoundForBrand />} />
  <Route path="/Contact" element={<Contact />} />
  <Route path="/personal-data-policy" element={<PersonalDataPolicy />} />
+ <Route path="/fb-connected" element={<FbConnected />} />
+ <Route path="/fb-data-deletion" element={<FbDataDeletion />} />
  <Route path="/leads/privacy" element={<LeadsPrivacy />} />
 
  {/* D13: internal/auth/admin/onboarding routes redirect to mktr.sg on the redeem build. */}


### PR DESCRIPTION
## What

The backend for agents connecting **their own Facebook Pages** to MKTR Leads with one tap — the platform half of the Connect Facebook button (the app-side screen is PR B). **Everything is dormant behind `META_OAUTH_ENABLED` (default off; production boot fails on partial config). Merging changes nothing until the flag + config exist.**

Design: `docs/plans/facebook-connect-self-serve.md` (codex-reviewed v2) · Review trail: `docs/plans/fb-connect-review-round1.md` (two adversarial rounds, dispositions + accepted residuals).

## How it works

Agent taps Connect (app, PR B) → broker EF → `/api/external/facebook-connect` mints an **opaque, 10-minute, single-use state** → Facebook Login for Business dialog → `GET /api/meta/oauth/callback` does the minimum (atomic nonce consume + sealed code stash) → **claim-fenced worker** exchanges (code marked consumed *before* the token endpoint — a crash resumes as `code_ambiguous`, never a replay), enforces the five required permissions + page tasks + leadgen TOS, **reserves the page** (unique across every live connection — second claimant gets terminal `page_in_use`), then idempotently wires: sealed page token → `meta_pages`, webhook subscription (with read-back), routing QR, personal lead form (created via API with the pinned PDPA disclaimer), form mapping. Reauth keeps live assets and **restores `connected` on denial/expiry**. Disconnect kills local intake first (tombstone DENY), then unsubscribes remotely, then wipes the token — all ownership-conditioned so a reconnect takeover is never clobbered. Deauthorize + data-deletion callbacks (signed_request-verified) auto-disconnect and genuinely scrub. Daily probe validates tokens + subscription drift.

## Review rigor

Two full adversarial rounds: round 1 = 19 findings (4 critical) — all addressed; round 2 verified fixes and found 5 more (1 critical) — criticals + cheap correctness fixed, and a short list of deep-polish items (multi-worker test rigs, telemetry span scrubbers, per-op error nuance) is **explicitly documented as accepted residuals for a flag-off v1** in the review-trail doc — to revisit before the Advanced-Access launch, not before merging dormant code.

## Tests

27 connect-service unit + 6 Graph-client + 3 DB integration (full journey → **a leadgen webhook for the connected page routes to that exact agent through the live pipe**; broker HMAC/status/disconnect-tombstone; multi-page selection + `page_in_use` conflict). Full battery: **2700 unit / 2318 integration / 23 migrations / eslint be+fe / typecheck — green with captured exit codes.**

## Config (all new, nothing required today)

`META_OAUTH_ENABLED`, `META_APP_ID`, `FB_LOGIN_CONFIG_ID`, `META_AGENT_ADS_CAMPAIGN_ID`, `META_OAUTH_CALLBACK_ORIGIN` (+ existing META_* secrets). Migrations 116/117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUuqU2nS4jZEaMs2yPZXFT