### PR TITLE
feat(redeem-ops): outreach personas + Workspace directory — email auto-send Phase A (dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -558,6 +558,15 @@ REDEEM_OPS_CADENCE_CAP=60
 # OPENAI_API_KEY / ANTHROPIC_API_KEY)
 REDEEM_OPS_CADENCES_AI_ENABLED=false
 
+# ── Cadence email auto-send (Phase A: personas + Workspace directory;
+#    migration 119; docs/plans/redeem-ops-cadence-email-autosend.md) ─────────
+# Settings card + persona/workspace-address routes (needs REDEEM_OPS_ENABLED).
+# Phase A never emails a prospect — test-send goes to the account's own inbox.
+REDEEM_OPS_EMAIL_AUTOSEND_ENABLED=false
+# Encrypts the pasted Google service-account key (own key — NEVER reuse
+# AI_SETTINGS_ENCRYPTION_KEY; rotating one must not brick the other). ≥32 chars.
+OUTREACH_MAILBOX_ENCRYPTION_KEY=
+
 # ── Discover tool (Apify prospecting; migration 053) ──────────────────────────
 DISCOVERY_ENABLED=false                       # master switch (also gates the reconcile sweep)
 DISCOVERY_IG_ENABLED=false                    # Instagram hashtag-discovery pilot (Maps stays primary)

--- a/backend/src/controllers/redeemOps/outreachController.js
+++ b/backend/src/controllers/redeemOps/outreachController.js
@@ -1,0 +1,74 @@
+import Joi from 'joi';
+import { asyncHandler, AppError } from '../../middleware/errorHandler.js';
+import outreachPersonaService from '../../services/redeemOps/outreachPersonaService.js';
+
+/**
+ * Outreach sending identities — Phase A (plan §7). Everything here is
+ * `settings.manage` (route-level): connecting a Workspace account and mapping
+ * personas is admin work, same tier as categories.
+ */
+
+function validateBody(schema, body) {
+  const { error, value } = schema.validate(body, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  return value;
+}
+
+const setupSchema = Joi.object({
+  accountEmail: Joi.string().email().required(),
+  // The pasted service-account key file. Validated + encrypted server-side;
+  // never returned by any endpoint.
+  serviceAccountJson: Joi.string().min(100).max(20000).required(),
+});
+
+export const getAccount = asyncHandler(async (req, res) => {
+  res.json({ success: true, data: await outreachPersonaService.getAccountStatus() });
+});
+
+export const setupAccount = asyncHandler(async (req, res) => {
+  const body = validateBody(setupSchema, req.body || {});
+  const result = await outreachPersonaService.setupAccount(body, req.user, req.id);
+  res.json({ success: true, data: result });
+});
+
+export const refreshHealth = asyncHandler(async (req, res) => {
+  const health = await outreachPersonaService.refreshHealth(req.user, req.id);
+  res.json({ success: true, data: { health } });
+});
+
+export const workspaceAddresses = asyncHandler(async (req, res) => {
+  res.json({ success: true, data: await outreachPersonaService.listWorkspaceAddresses() });
+});
+
+export const listPersonas = asyncHandler(async (req, res) => {
+  const personas = await outreachPersonaService.listPersonas();
+  res.json({ success: true, data: { personas } });
+});
+
+const importSchema = Joi.object({
+  addresses: Joi.array().items(Joi.string().email()).min(1).max(30).required(),
+});
+
+export const importPersonas = asyncHandler(async (req, res) => {
+  const body = validateBody(importSchema, req.body || {});
+  const result = await outreachPersonaService.importPersonas(body, req.user, req.id);
+  res.status(201).json({ success: true, data: result });
+});
+
+const updateSchema = Joi.object({
+  assignedUserId: Joi.string().uuid().allow(null),
+  displayName: Joi.string().max(120),
+  dailySendCap: Joi.number().integer().min(1).max(200),
+  isActive: Joi.boolean(),
+}).min(1);
+
+export const updatePersona = asyncHandler(async (req, res) => {
+  const body = validateBody(updateSchema, req.body || {});
+  const persona = await outreachPersonaService.updatePersona(req.params.personaId, body, req.user, req.id);
+  res.json({ success: true, data: { persona } });
+});
+
+export const testSend = asyncHandler(async (req, res) => {
+  const result = await outreachPersonaService.testSend(req.params.personaId, req.user, req.id);
+  res.json({ success: true, data: result });
+});

--- a/backend/src/database/migrations/119-outreach-accounts-personas.js
+++ b/backend/src/database/migrations/119-outreach-accounts-personas.js
@@ -1,0 +1,90 @@
+/**
+ * 119 — outreach sending identities (cadence email auto-send Phase A,
+ * docs/plans/redeem-ops-cadence-email-autosend.md §3).
+ *
+ * `outreach_accounts`: the Google Workspace mailbox the platform impersonates
+ * (business@mktr.sg today; a persona that turns out to be its own Google
+ * account gets a second row — plan F2). Carries the encrypted service-account
+ * key, the account-level warm-up cap (a shared-mailbox lockout bricks the
+ * company inbox for 24h — plan F7), and the reply-poll health fields the
+ * Phase-B sender gates on.
+ *
+ * `outreach_personas`: one row per sending alias (emily@redeem.sg …), tied to
+ * the CRM rep it belongs to (assignedUserId UNIQUE — the who-is-who).
+ * Personas without a rep, or reps without a persona, never send.
+ */
+
+export async function up(queryInterface, Sequelize) {
+  const tables = await queryInterface.showAllTables();
+
+  if (!tables.includes('outreach_accounts')) {
+    await queryInterface.createTable('outreach_accounts', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false },
+      provider: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'google' },
+      accountEmail: { type: Sequelize.STRING(160), allowNull: false, unique: true },
+      encryptedCredentials: { type: Sequelize.TEXT, allowNull: true },
+      dailySendCap: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 500 },
+      sentToday: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      sentTodayDate: { type: Sequelize.STRING(10), allowNull: true },
+      historyCursor: { type: Sequelize.STRING(32), allowNull: true },
+      lastSuccessfulPollAt: { type: Sequelize.DATE, allowNull: true },
+      lastHealthCheckAt: { type: Sequelize.DATE, allowNull: true },
+      lastError: { type: Sequelize.TEXT, allowNull: true },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      createdBy: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  }
+
+  if (!tables.includes('outreach_personas')) {
+    await queryInterface.createTable('outreach_personas', {
+      id: { type: Sequelize.UUID, primaryKey: true, allowNull: false },
+      accountId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'outreach_accounts', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      address: { type: Sequelize.STRING(160), allowNull: false, unique: true },
+      displayName: { type: Sequelize.STRING(120), allowNull: false },
+      assignedUserId: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      sendAsRegistered: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      sendAsVerified: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      isAccountAlias: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      dailySendCap: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 30 },
+      sentToday: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      sentTodayDate: { type: Sequelize.STRING(10), allowNull: true },
+      consecutiveFailures: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+      isActive: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: true },
+      lastError: { type: Sequelize.TEXT, allowNull: true },
+      createdBy: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+    // One persona per rep — the who-is-who mapping is 1:1 while assigned.
+    await queryInterface.sequelize.query(
+      'CREATE UNIQUE INDEX IF NOT EXISTS uq_op_assigned_user ON outreach_personas ("assignedUserId") WHERE "assignedUserId" IS NOT NULL'
+    );
+  }
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('outreach_personas');
+  await queryInterface.dropTable('outreach_accounts');
+}

--- a/backend/src/models/OutreachAccount.js
+++ b/backend/src/models/OutreachAccount.js
@@ -1,0 +1,31 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * The Google Workspace mailbox the platform impersonates for outreach email
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §3). One row today
+ * (business@mktr.sg); a persona that turns out to be its own Google account
+ * gets its own row (plan F2). Credentials = the service-account JSON key,
+ * encrypted with OUTREACH_MAILBOX_ENCRYPTION_KEY — never serialized out.
+ */
+const OutreachAccount = sequelize.define('OutreachAccount', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  provider: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'google' },
+  accountEmail: { type: DataTypes.STRING(160), allowNull: false, unique: true },
+  encryptedCredentials: { type: DataTypes.TEXT, allowNull: true },
+  dailySendCap: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 500 },
+  sentToday: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  sentTodayDate: { type: DataTypes.STRING(10), allowNull: true, comment: 'SGT date the counter belongs to (YYYY-MM-DD)' },
+  historyCursor: { type: DataTypes.STRING(32), allowNull: true, comment: 'Gmail historyId cursor for the Phase-C reply poll' },
+  lastSuccessfulPollAt: { type: DataTypes.DATE, allowNull: true, comment: 'Phase-B sender refuses to send when this is stale' },
+  lastHealthCheckAt: { type: DataTypes.DATE, allowNull: true },
+  lastError: { type: DataTypes.TEXT, allowNull: true },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+}, {
+  tableName: 'outreach_accounts',
+  defaultScope: { attributes: { exclude: ['encryptedCredentials'] } },
+  scopes: { withCredentials: { attributes: { include: ['encryptedCredentials'] } } },
+});
+
+export default OutreachAccount;

