### PR TITLE
fix(meta): leadgen_tos_accepted is advisory, not a gate (unblock self-serve connect)

### DIFF
--- a/backend/src/services/metaConnectService.js
+++ b/backend/src/services/metaConnectService.js
@@ -37,6 +37,20 @@ const LIVE = ['awaiting_callback', 'provisioning', 'needs_page_selection', 'wait
 const REQUIRED_SCOPES = ['leads_retrieval', 'pages_show_list', 'pages_manage_metadata', 'pages_read_engagement', 'pages_manage_ads'];
 const LEAD_CAPABLE_TASKS = ['MANAGE', 'ADVERTISE'];
 
+// Meta's "Page hasn't accepted the Lead Ads Terms" refusal, as it surfaces from
+// a real subscribe / leadgen_forms call. The error_subcode is the durable
+// signal; the message fallback catches wording drift — Meta uses both "Lead Ad
+// Terms" and "Lead Generation Terms of Service". Only consulted after a
+// permanent GraphError on a lead-ads op, so co-occurrence of "lead" with
+// terms/TOS is a high-precision signal (no unrelated messages live there).
+const LEADGEN_TOS_SUBCODES = new Set([1815605]);
+function isLeadgenTosError(err) {
+  if (!err) return false;
+  if (err.subcode != null && LEADGEN_TOS_SUBCODES.has(Number(err.subcode))) return true;
+  const msg = String(err.message || '');
+  return /lead/i.test(msg) && /(terms?|\btos\b)/i.test(msg);
+}
+
 const cxAad = (row) => `cx:${row.id}`;
 
 // ── armed latch (F7): the server shell keeps mounted routes serving even
@@ -316,6 +330,18 @@ export function makeMetaConnectService(overrides = {}) {
 
   /** Map a permanent GraphError to the right terminal (F16). */
   async function graphTerminal(row, err, phase) {
+    // A genuine "this Page hasn't accepted the Lead Ads Terms" refusal from the
+    // real subscribe / form-create calls maps to the actionable taxonomy so the
+    // app shows the exact fix (accept the TOS), instead of an opaque graph code.
+    // Meta signals it via subcode 1815605 or a message mentioning the lead-ads
+    // terms; match either, only on the operations where it can actually occur.
+    if (['subscribe', 'forms', 'form_create'].includes(phase) && isLeadgenTosError(err)) {
+      await fencedPatch(row, {
+        status: 'failed', statusDetail: 'leadgen_tos_required',
+        leadsAccessOk: false, oauthCodeEnc: null, secretKind: null,
+      });
+      return { status: 'failed' };
+    }
     const detail = `${phase}:graph_${err.code ?? err.kind ?? 'permanent'}`;
     if (err.code === 190) {
       await fencedPatch(row, {
@@ -501,22 +527,30 @@ export function makeMetaConnectService(overrides = {}) {
       });
       return { status: 'failed' };
     }
+    // `leadgen_tos_accepted` is an ADVISORY page signal, NOT a gate: it reports
+    // false even for pages with ACTIVE lead forms that deliver leads, and a page
+    // token can create forms on such a page anyway (verified live against the
+    // production Redeem SG page, 2026-08-08 — false here yet form-create + lead
+    // delivery both work). Hard-failing on `=== false` was a universal
+    // false-negative that blocked EVERY self-serve connect. We record the signal
+    // for observability and let the authoritative gate be the real subscribe +
+    // form-create calls below, which surface a genuine Lead-Ads-TOS refusal via
+    // graphTerminal → `leadgen_tos_required` (see isLeadgenTosError).
     let leadsAccessOk = null;
     try {
       const pageInfo = await graph.call(String(page.id), {
         token: page.access_token, params: { fields: 'leadgen_tos_accepted' },
       });
-      if (pageInfo.leadgen_tos_accepted === false) {
-        await fencedPatch(row, {
-          status: 'failed', statusDetail: 'leadgen_tos_required',
-          pageTasks: page.tasks || null, leadsAccessOk: false, oauthCodeEnc: null, secretKind: null,
-        });
-        return { status: 'failed' };
-      }
-      leadsAccessOk = pageInfo.leadgen_tos_accepted === true ? true : null;
+      leadsAccessOk = pageInfo.leadgen_tos_accepted === true ? true
+        : pageInfo.leadgen_tos_accepted === false ? false : null;
     } catch (err) {
-      if (err instanceof GraphError && !err.retryable) return graphTerminal(row, err, 'tos');
-      throw err; // transport errors retry — drift must not bypass the gate silently
+      // The advisory read failing must not fail the connect on its own — the
+      // real operations below decide. Only a dead token (190) is worth stopping
+      // for; everything else proceeds and the subscribe/form calls re-surface it.
+      if (err instanceof GraphError && !err.retryable && err.code === 190) {
+        return graphTerminal(row, err, 'tos');
+      }
+      // otherwise: swallow, leave leadsAccessOk null, continue to the real gate.
     }
 
     // ── meta_pages provenance (F3): never take over someone else's page ──

--- a/backend/test/unit/metaConnectService.test.js
+++ b/backend/test/unit/metaConnectService.test.js
@@ -261,6 +261,80 @@ describe('metaConnectService (unit)', () => {
       expect(deps.MetaFormMapping.create).toHaveBeenCalledWith(expect.objectContaining({ formId: 'form-77', qrTagId: 'qr-1' }));
     });
 
+    it('leadgen_tos_accepted:false is ADVISORY, not a gate — a lead-capable page still connects (2026-08-08 false-negative fix)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'Redeem SG', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
+      // Override ONLY the page-node advisory read to report false (as the real
+      // Redeem SG page does) — subscribe + form-create still succeed downstream.
+      const happy = deps.graph.call.getMockImplementation();
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (String(path).match(/^\d+$/)) return { leadgen_tos_accepted: false };
+        return happy(path, opts);
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'connected' });
+      expect(row.status).toBe('connected');
+      // The signal is recorded for observability, never used to block.
+      const patches = deps.MetaAgentConnection.update.mock.calls.map(([p]) => p);
+      expect(patches.some((p) => p.leadsAccessOk === false)).toBe(true);
+      expect(patches.some((p) => p.statusDetail === 'leadgen_tos_required')).toBe(false);
+    });
+
+    it('a GENUINE Lead-Ads-TOS refusal at form-create maps to leadgen_tos_required (subcode 1815605)', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
+      const happy = deps.graph.call.getMockImplementation();
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') {
+          throw new GraphError('The Page has not accepted the Lead Ad terms of service', { retryable: false, code: 100, subcode: 1815605 });
+        }
+        return happy(path, opts);
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('leadgen_tos_required');
+      expect(row.leadsAccessOk).toBe(false);
+    });
+
+    it('the TOS message fallback catches wording drift with NO subcode ("Lead Generation Terms of Service")', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
+      const happy = deps.graph.call.getMockImplementation();
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') {
+          // Real Meta wording variant, and NO error_subcode — must still map via the regex.
+          throw new GraphError('(#100) You must accept the Lead Generation Terms of Service for this Page', { retryable: false, code: 100 });
+        }
+        return happy(path, opts);
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('leadgen_tos_required');
+    });
+
+    it('an UNRELATED permanent 100 error at form-create is NOT mislabeled as TOS', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const row = provisioningRow();
+      wireHappyGraph(deps, { pages: [{ id: '111', name: 'P', access_token: 'PAGE-TOK', tasks: ['MANAGE'] }] });
+      const happy = deps.graph.call.getMockImplementation();
+      deps.graph.call.mockImplementation(async (path, opts = {}) => {
+        if (String(path).endsWith('/leadgen_forms') && opts.method === 'POST') {
+          throw new GraphError('(#100) Invalid parameter: questions', { retryable: false, code: 100 });
+        }
+        return happy(path, opts);
+      });
+      const r = await svc.processConnection(row);
+      expect(r).toEqual({ status: 'failed' });
+      expect(row.statusDetail).toBe('form_create:graph_100');
+    });
+
     it('resume after crash-post-exchange does NOT re-exchange (secretKind long_token)', async () => {
       const { deps } = makeDeps();
       const svc = makeMetaConnectService(deps);


### PR DESCRIPTION
## The bug (found in live rehearsal, 2026-08-08)
The Connect Facebook provisioning flow hard-failed when the page-level Graph field `leadgen_tos_accepted` was `false` → a **universal false-negative**. Verified against production:
- The real **Redeem SG** page reports `leadgen_tos_accepted: false` **yet has ACTIVE lead forms delivering leads today**.
- A page token **successfully creates** `leadgen_forms` on that page despite the field being false (confirmed by an actual API create).

So the gate would have blocked **every** agent connect.

## The fix
- Demote `leadgen_tos_accepted` to an **advisory signal** (`leadsAccessOk` true/false/null; never fails on it). Only a dead-token `190` during the advisory read still stops.
- Make the **authoritative gate** the real `subscribed_apps` + `leadgen_forms` operations. A **genuine** Lead-Ads-TOS refusal from those (error_subcode `1815605`, or a wording-robust message match covering both "Lead Ad Terms" and "Lead Generation Terms of Service") maps to `statusDetail: leadgen_tos_required` in `graphTerminal` — so a truly-unaccepted page still shows the app's actionable copy.

## Review + tests
Codex-reviewed (one finding folded in: broadened the message matcher for wording drift + added the missing regex-path and negative-precision tests). Four targeted unit tests: false-signal page still connects · genuine TOS by subcode maps · wording-drift message with no subcode maps · unrelated 100 error is not mislabeled. **77/77** across all six meta suites; integration journey green.

Backend auto-deploys on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUuqU2nS4jZEaMs2yPZXFT