### PR TITLE
fix(meta): sweep abandoned OAuth dialogs (server-side self-heal)

### DIFF
--- a/backend/src/services/metaConnectService.js
+++ b/backend/src/services/metaConnectService.js
@@ -678,12 +678,51 @@ export function makeMetaConnectService(overrides = {}) {
     return { status: 'connected' };
   }
 
+  // ── abandoned-dialog sweep ───────────────────────────────────────────────
+  // The agent opened the Facebook dialog and never continued: the callback
+  // never fires, so nothing else ever moves the row out of awaiting_callback
+  // (the app offers Cancel, but the server must self-heal too — an agent who
+  // just backs out should find the clean pitch on a cold revisit, not a
+  // forever-pending connect). Terminal semantics mirror the expired-callback
+  // path (dialogFailurePatch): a reauth attempt restores `connected` with its
+  // assets intact; a fresh attempt becomes `disconnected` — the same state the
+  // app's Cancel produces. Grace runs PAST the nonce TTL so we only ever sweep
+  // rows whose callback would be refused as state_expired anyway; conditional
+  // UPDATEs keyed on status make a concurrent callback race a no-op in either
+  // order.
+  const ABANDON_GRACE_MS = 5 * 60 * 1000;
+  async function sweepAbandonedDialogs() {
+    const cutoff = new Date(Date.now() - ABANDON_GRACE_MS);
+    const wipe = { stateNonce: null, stateExpiresAt: null, oauthCodeEnc: null, secretKind: null };
+    const [restored] = await d.MetaAgentConnection.update(
+      { ...wipe, status: 'connected', statusDetail: 'state_expired' },
+      { where: { status: 'awaiting_callback', stateExpiresAt: { [Op.lt]: cutoff }, connectedAt: { [Op.ne]: null } } }
+    );
+    const [cleared] = await d.MetaAgentConnection.update(
+      {
+        ...wipe,
+        status: 'disconnected', statusDetail: 'abandoned',
+        disconnectReason: 'abandoned', disconnectedAt: new Date(),
+      },
+      { where: { status: 'awaiting_callback', stateExpiresAt: { [Op.lt]: cutoff }, connectedAt: null } }
+    );
+    if (restored + cleared > 0) {
+      d.logger.info('[MetaConnect] swept abandoned dialogs', { restored, cleared });
+    }
+    return { restored, cleared };
+  }
+
   let draining = false;
   async function drainMetaConnections({ batchSize = 5, maxBatches = 4 } = {}) {
     if (draining) return { drained: 0, note: 'already draining' };
     draining = true;
     let drained = 0;
     try {
+      // Piggyback the worker cadence (60s interval + every callback kick) —
+      // cheap conditional UPDATEs, and a sweep failure must never block claims.
+      await sweepAbandonedDialogs().catch((err) => {
+        d.logger.warn('[MetaConnect] abandon sweep failed', { error: err?.message });
+      });
       for (let i = 0; i < maxBatches; i += 1) {
         const rows = await claimDue(batchSize);
         if (rows.length === 0) break;
@@ -973,7 +1012,7 @@ export function makeMetaConnectService(overrides = {}) {
     startConnect, handleOAuthCallback, drainMetaConnections, processConnection,
     selectPage, getConnectionStatus, disconnect, disconnectForUsers,
     handleDeauthorize, handleDataDeletion, probeConnectionsHealth,
-    ensureMetaAgentQr, formNameFor,
+    ensureMetaAgentQr, formNameFor, sweepAbandonedDialogs,
   };
 }
 

--- a/backend/test/unit/metaConnectService.test.js
+++ b/backend/test/unit/metaConnectService.test.js
@@ -482,6 +482,60 @@ describe('metaConnectService (unit)', () => {
     });
   });
 
+  describe('sweepAbandonedDialogs (abandoned "Finish in your browser")', () => {
+    it('fresh abandons → disconnected/abandoned; reauth abandons → connected restored; both wipe dialog secrets', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      const r = await svc.sweepAbandonedDialogs();
+      expect(r).toEqual({ restored: 1, cleared: 1 });
+
+      const calls = deps.MetaAgentConnection.update.mock.calls;
+      expect(calls).toHaveLength(2);
+
+      // Reauth pass: previously-connected rows RESTORE connected (assets stay wired).
+      const [restorePatch, restoreOpts] = calls[0];
+      expect(restorePatch).toEqual(expect.objectContaining({
+        status: 'connected', statusDetail: 'state_expired',
+        stateNonce: null, stateExpiresAt: null, oauthCodeEnc: null, secretKind: null,
+      }));
+      expect(restoreOpts.where.status).toBe('awaiting_callback');
+      expect(restoreOpts.where.connectedAt).not.toBeNull();
+
+      // Fresh pass: never-connected rows land on the SAME state the app's Cancel
+      // produces, so cold revisits render the pitch.
+      const [clearPatch, clearOpts] = calls[1];
+      expect(clearPatch).toEqual(expect.objectContaining({
+        status: 'disconnected', statusDetail: 'abandoned', disconnectReason: 'abandoned',
+        stateNonce: null, oauthCodeEnc: null, secretKind: null,
+      }));
+      expect(clearPatch.disconnectedAt).toBeInstanceOf(Date);
+      expect(clearOpts.where.status).toBe('awaiting_callback');
+      expect(clearOpts.where.connectedAt).toBeNull();
+
+      // Both passes only touch rows expired PAST the grace window — the cutoff
+      // sits before now (TTL already elapsed), so a live dialog is never swept.
+      for (const [, opts] of calls) {
+        // Op.lt is a Symbol key — read it via getOwnPropertySymbols.
+        const clause = opts.where.stateExpiresAt;
+        const cutoff = clause[Object.getOwnPropertySymbols(clause)[0]];
+        expect(cutoff).toBeInstanceOf(Date);
+        expect(cutoff.getTime()).toBeLessThan(Date.now());
+      }
+    });
+
+    it('runs on every drain and NEVER blocks claims when it fails', async () => {
+      const { deps } = makeDeps();
+      const svc = makeMetaConnectService(deps);
+      deps.MetaAgentConnection.update.mockRejectedValueOnce(new Error('db blip'));
+      const r = await svc.drainMetaConnections();
+      expect(r).toEqual({ drained: 0 });
+      expect(deps.logger.warn).toHaveBeenCalledWith(
+        '[MetaConnect] abandon sweep failed',
+        expect.objectContaining({ error: 'db blip' })
+      );
+    });
+  });
+
   describe('disconnect ordering (F11) + platform callbacks (F12)', () => {
     it('disconnect: local intake dies in one txn (token KEPT), then remote unsubscribe, then token wipe', async () => {
       const { deps } = makeDeps();


### PR DESCRIPTION
Completes the abandoned-connect fix shipped app-side via OTA (Cancel + honest copy): rows stuck in `awaiting_callback` because the agent never finished in the browser now self-heal on the worker cadence.

- Reauth abandons → **restore `connected`** (`state_expired`), assets stay wired — mirrors the existing expired-callback semantics.
- Fresh abandons → **`disconnected`/`abandoned`** — the same state the app's Cancel produces, so cold revisits render the pitch.
- Grace runs past the nonce TTL (sweep only touches rows whose callback would already be refused); conditional UPDATEs make the callback race a no-op in either order; sweep failures never block claims.

Codex review: **SHIP** (no findings). 79/79 across all six meta suites incl. the live-pipe integration journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUuqU2nS4jZEaMs2yPZXFT