--- a/backend/src/models/OutreachPersona.js
+++ b/backend/src/models/OutreachPersona.js
@@ -1,0 +1,35 @@
+import { DataTypes, Op } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * A sending alias (emily@redeem.sg) tied to the CRM rep it belongs to
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §3). Personas without a
+ * rep never send; reps without a persona get manual tasks instead of a
+ * borrowed identity. isAccountAlias records the plan-F2 parentage check:
+ * the address must be an alias OF THE ACCOUNT ROW, or its replies land in
+ * somebody else's mailbox.
+ */
+const OutreachPersona = sequelize.define('OutreachPersona', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  accountId: { type: DataTypes.UUID, allowNull: false, references: { model: 'outreach_accounts', key: 'id' } },
+  address: { type: DataTypes.STRING(160), allowNull: false, unique: true },
+  displayName: { type: DataTypes.STRING(120), allowNull: false },
+  assignedUserId: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+  sendAsRegistered: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  sendAsVerified: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  isAccountAlias: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+  dailySendCap: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 30 },
+  sentToday: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  sentTodayDate: { type: DataTypes.STRING(10), allowNull: true },
+  consecutiveFailures: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+  lastError: { type: DataTypes.TEXT, allowNull: true },
+  createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },
+}, {
+  tableName: 'outreach_personas',
+  indexes: [
+    { fields: ['assignedUserId'], unique: true, name: 'uq_op_assigned_user', where: { assignedUserId: { [Op.ne]: null } } },
+  ],
+});
+
+export default OutreachPersona;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -191,6 +191,12 @@ function defineAssociations() {
   AgentGroupMember.belongsTo(AgentGroup, { foreignKey: 'agentGroupId', as: 'group' });
   AgentGroupMember.belongsTo(User, { foreignKey: 'userId', as: 'user', onDelete: 'SET NULL' });
 
+  // Outreach sending identities (cadence email auto-send Phase A). Personas
+  // die with their account; rep deletion only unassigns (SET NULL).
+  models.OutreachPersona.belongsTo(models.OutreachAccount, { foreignKey: 'accountId', as: 'account', onDelete: 'CASCADE' });
+  models.OutreachAccount.hasMany(models.OutreachPersona, { foreignKey: 'accountId', as: 'personas' });
+  models.OutreachPersona.belongsTo(User, { foreignKey: 'assignedUserId', as: 'assignedUser', onDelete: 'SET NULL' });
+
   // Redeem Ops associations (docs/redeem-ops/ERD.md). Append-only history/audit
   // rows must survive actor deletion: SET NULL, never cascade from users.
   const {
@@ -393,7 +399,8 @@ export const {
   SuppressionPropagation, Cohort, EmailBroadcast, EmailBroadcastRecipient,
   WaMessageStatus, WaMessageSend, ConsumerObservation, ConsumerProfile, EnrichmentJob,
   EnrichmentScoringConfig, EnrichmentSweepRun,
-  MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection
+  MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection,
+  OutreachAccount, OutreachPersona
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsOutreach.js
+++ b/backend/src/routes/redeemOpsOutreach.js
@@ -1,0 +1,38 @@
+import express from 'express';
+import { requireRedeemOps } from '../middleware/redeemOpsAuth.js';
+import * as ctrl from '../controllers/redeemOps/outreachController.js';
+
+/**
+ * Outreach sending identities — cadence email auto-send Phase A
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §7). Dark behind its OWN
+ * flag on top of the Redeem Ops module flag — both must be true. Phase A is
+ * setup-only: nothing here sends to a prospect (test-send goes to the
+ * account's own inbox).
+ */
+export const meta = {
+  path: '/api/redeem-ops',
+  flag: 'REDEEM_OPS_EMAIL_AUTOSEND_ENABLED',
+  flagDefault: 'false',
+};
+
+const router = express.Router();
+
+router.use((req, res, next) => {
+  if (String(process.env.REDEEM_OPS_ENABLED || 'false').toLowerCase() !== 'true') {
+    return res.status(404).json({ success: false, message: 'Not found' });
+  }
+  return next();
+});
+
+// Admin tier throughout — connecting a Workspace account and mapping who
+// sends as whom is settings work, not rep work.
+router.get('/outreach/account', requireRedeemOps('settings.manage'), ctrl.getAccount);
+router.put('/outreach/account', requireRedeemOps('settings.manage'), ctrl.setupAccount);
+router.post('/outreach/account/health', requireRedeemOps('settings.manage'), ctrl.refreshHealth);
+router.get('/outreach/workspace-addresses', requireRedeemOps('settings.manage'), ctrl.workspaceAddresses);
+router.get('/outreach/personas', requireRedeemOps('settings.manage'), ctrl.listPersonas);
+router.post('/outreach/personas/import', requireRedeemOps('settings.manage'), ctrl.importPersonas);
+router.patch('/outreach/personas/:personaId', requireRedeemOps('settings.manage'), ctrl.updatePersona);
+router.post('/outreach/personas/:personaId/test-send', requireRedeemOps('settings.manage'), ctrl.testSend);
+
+export default router;

--- a/backend/src/services/google/workspaceService.js
+++ b/backend/src/services/google/workspaceService.js
@@ -1,0 +1,156 @@
+import jwt from 'jsonwebtoken';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SHARED Google Workspace client (docs/plans/redeem-ops-cadence-email-autosend.md
+ * §2a) — generic, redeemOps-agnostic. Auth is a service account with
+ * domain-wide delegation impersonating a Workspace user; calls are plain REST
+ * via fetch (no googleapis dependency — jsonwebtoken signs the RS256
+ * assertion, the repo already carries it).
+ *
+ * Consumers today: outreach personas (Phase A: directory + send-as health,
+ * test-send). Future features import this same module and at most add a scope
+ * to the one DWD grant. Read-only against the directory BY DESIGN — no
+ * users/aliases writes live here (plan §2a).
+ */
+
+export const WORKSPACE_SCOPES = {
+  gmailSend: 'https://www.googleapis.com/auth/gmail.send',
+  gmailReadonly: 'https://www.googleapis.com/auth/gmail.readonly',
+  gmailSettingsBasic: 'https://www.googleapis.com/auth/gmail.settings.basic',
+  directoryReadonly: 'https://www.googleapis.com/auth/admin.directory.user.readonly',
+};
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const TOKEN_TTL_SLACK_MS = 60_000;
+
+/** Parse + sanity-check a pasted service-account JSON key. Throws plain Error. */
+export function parseServiceAccountKey(raw) {
+  let parsed;
+  try {
+    parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch {
+    throw new Error('Not valid JSON — paste the full service-account key file.');
+  }
+  if (parsed?.type !== 'service_account' || !parsed.client_email || !parsed.private_key) {
+    throw new Error('The JSON is not a service-account key (needs type, client_email, private_key).');
+  }
+  return { clientEmail: parsed.client_email, privateKey: parsed.private_key };
+}
+
+/**
+ * @param {object} opts
+ * @param {{clientEmail: string, privateKey: string}} opts.credentials
+ * @param {string} opts.subject   Workspace user to impersonate (must be the
+ *                                mailbox owner; admin-capable for directory calls)
+ * @param {string[]} opts.scopes
+ */
+export function makeWorkspaceClient({ credentials, subject, scopes, fetchImpl = fetch, now = () => new Date() }) {
+  let cached = null; // { token, expiresAt }
+
+  async function accessToken() {
+    if (cached && cached.expiresAt - TOKEN_TTL_SLACK_MS > now().getTime()) return cached.token;
+    const iat = Math.floor(now().getTime() / 1000);
+    const assertion = jwt.sign(
+      {
+        iss: credentials.clientEmail,
+        sub: subject,
+        aud: TOKEN_URL,
+        scope: scopes.join(' '),
+        iat,
+        exp: iat + 3500,
+      },
+      credentials.privateKey,
+      { algorithm: 'RS256' }
+    );
+    const res = await fetchImpl(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      // unauthorized_client = the DWD grant is missing/mismatched — the most
+      // common setup failure; surface Google's own words.
+      throw new Error(`Google token exchange failed (${res.status}): ${body.error || ''} ${body.error_description || ''}`.trim());
+    }
+    cached = { token: body.access_token, expiresAt: now().getTime() + (body.expires_in || 3600) * 1000 };
+    return cached.token;
+  }
+
+  async function api(url, { method = 'GET', json } = {}) {
+    const token = await accessToken();
+    const res = await fetchImpl(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(json ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(json ? { body: JSON.stringify(json) } : {}),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const err = new Error(`Google API ${method} ${url.split('?')[0]} → ${res.status}: ${body?.error?.message || 'unknown error'}`);
+      err.status = res.status;
+      throw err;
+    }
+    return body;
+  }
+
+  return {
+    // ── Directory (read-only) ────────────────────────────────────────────
+    /** Every user in the tenant with primaryEmail + aliases[] + emails[]. */
+    async listUsers() {
+      const users = [];
+      let pageToken = '';
+      do {
+        const page = await api(
+          `https://admin.googleapis.com/admin/directory/v1/users?customer=my_customer&maxResults=200&projection=full${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`
+        );
+        users.push(...(page.users || []));
+        pageToken = page.nextPageToken || '';
+      } while (pageToken);
+      return users;
+    },
+    /** The aliases OF ONE user — the plan-F2 parentage source of truth. */
+    async listUserAliases(email) {
+      const body = await api(`https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(email)}/aliases`);
+      return (body.aliases || []).map((a) => a.alias);
+    },
+
+    // ── Gmail (impersonated subject's mailbox) ───────────────────────────
+    async getProfile() {
+      return api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/profile`);
+    },
+    /** Send-as identities incl. verification status — the health card's feed. */
+    async listSendAs() {
+      const body = await api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/settings/sendAs`);
+      return body.sendAs || [];
+    },
+    /** Raw RFC-2822 send. Returns Gmail's { id, threadId, labelIds }. */
+    async sendRaw(rfc822) {
+      return api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/messages/send`, {
+        method: 'POST',
+        json: { raw: Buffer.from(rfc822, 'utf8').toString('base64url') },
+      });
+    },
+    /** Metadata of one message — used to learn the REAL wire Message-ID (plan F4). */
+    async getMessageHeaders(id, headerNames = ['Message-ID']) {
+      const qs = headerNames.map((h) => `metadataHeaders=${encodeURIComponent(h)}`).join('&');
+      return api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/messages/${encodeURIComponent(id)}?format=metadata&${qs}`);
+    },
+  };
+}
+
+/** Log-and-rethrow helper for boot-time health probes. */
+export async function safeProbe(label, fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    logger.warn({ err: err?.message }, `[workspace] ${label} failed`);
+    throw err;
+  }
+}

--- a/backend/src/services/redeemOps/outreachPersonaService.js
+++ b/backend/src/services/redeemOps/outreachPersonaService.js
@@ -1,0 +1,367 @@
+import { OutreachAccount, OutreachPersona, User, sequelize } from '../../models/index.js';
+import { AppError } from '../../middleware/appError.js';
+import { logger } from '../../utils/logger.js';
+import { makeSecretBox } from '../../utils/secretBox.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import {
+  makeWorkspaceClient, parseServiceAccountKey, WORKSPACE_SCOPES,
+} from '../google/workspaceService.js';
+
+/**
+ * Outreach sending identities — Phase A of cadence email auto-send
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §2/§2a/§3/§8-A).
+ *
+ * What lives here: the impersonated account (encrypted service-account key),
+ * the persona↔rep mapping, the plan-F2 PARENTAGE pre-flight (an address must
+ * be an alias OF THE ACCOUNT or its replies land in someone else's mailbox),
+ * send-as verification health (plan F1: registration itself is a manual
+ * Gmail tick — the platform only VERIFIES via sendAs.list), and the test-send
+ * that doubles as the plan-F4 empirical Message-ID probe.
+ *
+ * NO engine integration in Phase A — nothing here touches cadences.
+ */
+
+const outreachBox = makeSecretBox('OUTREACH_MAILBOX_ENCRYPTION_KEY', 'outreach mailbox');
+
+const ACCOUNT_SCOPES = [
+  WORKSPACE_SCOPES.gmailSend,
+  WORKSPACE_SCOPES.gmailReadonly,
+  WORKSPACE_SCOPES.gmailSettingsBasic,
+  WORKSPACE_SCOPES.directoryReadonly,
+];
+
+export function makeOutreachPersonaService(overrides = {}) {
+  const d = {
+    OutreachAccount, OutreachPersona, User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    secretBox: outreachBox,
+    makeClient: makeWorkspaceClient,
+    now: () => new Date(),
+    ...overrides,
+  };
+
+  async function accountRowTx(t, { withCredentials = false } = {}) {
+    const scope = withCredentials ? d.OutreachAccount.scope('withCredentials') : d.OutreachAccount;
+    return scope.findOne({ order: [['createdAt', 'ASC']], ...(t ? { transaction: t } : {}) });
+  }
+
+  function clientFor(account, credentialsJson) {
+    const credentials = parseServiceAccountKey(credentialsJson);
+    return d.makeClient({ credentials, subject: account.accountEmail, scopes: ACCOUNT_SCOPES });
+  }
+
+  async function decryptedClient(account) {
+    if (!account?.encryptedCredentials) {
+      throw new AppError('Connect the Workspace account first — paste the service-account key in Settings.', 409);
+    }
+    return clientFor(account, d.secretBox.decrypt(account.encryptedCredentials));
+  }
+
+  // ── Account setup & health ────────────────────────────────────────────────
+
+  /**
+   * Store (or replace) the impersonated account + its encrypted key, then run
+   * the health probe immediately so a bad DWD grant fails HERE, loudly, not
+   * at first send.
+   */
+  async function setupAccount({ accountEmail, serviceAccountJson }, user, requestId = null) {
+    const email = String(accountEmail || '').trim().toLowerCase();
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) throw new AppError('A valid account email is required', 400);
+    let credentials;
+    try {
+      credentials = parseServiceAccountKey(serviceAccountJson);
+    } catch (err) {
+      throw new AppError(err.message, 400);
+    }
+
+    const encrypted = d.secretBox.encrypt(JSON.stringify({
+      type: 'service_account', client_email: credentials.clientEmail, private_key: credentials.privateKey,
+    }));
+
+    const account = await d.sequelize.transaction(async (t) => {
+      const existing = await accountRowTx(t, { withCredentials: true });
+      if (existing && existing.accountEmail !== email) {
+        // One account row in Phase A — replacing the address is explicit.
+        await existing.update({ accountEmail: email, encryptedCredentials: encrypted, lastError: null }, { transaction: t });
+        return existing;
+      }
+      if (existing) {
+        await existing.update({ encryptedCredentials: encrypted, lastError: null }, { transaction: t });
+        return existing;
+      }
+      return d.OutreachAccount.create({
+        accountEmail: email, encryptedCredentials: encrypted, createdBy: user.id,
+      }, { transaction: t });
+    });
+
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'outreach.account_configured', entityType: 'outreach_account',
+      entityId: account.id, after: { accountEmail: email, keyClient: credentials.clientEmail }, requestId,
+    });
+
+    // Probe immediately; failures are stored on the row AND thrown to the caller.
+    const health = await refreshHealth(user, requestId).catch((err) => ({ error: err.message }));
+    return { account: await getAccountStatus(), health };
+  }
+
+  /**
+   * Live health: token exchange works, mailbox reachable, send-as list +
+   * parentage per persona. Persists per-persona sendAs/parentage flags so the
+   * UI reads truth even between probes.
+   */
+  async function refreshHealth(user = null, requestId = null) {
+    const account = await d.OutreachAccount.scope('withCredentials').findOne({ order: [['createdAt', 'ASC']] });
+    if (!account) throw new AppError('No Workspace account configured yet', 404);
+    const client = await decryptedClient(account);
+
+    let profile;
+    let sendAs;
+    let aliases;
+    try {
+      profile = await client.getProfile();
+      sendAs = await client.listSendAs();
+      aliases = await client.listUserAliases(account.accountEmail);
+      await account.update({ lastHealthCheckAt: d.now(), lastError: null });
+    } catch (err) {
+      await account.update({ lastHealthCheckAt: d.now(), lastError: String(err.message).slice(0, 500) });
+      throw new AppError(`Workspace health check failed: ${err.message}`, 502);
+    }
+
+    const aliasSet = new Set(aliases.map((a) => a.toLowerCase()));
+    const sendAsByEmail = new Map(sendAs.map((s) => [String(s.sendAsEmail || '').toLowerCase(), s]));
+
+    const personas = await d.OutreachPersona.findAll({ where: { accountId: account.id } });
+    for (const p of personas) {
+      const addr = p.address.toLowerCase();
+      const s = sendAsByEmail.get(addr);
+      await p.update({
+        isAccountAlias: aliasSet.has(addr),
+        sendAsRegistered: Boolean(s),
+        sendAsVerified: Boolean(s && (s.verificationStatus === 'accepted' || s.isPrimary)),
+      });
+    }
+
+    return {
+      accountEmail: account.accountEmail,
+      mailboxOk: Boolean(profile?.emailAddress),
+      aliasCount: aliases.length,
+      sendAsCount: sendAs.length,
+      checkedAt: account.lastHealthCheckAt,
+    };
+  }
+
+  async function getAccountStatus() {
+    const account = await accountRowTx(null);
+    if (!account) return { configured: false };
+    const json = account.toJSON();
+    return {
+      configured: true,
+      hasCredentials: Boolean(
+        (await d.OutreachAccount.scope('withCredentials').findByPk(account.id))?.encryptedCredentials
+      ),
+      encryptionReady: d.secretBox.isReady(),
+      ...json,
+    };
+  }
+
+  // ── Workspace address listing (§2a — the reusable read) ──────────────────
+
+  /**
+   * The live tenant address book, parentage-aware: every user with their
+   * aliases, plus which addresses are aliases OF THE CONFIGURED ACCOUNT
+   * (only those can be personas — plan F2).
+   */
+  async function listWorkspaceAddresses() {
+    const account = await d.OutreachAccount.scope('withCredentials').findOne({ order: [['createdAt', 'ASC']] });
+    if (!account) throw new AppError('No Workspace account configured yet', 404);
+    const client = await decryptedClient(account);
+
+    const [users, accountAliases] = await Promise.all([
+      client.listUsers(),
+      client.listUserAliases(account.accountEmail),
+    ]);
+    const aliasSet = new Set(accountAliases.map((a) => a.toLowerCase()));
+    const existing = await d.OutreachPersona.findAll({ attributes: ['address'] });
+    const taken = new Set(existing.map((p) => p.address.toLowerCase()));
+
+    return {
+      accountEmail: account.accountEmail,
+      users: users.map((u) => ({
+        primaryEmail: u.primaryEmail,
+        fullName: u.name?.fullName || u.primaryEmail,
+        aliases: u.aliases || [],
+      })),
+      accountAliases: accountAliases.map((a) => ({
+        address: a,
+        importable: !taken.has(a.toLowerCase()),
+      })),
+    };
+  }
+
+  // ── Personas ─────────────────────────────────────────────────────────────
+
+  async function listPersonas() {
+    return d.OutreachPersona.findAll({
+      include: [{ model: d.User, as: 'assignedUser', attributes: ['id', 'fullName', 'email'] }],
+      order: [['createdAt', 'ASC']],
+    });
+  }
+
+  /**
+   * Import addresses as personas. Parentage-enforced at the door: only
+   * aliases of the configured account are accepted (plan F2) — anything else
+   * is returned under `rejected`, never silently dropped.
+   */
+  async function importPersonas({ addresses }, user, requestId = null) {
+    const account = await d.OutreachAccount.scope('withCredentials').findOne({ order: [['createdAt', 'ASC']] });
+    if (!account) throw new AppError('No Workspace account configured yet', 404);
+    const client = await decryptedClient(account);
+    const aliasSet = new Set((await client.listUserAliases(account.accountEmail)).map((a) => a.toLowerCase()));
+
+    const wanted = [...new Set((addresses || []).map((a) => String(a).trim().toLowerCase()).filter(Boolean))];
+    if (wanted.length === 0) throw new AppError('Pick at least one address to import', 400);
+
+    const created = [];
+    const rejected = [];
+    for (const address of wanted) {
+      if (!aliasSet.has(address)) {
+        rejected.push({ address, reason: 'not_account_alias' });
+        continue;
+      }
+      const [row, wasCreated] = await d.OutreachPersona.findOrCreate({
+        where: { address },
+        defaults: {
+          accountId: account.id,
+          address,
+          // Default display name from the local part — replaced by the rep's
+          // full CRM name at assignment time.
+          displayName: address.split('@')[0].replace(/^./, (c) => c.toUpperCase()),
+          isAccountAlias: true,
+          createdBy: user.id,
+        },
+      });
+      if (wasCreated) created.push(row);
+      else rejected.push({ address, reason: 'already_imported' });
+    }
+
+    if (created.length > 0) {
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'outreach.personas_imported', entityType: 'outreach_account',
+        entityId: account.id, after: { addresses: created.map((c) => c.address) }, requestId,
+      });
+    }
+    return { created, rejected };
+  }
+
+  async function updatePersona(personaId, body, user, requestId = null) {
+    return d.sequelize.transaction(async (t) => {
+      const persona = await d.OutreachPersona.findByPk(personaId, { transaction: t, lock: t.LOCK.UPDATE });
+      if (!persona) throw new AppError('Persona not found', 404);
+
+      const patch = {};
+      if (body.assignedUserId !== undefined) {
+        if (body.assignedUserId === null) {
+          patch.assignedUserId = null;
+        } else {
+          const rep = await d.User.findByPk(body.assignedUserId, { transaction: t });
+          if (!rep) throw new AppError('Rep not found', 404);
+          const clash = await d.OutreachPersona.findOne({
+            where: { assignedUserId: rep.id }, transaction: t,
+          });
+          if (clash && clash.id !== persona.id) {
+            throw new AppError(`${rep.fullName || 'That rep'} already sends as ${clash.address} — unassign it first`, 409);
+          }
+          patch.assignedUserId = rep.id;
+          // Default the From display name to the rep's full CRM name unless
+          // the caller sets one explicitly (plan §9.2).
+          if (body.displayName === undefined && rep.fullName) patch.displayName = rep.fullName;
+        }
+      }
+      if (body.displayName !== undefined) {
+        const name = String(body.displayName).trim();
+        if (!name || name.length > 120) throw new AppError('Display name must be 1–120 characters', 400);
+        patch.displayName = name;
+      }
+      if (body.dailySendCap !== undefined) {
+        const cap = Number.parseInt(body.dailySendCap, 10);
+        if (!Number.isInteger(cap) || cap < 1 || cap > 200) throw new AppError('Daily cap must be 1–200', 400);
+        patch.dailySendCap = cap;
+      }
+      if (body.isActive !== undefined) patch.isActive = Boolean(body.isActive);
+
+      const before = { assignedUserId: persona.assignedUserId, displayName: persona.displayName, dailySendCap: persona.dailySendCap, isActive: persona.isActive };
+      await persona.update(patch, { transaction: t });
+      await d.audit.recordAuditEvent({
+        actorUser: user, action: 'outreach.persona_updated', entityType: 'outreach_persona',
+        entityId: persona.id, before, after: patch, requestId, transaction: t,
+      });
+      return persona;
+    });
+  }
+
+  // ── Test send (also the plan-F4 Message-ID probe) ────────────────────────
+
+  /**
+   * Send a test email FROM the persona TO the account's own inbox — no
+   * external mail. Returns whether Gmail preserved our minted Message-ID
+   * (plan F4: the Phase-B idempotency design must know, and the answer is
+   * undocumented — this settles it empirically per environment).
+   */
+  async function testSend(personaId, user, requestId = null) {
+    const persona = await d.OutreachPersona.findByPk(personaId);
+    if (!persona) throw new AppError('Persona not found', 404);
+    const account = await d.OutreachAccount.scope('withCredentials').findByPk(persona.accountId);
+    const client = await decryptedClient(account);
+
+    if (!persona.isAccountAlias) {
+      throw new AppError(`${persona.address} is not an alias of ${account.accountEmail} — replies would land in another mailbox. Fix the alias in Admin console first.`, 409);
+    }
+    if (!persona.sendAsVerified) {
+      throw new AppError(`${persona.address} is not a verified "Send mail as" identity on ${account.accountEmail} yet — tick it once in Gmail settings, then Refresh health.`, 409);
+    }
+
+    const minted = `<outreach-test-${persona.id}-${Date.now()}@mktr.sg>`;
+    const rfc822 = [
+      `From: "${persona.displayName.replace(/"/g, '')}" <${persona.address}>`,
+      `To: <${account.accountEmail}>`,
+      `Subject: Redeem Ops test send — ${persona.address}`,
+      `Message-ID: ${minted}`,
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      `This is a test from the Redeem Ops outreach setup (${persona.displayName} / ${persona.address}).`,
+      'If you can read this, sending works. No prospect was contacted.',
+    ].join('\r\n');
+
+    const sent = await client.sendRaw(rfc822);
+    let wireMessageId = null;
+    try {
+      const meta = await client.getMessageHeaders(sent.id, ['Message-ID']);
+      wireMessageId = meta?.payload?.headers?.find((h) => h.name?.toLowerCase() === 'message-id')?.value || null;
+    } catch (err) {
+      d.logger.warn({ err: err?.message }, '[outreach] test-send header fetch failed');
+    }
+
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'outreach.test_send', entityType: 'outreach_persona',
+      entityId: persona.id,
+      after: { gmailId: sent.id, threadId: sent.threadId, mintedPreserved: wireMessageId === minted },
+      requestId,
+    });
+
+    return {
+      gmailId: sent.id,
+      threadId: sent.threadId,
+      mintedMessageId: minted,
+      wireMessageId,
+      mintedPreserved: wireMessageId ? wireMessageId === minted : null,
+    };
+  }
+
+  return {
+    setupAccount, getAccountStatus, refreshHealth,
+    listWorkspaceAddresses, listPersonas, importPersonas, updatePersona, testSend,
+  };
+}
+
+const _default = makeOutreachPersonaService();
+export default _default;

--- a/backend/src/utils/secretBox.js
+++ b/backend/src/utils/secretBox.js
@@ -1,0 +1,43 @@
+import crypto from 'crypto';
+import { AppError } from '../middleware/appError.js';
+
+/**
+ * Parameterized twin of aiCredentialEncryption.js (which hardwires its env
+ * var — plan m8): AES-256-GCM `v1:iv:tag:ct` with a sha256-derived key from a
+ * named env secret. Each credential family gets its OWN env key so rotating
+ * one can never brick another.
+ */
+export function makeSecretBox(envVar, label) {
+  const key = () => {
+    const secret = process.env[envVar] || '';
+    if (secret.length < 32) return null;
+    return crypto.createHash('sha256').update(secret, 'utf8').digest();
+  };
+
+  return {
+    isReady: () => Boolean(key()),
+    encrypt(value) {
+      const k = key();
+      if (!k) throw new AppError(`${label} encryption is not configured on the server (${envVar}).`, 503);
+      const iv = crypto.randomBytes(12);
+      const cipher = crypto.createCipheriv('aes-256-gcm', k, iv);
+      const ciphertext = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+      const tag = cipher.getAuthTag();
+      return `v1:${iv.toString('base64')}:${tag.toString('base64')}:${ciphertext.toString('base64')}`;
+    },
+    decrypt(payload) {
+      if (!payload) return null;
+      const k = key();
+      if (!k) throw new AppError(`${label} encryption is not configured on the server (${envVar}).`, 503);
+      const [version, iv, tag, ciphertext] = String(payload).split(':');
+      if (version !== 'v1' || !iv || !tag || !ciphertext) throw new AppError(`Stored ${label} credential cannot be read.`, 500);
+      try {
+        const decipher = crypto.createDecipheriv('aes-256-gcm', k, Buffer.from(iv, 'base64'));
+        decipher.setAuthTag(Buffer.from(tag, 'base64'));
+        return Buffer.concat([decipher.update(Buffer.from(ciphertext, 'base64')), decipher.final()]).toString('utf8');
+      } catch {
+        throw new AppError(`Stored ${label} credential cannot be decrypted. Check the server encryption key.`, 503);
+      }
+    },
+  };
+}

--- a/backend/test/redeemOpsOutreachPersonas.test.js
+++ b/backend/test/redeemOpsOutreachPersonas.test.js
@@ -1,0 +1,229 @@
+/**
+ * Outreach personas — email auto-send Phase A
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §8-A).
+ *
+ * Google is DI-mocked at the service factory (makeClient override) — no
+ * network. Route-level tests cover only the gates + validation that fail
+ * BEFORE any Google call; every Google-flow behavior is service-level.
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED = 'true';
+process.env.OUTREACH_MAILBOX_ENCRYPTION_KEY = 'test-outreach-encryption-key-32chars!';
+
+import request from 'supertest';
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import { OutreachAccount, OutreachPersona, RedeemOpsAuditEvent } from '../src/models/index.js';
+import { makeOutreachPersonaService } from '../src/services/redeemOps/outreachPersonaService.js';
+import { makeSecretBox } from '../src/utils/secretBox.js';
+
+let app;
+let admin, exec;
+
+const KEY_JSON = JSON.stringify({
+  type: 'service_account',
+  client_email: 'outreach@mktr-platform.iam.gserviceaccount.com',
+  private_key: '-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----\n',
+});
+
+/** Mutable Google fixture each test can shape. */
+const google = {
+  aliases: ['emily@redeem.sg', 'jeremy@redeem.sg'],
+  sendAs: [
+    { sendAsEmail: 'business@mktr.sg', isPrimary: true, verificationStatus: 'accepted' },
+    { sendAsEmail: 'emily@redeem.sg', verificationStatus: 'accepted' },
+    { sendAsEmail: 'jeremy@redeem.sg', verificationStatus: 'pending' },
+  ],
+  users: [
+    { primaryEmail: 'business@mktr.sg', name: { fullName: 'MKTR Business' }, aliases: ['emily@redeem.sg', 'jeremy@redeem.sg'] },
+    { primaryEmail: 'tyler@redeem.sg', name: { fullName: 'Tyler Lim' }, aliases: [] },
+  ],
+  sendRaw: jest.fn(async () => ({ id: 'gm-1', threadId: 'th-1' })),
+  wireMessageId: null, // null = echo the minted one back
+};
+
+const mockClient = () => ({
+  listUsers: async () => google.users,
+  listUserAliases: async () => google.aliases,
+  getProfile: async () => ({ emailAddress: 'business@mktr.sg' }),
+  listSendAs: async () => google.sendAs,
+  sendRaw: google.sendRaw,
+  getMessageHeaders: async () => ({
+    payload: {
+      headers: [{
+        name: 'Message-ID',
+        value: google.wireMessageId ?? google.sendRaw.mock.calls.at(-1)?.[0]?.match(/Message-ID: (<[^>]+>)/)?.[1] ?? null,
+      }],
+    },
+  }),
+});
+
+const svc = makeOutreachPersonaService({ makeClient: mockClient });
+
+beforeAll(async () => {
+  app = await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+beforeEach(async () => {
+  google.sendRaw.mockClear();
+  google.wireMessageId = null;
+  await OutreachPersona.destroy({ where: {} });
+  await OutreachAccount.destroy({ where: {} });
+});
+
+const auth = (t) => ({ Authorization: `Bearer ${t}` });
+
+async function connectedAccount() {
+  const { account } = await svc.setupAccount(
+    { accountEmail: 'business@mktr.sg', serviceAccountJson: KEY_JSON }, admin.user
+  );
+  return account;
+}
+
+describe('routes: gates & validation (no Google touched)', () => {
+  test('settings.manage gate: exec 403, admin 200; bad setup body 400', async () => {
+    expect((await request(app).get('/api/redeem-ops/outreach/account').set(auth(exec.token))).status).toBe(403);
+    const ok = await request(app).get('/api/redeem-ops/outreach/account').set(auth(admin.token));
+    expect(ok.status).toBe(200);
+    expect(ok.body.data.configured).toBe(false);
+
+    const bad = await request(app).put('/api/redeem-ops/outreach/account')
+      .set(auth(admin.token)).send({ accountEmail: 'not-an-email', serviceAccountJson: 'x' });
+    expect(bad.status).toBe(400);
+  });
+});
+
+describe('account setup & status', () => {
+  test('stores the key encrypted, masks it on read, and probes health immediately', async () => {
+    const { health } = await svc.setupAccount(
+      { accountEmail: 'Business@MKTR.sg', serviceAccountJson: KEY_JSON }, admin.user
+    );
+    expect(health.mailboxOk).toBe(true);
+    expect(health.aliasCount).toBe(2);
+
+    const raw = await OutreachAccount.scope('withCredentials').findOne({});
+    expect(raw.accountEmail).toBe('business@mktr.sg'); // lowercased
+    expect(raw.encryptedCredentials).toMatch(/^v1:/); // never plaintext
+    // round-trips with the box, and contains no raw key in the row
+    const box = makeSecretBox('OUTREACH_MAILBOX_ENCRYPTION_KEY', 'outreach mailbox');
+    expect(JSON.parse(box.decrypt(raw.encryptedCredentials)).client_email)
+      .toBe('outreach@mktr-platform.iam.gserviceaccount.com');
+
+    const status = await svc.getAccountStatus();
+    expect(status.configured).toBe(true);
+    expect(status.hasCredentials).toBe(true);
+    expect(status.encryptedCredentials).toBeUndefined(); // defaultScope masks
+  });
+
+  test('a garbage key is refused before anything is stored', async () => {
+    await expect(svc.setupAccount(
+      { accountEmail: 'business@mktr.sg', serviceAccountJson: '{"type":"user"}' }, admin.user
+    )).rejects.toMatchObject({ statusCode: 400 });
+    expect(await OutreachAccount.count()).toBe(0);
+  });
+});
+
+describe('workspace addresses & parentage (plan F2)', () => {
+  test('lists the account aliases with importable flags and the tenant users', async () => {
+    await connectedAccount();
+    const out = await svc.listWorkspaceAddresses();
+    expect(out.accountEmail).toBe('business@mktr.sg');
+    expect(out.accountAliases).toEqual([
+      { address: 'emily@redeem.sg', importable: true },
+      { address: 'jeremy@redeem.sg', importable: true },
+    ]);
+    // tyler is a USER in the tenant, not an alias of business@ — visible in
+    // users[], absent from accountAliases: the F2 distinction.
+    expect(out.users.map((u) => u.primaryEmail)).toContain('tyler@redeem.sg');
+  });
+
+  test('import enforces parentage: non-aliases are rejected loudly, never silently dropped', async () => {
+    await connectedAccount();
+    const result = await svc.importPersonas(
+      { addresses: ['emily@redeem.sg', 'tyler@redeem.sg'] }, admin.user
+    );
+    expect(result.created.map((c) => c.address)).toEqual(['emily@redeem.sg']);
+    expect(result.rejected).toEqual([{ address: 'tyler@redeem.sg', reason: 'not_account_alias' }]);
+
+    const again = await svc.importPersonas({ addresses: ['emily@redeem.sg'] }, admin.user);
+    expect(again.rejected).toEqual([{ address: 'emily@redeem.sg', reason: 'already_imported' }]);
+  });
+});
+
+describe('persona mapping (who-is-who)', () => {
+  test('assigning a rep defaults the display name to their full CRM name; one persona per rep', async () => {
+    await connectedAccount();
+    const { created } = await svc.importPersonas(
+      { addresses: ['emily@redeem.sg', 'jeremy@redeem.sg'] }, admin.user
+    );
+    const [emily, jeremy] = created;
+
+    const updated = await svc.updatePersona(emily.id, { assignedUserId: exec.user.id }, admin.user);
+    expect(updated.assignedUserId).toBe(exec.user.id);
+    expect(updated.displayName).toBe(exec.user.fullName);
+
+    // the same rep cannot hold a second persona
+    await expect(svc.updatePersona(jeremy.id, { assignedUserId: exec.user.id }, admin.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+
+    // cap bounds enforced
+    await expect(svc.updatePersona(emily.id, { dailySendCap: 0 }, admin.user))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe('health refresh persists per-persona truth', () => {
+  test('sendAs verification and parentage flags land on the rows', async () => {
+    await connectedAccount();
+    await svc.importPersonas({ addresses: ['emily@redeem.sg', 'jeremy@redeem.sg'] }, admin.user);
+    await svc.refreshHealth(admin.user);
+
+    const emily = await OutreachPersona.findOne({ where: { address: 'emily@redeem.sg' } });
+    const jeremy = await OutreachPersona.findOne({ where: { address: 'jeremy@redeem.sg' } });
+    expect(emily.sendAsVerified).toBe(true);
+    expect(emily.isAccountAlias).toBe(true);
+    expect(jeremy.sendAsRegistered).toBe(true);
+    expect(jeremy.sendAsVerified).toBe(false); // pending in the fixture
+  });
+});
+
+describe('test send (and the plan-F4 Message-ID probe)', () => {
+  test('refuses unverified send-as; sends From the persona to the shared inbox; reports the probe', async () => {
+    await connectedAccount();
+    const { created } = await svc.importPersonas(
+      { addresses: ['emily@redeem.sg', 'jeremy@redeem.sg'] }, admin.user
+    );
+    await svc.refreshHealth(admin.user);
+
+    const jeremy = created.find((p) => p.address === 'jeremy@redeem.sg');
+    await expect(svc.testSend(jeremy.id, admin.user)).rejects.toMatchObject({ statusCode: 409 });
+
+    const emily = created.find((p) => p.address === 'emily@redeem.sg');
+    const result = await svc.testSend(emily.id, admin.user);
+    const rfc = google.sendRaw.mock.calls[0][0];
+    expect(rfc).toContain('From: "Emily" <emily@redeem.sg>');
+    expect(rfc).toContain('To: <business@mktr.sg>'); // never a prospect
+    expect(result.mintedPreserved).toBe(true); // fixture echoes the minted id
+
+    const audit = await RedeemOpsAuditEvent.findOne({
+      where: { action: 'outreach.test_send', entityId: emily.id },
+    });
+    expect(audit.after).toMatchObject({ gmailId: 'gm-1', mintedPreserved: true });
+  });
+
+  test('a rewritten Message-ID is detected, not assumed', async () => {
+    await connectedAccount();
+    const { created } = await svc.importPersonas({ addresses: ['emily@redeem.sg'] }, admin.user);
+    await svc.refreshHealth(admin.user);
+    google.wireMessageId = '<CAxyz-rewritten@mail.gmail.com>';
+    const result = await svc.testSend(created[0].id, admin.user);
+    expect(result.mintedPreserved).toBe(false);
+    expect(result.wireMessageId).toBe('<CAxyz-rewritten@mail.gmail.com>');
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -455,6 +455,39 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/resume`);
     return res.data?.enrollment;
   },
+  // ── Outreach personas (email auto-send Phase A; flag REDEEM_OPS_EMAIL_AUTOSEND_ENABLED) ──
+  async getOutreachAccount() {
+    const res = await apiClient.get('/redeem-ops/outreach/account');
+    return res.data;
+  },
+  async setupOutreachAccount(body) {
+    const res = await apiClient.put('/redeem-ops/outreach/account', body);
+    return res.data;
+  },
+  async refreshOutreachHealth() {
+    const res = await apiClient.post('/redeem-ops/outreach/account/health');
+    return res.data?.health;
+  },
+  async listWorkspaceAddresses() {
+    const res = await apiClient.get('/redeem-ops/outreach/workspace-addresses');
+    return res.data;
+  },
+  async listOutreachPersonas() {
+    const res = await apiClient.get('/redeem-ops/outreach/personas');
+    return res.data?.personas || [];
+  },
+  async importOutreachPersonas(addresses) {
+    const res = await apiClient.post('/redeem-ops/outreach/personas/import', { addresses });
+    return res.data;
+  },
+  async updateOutreachPersona(personaId, body) {
+    const res = await apiClient.patch(`/redeem-ops/outreach/personas/${personaId}`, body);
+    return res.data?.persona;
+  },
+  async testSendOutreachPersona(personaId) {
+    const res = await apiClient.post(`/redeem-ops/outreach/personas/${personaId}/test-send`);
+    return res.data;
+  },
   async skipCadenceStep(partnerId, body = {}) {
     const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/skip-step`, body);
     return res.data;

--- a/src/components/redeemops/OutreachPersonasCard.jsx
+++ b/src/components/redeemops/OutreachPersonasCard.jsx
@@ -1,0 +1,306 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { redeemOpsApi } from '@/api/redeemOps';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { RoTag } from '@/components/redeemops/ui';
+
+export const EMAIL_AUTOSEND_ENABLED = import.meta.env.VITE_REDEEM_OPS_EMAIL_AUTOSEND_ENABLED === 'true';
+
+const ACCOUNT_KEY = ['redeem-ops', 'outreach-account'];
+const PERSONAS_KEY = ['redeem-ops', 'outreach-personas'];
+
+/**
+ * Settings → Outreach personas (email auto-send Phase A, plan §7): connect the
+ * Workspace account, import sending aliases FROM THE LIVE DIRECTORY (nobody
+ * types an address — plan §2a), tie who-is-who, verify send-as health, test
+ * send. Phase A never emails a prospect: test sends go to the account's own
+ * inbox.
+ */
+export default function OutreachPersonasCard() {
+  const queryClient = useQueryClient();
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [accountEmail, setAccountEmail] = useState('business@mktr.sg');
+  const [keyJson, setKeyJson] = useState('');
+  const [picked, setPicked] = useState({});
+
+  const accountQuery = useQuery({ queryKey: ACCOUNT_KEY, queryFn: () => redeemOpsApi.getOutreachAccount() });
+  const personasQuery = useQuery({ queryKey: PERSONAS_KEY, queryFn: () => redeemOpsApi.listOutreachPersonas() });
+  const teamQuery = useQuery({ queryKey: ['redeem-ops', 'team'], queryFn: () => redeemOpsApi.getTeam() });
+  const addressesQuery = useQuery({
+    queryKey: ['redeem-ops', 'workspace-addresses'],
+    queryFn: () => redeemOpsApi.listWorkspaceAddresses(),
+    enabled: importOpen,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ACCOUNT_KEY });
+    queryClient.invalidateQueries({ queryKey: PERSONAS_KEY });
+    queryClient.invalidateQueries({ queryKey: ['redeem-ops', 'workspace-addresses'] });
+  };
+  const onError = (title) => (err) => toast.error(title, { description: err.message });
+
+  const setupMutation = useMutation({
+    mutationFn: () => redeemOpsApi.setupOutreachAccount({ accountEmail: accountEmail.trim(), serviceAccountJson: keyJson }),
+    onSuccess: (data) => {
+      setSetupOpen(false);
+      setKeyJson('');
+      if (data?.health?.error) {
+        toast.warning('Key saved — but the health check failed', { description: data.health.error, duration: 10000 });
+      } else {
+        toast.success('Workspace account connected', {
+          description: `${data?.health?.aliasCount ?? 0} aliases visible on ${accountEmail.trim()}`,
+        });
+      }
+      invalidate();
+    },
+    onError: onError('Could not connect the account'),
+  });
+  const healthMutation = useMutation({
+    mutationFn: () => redeemOpsApi.refreshOutreachHealth(),
+    onSuccess: (h) => {
+      toast.success('Health check passed', {
+        description: `${h.aliasCount} aliases · ${h.sendAsCount} send-as identities on ${h.accountEmail}`,
+      });
+      invalidate();
+    },
+    onError: onError('Health check failed'),
+  });
+  const importMutation = useMutation({
+    mutationFn: () => redeemOpsApi.importOutreachPersonas(Object.keys(picked).filter((a) => picked[a])),
+    onSuccess: (data) => {
+      setImportOpen(false);
+      setPicked({});
+      const rejected = data?.rejected || [];
+      toast.success(`Imported ${data?.created?.length || 0} persona${(data?.created?.length || 0) === 1 ? '' : 's'}`, {
+        description: rejected.length ? `${rejected.length} skipped (${rejected.map((r) => r.reason).join(', ')})` : undefined,
+      });
+      invalidate();
+    },
+    onError: onError('Import failed'),
+  });
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }) => redeemOpsApi.updateOutreachPersona(id, body),
+    onSuccess: () => invalidate(),
+    onError: onError('Could not update the persona'),
+  });
+  const testMutation = useMutation({
+    mutationFn: (id) => redeemOpsApi.testSendOutreachPersona(id),
+    onSuccess: (r) => {
+      toast.success('Test email sent to the shared inbox', {
+        description: r.mintedPreserved === false
+          ? 'Note: Gmail rewrote our Message-ID (expected — the sender is designed for it).'
+          : 'Check the shared mailbox for the test message.',
+        duration: 8000,
+      });
+    },
+    onError: onError('Test send failed'),
+  });
+
+  const account = accountQuery.data;
+  const personas = personasQuery.data || [];
+  const team = teamQuery.data || [];
+  const takenUserIds = new Set(personas.map((p) => p.assignedUserId).filter(Boolean));
+
+  const personaStatus = (p) => {
+    if (!p.isActive) return { tone: 'paused', label: 'inactive' };
+    if (!p.isAccountAlias) return { tone: 'lost', label: 'not an alias' };
+    if (!p.sendAsVerified) return { tone: 'paused', label: 'send-as pending' };
+    if (!p.assignedUserId) return { tone: 'paused', label: 'no rep' };
+    return { tone: 'open', label: 'ready' };
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Outreach personas</CardTitle>
+        <CardDescription>
+          Which Workspace alias each rep sends outreach email as. Addresses come from the live
+          Google directory — nothing is typed by hand. Auto-sending itself ships in a later
+          phase; this card only sets up and verifies identities.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!account?.configured ? (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+              No Workspace account connected yet.
+            </p>
+            <Button size="sm" onClick={() => setSetupOpen(true)}>Connect account</Button>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-3">
+              <p className="text-sm font-semibold m-0">{account.accountEmail}</p>
+              {account.encryptionReady === false && (
+                <RoTag tone="lost" size="sm">encryption key missing</RoTag>
+              )}
+              {account.lastError
+                ? <RoTag tone="lost" size="sm">health error</RoTag>
+                : account.lastHealthCheckAt && <RoTag tone="open" size="sm">healthy</RoTag>}
+              <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>
+                {account.lastHealthCheckAt
+                  ? `checked ${new Date(account.lastHealthCheckAt).toLocaleString()}`
+                  : 'never checked'}
+              </span>
+              <span className="ml-auto flex gap-1.5">
+                <Button size="sm" variant="outline" disabled={healthMutation.isPending} onClick={() => healthMutation.mutate()}>
+                  {healthMutation.isPending ? 'Checking…' : 'Refresh health'}
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => setSetupOpen(true)}>Replace key</Button>
+                <Button size="sm" onClick={() => setImportOpen(true)}>Import from Workspace</Button>
+              </span>
+            </div>
+            {account.lastError && (
+              <p className="text-xs mb-3 mt-0 leading-relaxed" style={{ color: 'var(--ro-tag-red-fg, #BD3A2E)' }}>
+                {account.lastError}
+              </p>
+            )}
+
+            {personas.length === 0 ? (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No personas yet — import the redeem.sg aliases from Workspace.
+              </p>
+            ) : (
+              <div className="divide-y divide-border rounded-xl border border-border">
+                {personas.map((p) => {
+                  const st = personaStatus(p);
+                  return (
+                    <div key={p.id} className="flex flex-wrap items-center gap-2 px-3 py-2.5">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold m-0 truncate">{p.address}</p>
+                        <p className="text-xs m-0 mt-0.5 truncate" style={{ color: 'var(--ro-text-3)' }}>
+                          From: “{p.displayName}” · cap {p.dailySendCap}/day
+                        </p>
+                      </div>
+                      <RoTag tone={st.tone} size="sm">{st.label}</RoTag>
+                      {/* Native select keeps the row compact; server enforces
+                          the one-persona-per-rep rule and 409s duplicates. */}
+                      <select
+                        aria-label={`Rep for ${p.address}`}
+                        className="h-8 rounded-md border border-border bg-white px-2 text-xs"
+                        value={p.assignedUserId || ''}
+                        onChange={(e) => updateMutation.mutate({
+                          id: p.id, body: { assignedUserId: e.target.value || null },
+                        })}
+                      >
+                        <option value="">Unassigned</option>
+                        {team.map((u) => (
+                          <option key={u.id} value={u.id} disabled={takenUserIds.has(u.id) && p.assignedUserId !== u.id}>
+                            {u.fullName || u.email}
+                          </option>
+                        ))}
+                      </select>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={testMutation.isPending}
+                        onClick={() => testMutation.mutate(p.id)}
+                      >
+                        Test send
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+
+      {/* ── Connect / replace key ── */}
+      <Dialog open={setupOpen} onOpenChange={setSetupOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Connect the Workspace account</DialogTitle>
+            <DialogDescription>
+              Paste the Google service-account key (JSON file). It is encrypted on the server and
+              never shown again. The account email is the mailbox the platform impersonates —
+              domain-wide delegation for its client ID must be granted in admin.google.com first.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={accountEmail}
+            onChange={(e) => setAccountEmail(e.target.value)}
+            placeholder="business@mktr.sg"
+            aria-label="Account email"
+          />
+          <textarea
+            value={keyJson}
+            onChange={(e) => setKeyJson(e.target.value)}
+            placeholder='{"type": "service_account", "client_email": …}'
+            aria-label="Service account key JSON"
+            rows={6}
+            className="w-full rounded-md border border-border bg-white p-2 font-mono text-xs"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSetupOpen(false)}>Back</Button>
+            <Button
+              disabled={setupMutation.isPending || !keyJson.trim() || !accountEmail.trim()}
+              onClick={() => setupMutation.mutate()}
+            >
+              {setupMutation.isPending ? 'Connecting…' : 'Connect & check'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ── Import from Workspace ── */}
+      <Dialog open={importOpen} onOpenChange={setImportOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Import personas from Workspace</DialogTitle>
+            <DialogDescription>
+              Only aliases of {account?.accountEmail || 'the connected account'} are listed —
+              an address owned by another account would swallow its own replies, so it can’t be
+              a persona.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 max-h-72 overflow-y-auto">
+            {addressesQuery.isLoading && (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>Reading the directory…</p>
+            )}
+            {addressesQuery.isError && (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-tag-red-fg, #BD3A2E)' }}>
+                {addressesQuery.error?.message}
+              </p>
+            )}
+            {(addressesQuery.data?.accountAliases || []).map((a) => (
+              <label key={a.address} className="flex items-center gap-2 text-sm font-medium cursor-pointer">
+                <Checkbox
+                  checked={!!picked[a.address]}
+                  disabled={!a.importable}
+                  onCheckedChange={(v) => setPicked((prev) => ({ ...prev, [a.address]: !!v }))}
+                />
+                <span className={a.importable ? '' : 'opacity-50'}>
+                  {a.address}{!a.importable && ' — already imported'}
+                </span>
+              </label>
+            ))}
+            {addressesQuery.data && (addressesQuery.data.accountAliases || []).length === 0 && (
+              <p className="text-sm m-0" style={{ color: 'var(--ro-text-2)' }}>
+                No aliases on {addressesQuery.data.accountEmail} — create them in Admin console first.
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setImportOpen(false)}>Back</Button>
+            <Button
+              disabled={importMutation.isPending || Object.values(picked).every((v) => !v)}
+              onClick={() => importMutation.mutate()}
+            >
+              {importMutation.isPending ? 'Importing…' : 'Import selected'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
+++ b/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * Outreach personas card (email auto-send Phase A): connect account, import
+ * from the LIVE Workspace directory (no typed addresses), tie who-is-who,
+ * test send. redeemOpsApi fully mocked — no network.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const api = vi.hoisted(() => ({
+  getOutreachAccount: vi.fn(),
+  setupOutreachAccount: vi.fn(),
+  refreshOutreachHealth: vi.fn(),
+  listWorkspaceAddresses: vi.fn(),
+  listOutreachPersonas: vi.fn(),
+  importOutreachPersonas: vi.fn(),
+  updateOutreachPersona: vi.fn(),
+  testSendOutreachPersona: vi.fn(),
+  getTeam: vi.fn(),
+}));
+vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
+
+const toastMock = vi.hoisted(() => {
+  const t = vi.fn();
+  t.success = vi.fn();
+  t.error = vi.fn();
+  t.warning = vi.fn();
+  return t;
+});
+vi.mock('sonner', () => ({ toast: toastMock }));
+
+import OutreachPersonasCard from '../OutreachPersonasCard';
+
+function wrap(ui) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+const configuredAccount = {
+  configured: true,
+  hasCredentials: true,
+  encryptionReady: true,
+  accountEmail: 'business@mktr.sg',
+  lastHealthCheckAt: '2026-08-11T04:00:00Z',
+  lastError: null,
+};
+
+const emily = {
+  id: 'op-1',
+  address: 'emily@redeem.sg',
+  displayName: 'Emily Wong',
+  assignedUserId: 'u-emily',
+  isAccountAlias: true,
+  sendAsVerified: true,
+  dailySendCap: 30,
+  isActive: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getTeam.mockResolvedValue([
+    { id: 'u-emily', fullName: 'Emily Wong' },
+    { id: 'u-jeremy', fullName: 'Jeremy Ho Wei Kang' },
+  ]);
+  api.listOutreachPersonas.mockResolvedValue([]);
+});
+
+describe('OutreachPersonasCard', () => {
+  it('unconfigured: offers Connect and posts the pasted key with the account email', async () => {
+    api.getOutreachAccount.mockResolvedValue({ configured: false });
+    api.setupOutreachAccount.mockResolvedValue({ health: { aliasCount: 4 } });
+    const user = userEvent.setup();
+    wrap(<OutreachPersonasCard />);
+
+    await user.click(await screen.findByRole('button', { name: /connect account/i }));
+    await user.type(screen.getByLabelText(/service account key json/i), '{{"type": "service_account"}');
+    await user.click(screen.getByRole('button', { name: /connect & check/i }));
+    await waitFor(() => expect(api.setupOutreachAccount).toHaveBeenCalledWith({
+      accountEmail: 'business@mktr.sg',
+      serviceAccountJson: '{"type": "service_account"}',
+    }));
+  });
+
+  it('renders persona rows with status and reassigns via the rep select (server enforces 1:1)', async () => {
+    api.getOutreachAccount.mockResolvedValue(configuredAccount);
+    api.listOutreachPersonas.mockResolvedValue([
+      emily,
+      { ...emily, id: 'op-2', address: 'jeremy@redeem.sg', displayName: 'Jeremy', assignedUserId: null, sendAsVerified: false },
+    ]);
+    api.updateOutreachPersona.mockResolvedValue({});
+    const user = userEvent.setup();
+    wrap(<OutreachPersonasCard />);
+
+    expect(await screen.findByText('emily@redeem.sg')).toBeInTheDocument();
+    expect(screen.getByText('ready')).toBeInTheDocument();
+    expect(screen.getByText('send-as pending')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Rep for jeremy@redeem.sg'), 'u-jeremy');
+    await waitFor(() => expect(api.updateOutreachPersona).toHaveBeenCalledWith('op-2', { assignedUserId: 'u-jeremy' }));
+    // Emily already holds u-emily — that option is disabled for Jeremy's row.
+    expect(screen.getByLabelText('Rep for jeremy@redeem.sg').querySelector('option[value="u-emily"]').disabled).toBe(true);
+  });
+
+  it('import dialog lists ONLY the account aliases, disables taken ones, and imports the picked set', async () => {
+    api.getOutreachAccount.mockResolvedValue(configuredAccount);
+    api.listWorkspaceAddresses.mockResolvedValue({
+      accountEmail: 'business@mktr.sg',
+      users: [],
+      accountAliases: [
+        { address: 'dara@redeem.sg', importable: true },
+        { address: 'emily@redeem.sg', importable: false },
+      ],
+    });
+    api.importOutreachPersonas.mockResolvedValue({ created: [{ address: 'dara@redeem.sg' }], rejected: [] });
+    const user = userEvent.setup();
+    wrap(<OutreachPersonasCard />);
+
+    await user.click(await screen.findByRole('button', { name: /import from workspace/i }));
+    expect(await screen.findByText(/dara@redeem.sg/)).toBeInTheDocument();
+    expect(screen.getByText(/emily@redeem.sg — already imported/)).toBeInTheDocument();
+
+    await user.click(screen.getByText(/dara@redeem.sg/));
+    await user.click(screen.getByRole('button', { name: /import selected/i }));
+    await waitFor(() => expect(api.importOutreachPersonas).toHaveBeenCalledWith(['dara@redeem.sg']));
+  });
+
+  it('test send reports the Message-ID probe result honestly', async () => {
+    api.getOutreachAccount.mockResolvedValue(configuredAccount);
+    api.listOutreachPersonas.mockResolvedValue([emily]);
+    api.testSendOutreachPersona.mockResolvedValue({ gmailId: 'gm-1', mintedPreserved: false });
+    const user = userEvent.setup();
+    wrap(<OutreachPersonasCard />);
+
+    await user.click(await screen.findByRole('button', { name: /test send/i }));
+    await waitFor(() => expect(api.testSendOutreachPersona).toHaveBeenCalledWith('op-1'));
+    const [, opts] = toastMock.success.mock.calls.at(-1);
+    expect(opts.description).toMatch(/rewrote our Message-ID/i);
+  });
+
+  it('a health error is shown loudly on the card', async () => {
+    api.getOutreachAccount.mockResolvedValue({
+      ...configuredAccount,
+      lastError: 'Google token exchange failed (401): unauthorized_client',
+    });
+    wrap(<OutreachPersonasCard />);
+    expect(await screen.findByText(/health error/i)).toBeInTheDocument();
+    expect(screen.getByText(/unauthorized_client/)).toBeInTheDocument();
+  });
+});

--- a/src/pages/redeemops/SettingsPage.jsx
+++ b/src/pages/redeemops/SettingsPage.jsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
 import CadenceStudio from '@/components/redeemops/CadenceStudio';
+import OutreachPersonasCard, { EMAIL_AUTOSEND_ENABLED } from '@/components/redeemops/OutreachPersonasCard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
@@ -280,6 +281,8 @@ export default function SettingsPage() {
       </Card>
 
       <CadenceStudio />
+
+      {EMAIL_AUTOSEND_ENABLED && <OutreachPersonasCard />}
 
       <Dialog open={!!renameTarget} onOpenChange={(open) => { if (!open) setRenameTarget(null); }}>
         <DialogContent className="max-w-sm">


### PR DESCRIPTION
Phase A of cadence email auto-send — the plan is **PR #440** (v4, adversarially reviewed by 3 Fable 5 agents; the Google-side claims carry official-doc citations). This PR is foundations only: **no cadence-engine changes, no email ever reaches a prospect** (test-send goes to the shared inbox itself). Ships fully dark behind `REDEEM_OPS_EMAIL_AUTOSEND_ENABLED` + VITE twin.

## What's in it
- **Shared Google Workspace module** (`backend/src/services/google/workspaceService.js`): service-account DWD auth (hand-rolled RS256 JWT via the existing `jsonwebtoken` dep — no `googleapis`), Directory reads (users + aliases), Gmail profile / send-as list / raw send / header fetch. Read-only against the directory by design; future features reuse it (Shawn's ask: "so a future purpose will still work").
- **Migration 119**: `outreach_accounts` (impersonated mailbox, AES-GCM-encrypted service-account key, account-level daily cap + reply-poll health fields Phase B gates on) + `outreach_personas` (alias ↔ rep mapping, UNIQUE per rep, parentage/send-as flags, per-persona caps).
- **Persona service**: connect-with-immediate-health-probe; **parentage pre-flight** (plan F2 — an address must be an alias OF business@ or its replies land in someone else's mailbox; e.g. it will answer the tyler@redeem.sg question definitively); send-as **verification only** via `sendAs.list` (plan F1 — no `gmail.settings.sharing`; registration stays a one-time manual Gmail tick); **Import from Workspace** (addresses come from the live directory, never typed); who-is-who with display-name defaulting to the rep's CRM name; test-send that doubles as the **plan-F4 Message-ID probe** (reports whether Gmail preserved our minted ID — Phase B's idempotency design needs the empirical answer).
- **Settings → Outreach personas card**: connect account (key pasted once, encrypted with its own `OUTREACH_MAILBOX_ENCRYPTION_KEY` via a new parameterized `secretBox` util), health status, import picker, per-persona rep select / status tags / test send.

## Activation (Shawn-side, when ready — nothing needed to merge)
1. GCP "MKTR Platform": create service account + JSON key (if key creation is org-policy-blocked, lift it for the project — plan F5).
2. admin.google.com → API controls → Domain-wide delegation: authorize the client ID for `gmail.send, gmail.readonly, gmail.settings.basic, admin.directory.user.readonly`.
3. Render env: `REDEEM_OPS_EMAIL_AUTOSEND_ENABLED=true`, `OUTREACH_MAILBOX_ENCRYPTION_KEY=<32+ chars>` (backend), `VITE_REDEEM_OPS_EMAIL_AUTOSEND_ENABLED=true` (ops frontends).
4. Settings card: paste the key → Connect & check → Import → assign reps → tick "Send mail as" once per persona in Gmail → Test send.

## Tests
9 backend (Google DI-mocked, zero network: encryption round-trip + masking, parentage rejection, 1:1 rep mapping + 409, send-as gating, Message-ID probe honesty both ways) · 5 vitest (card flows incl. import picker + probe toast) · migrations 23/23 (119 on the frozen baseline) · cadence regression 53/53 · lint both trees · typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S