### PR TITLE
feat(redeem-ops): email auto-send Phase C — the inbox loop that unlocks the sender (dark)

### DIFF
--- a/backend/src/controllers/redeemOps/outreachController.js
+++ b/backend/src/controllers/redeemOps/outreachController.js
@@ -90,3 +90,14 @@ export const convertEmailToManual = asyncHandler(async (req, res) => {
   const email = await outreachSenderService.convertToManual(req.params.emailId, req.user, req.id);
   res.json({ success: true, data: { email } });
 });
+
+const optOutSchema = Joi.object({ email: Joi.string().email().required() });
+
+// The Replied-card classification (plan P18): a "please stop" phrased outside
+// the keyword list still ends up on the suppression list, by a human tap.
+export const recordOptOut = asyncHandler(async (req, res) => {
+  const body = validateBody(optOutSchema, req.body || {});
+  const { default: outreachInboxService } = await import('../../services/redeemOps/outreachInboxService.js');
+  const suppression = await outreachInboxService.optOutAddress(body.email, req.user, req.id);
+  res.status(201).json({ success: true, data: { suppression } });
+});

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -361,15 +361,26 @@ export async function bootstrapDatabase() {
           const autosendOn = String(process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED || 'false').toLowerCase() === 'true';
           if (autosendOn) {
             const { makeOutreachSenderService } = await import('../services/redeemOps/outreachSenderService.js');
+            const { makeOutreachInboxService } = await import('../services/redeemOps/outreachInboxService.js');
             const sender = makeOutreachSenderService();
+            const inbox = makeOutreachInboxService();
             const safeTick = async () => {
               try { await sender.tick(); } catch (err) {
                 logger.warn({ error: err?.message }, '[RedeemOps] auto-send tick failed (non-fatal)');
               }
             };
+            // The inbox poll is what UNLOCKS the sender (P1) — it stamps
+            // lastSuccessfulPollAt on every clean pass. Poll first, tick after.
+            const safePoll = async () => {
+              try { await inbox.poll(); } catch (err) {
+                logger.warn({ error: err?.message }, '[RedeemOps] inbox poll failed (non-fatal, sender stays gated)');
+              }
+            };
+            setTimeout(safePoll, 45_000);
+            setInterval(safePoll, 2 * 60_000);
             setTimeout(safeTick, 90_000);
             setInterval(safeTick, 60_000);
-            logger.info('[RedeemOps] email auto-send worker scheduled (60s interval)');
+            logger.info('[RedeemOps] email auto-send worker (60s) + inbox poll (2m) scheduled');
           }
         });
       } else if (String(process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED || 'false').toLowerCase() === 'true') {

--- a/backend/src/database/migrations/121-outreach-inbox-health.js
+++ b/backend/src/database/migrations/121-outreach-inbox-health.js
@@ -1,0 +1,21 @@
+/**
+ * 121 — inbox-loop health surface (Phase C,
+ * docs/plans/redeem-ops-cadence-email-autosend.md §5).
+ *
+ * unmatchedInboxCount: human mail to persona addresses the reply-matcher
+ * couldn't tie to a tracked thread — a gauge on the Settings health card so
+ * nobody has to tail the shared mailbox raw. Ordinary business@ mail (not
+ * addressed to a persona) never counts.
+ */
+
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_accounts ADD COLUMN IF NOT EXISTS "unmatchedInboxCount" INTEGER NOT NULL DEFAULT 0'
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.sequelize.query(
+    'ALTER TABLE outreach_accounts DROP COLUMN IF EXISTS "unmatchedInboxCount"'
+  );
+}

--- a/backend/src/models/OutreachAccount.js
+++ b/backend/src/models/OutreachAccount.js
@@ -19,6 +19,7 @@ const OutreachAccount = sequelize.define('OutreachAccount', {
   historyCursor: { type: DataTypes.STRING(32), allowNull: true, comment: 'Gmail historyId cursor for the Phase-C reply poll' },
   lastSuccessfulPollAt: { type: DataTypes.DATE, allowNull: true, comment: 'Phase-B sender refuses to send when this is stale' },
   lastHealthCheckAt: { type: DataTypes.DATE, allowNull: true },
+  unmatchedInboxCount: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0, comment: 'persona-addressed inbox mail the reply-matcher could not tie to a tracked thread' },
   lastError: { type: DataTypes.TEXT, allowNull: true },
   isActive: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
   createdBy: { type: DataTypes.UUID, allowNull: true, references: { model: 'users', key: 'id' } },

--- a/backend/src/routes/redeemOpsOutreach.js
+++ b/backend/src/routes/redeemOpsOutreach.js
@@ -41,5 +41,8 @@ router.post('/outreach/personas/:personaId/test-send', requireRedeemOps('setting
 router.post('/outreach/emails/:emailId/approve', requireRedeemOps('tasks.manage'), ctrl.approveEmail);
 router.post('/outreach/emails/:emailId/send-now', requireRedeemOps('tasks.manage'), ctrl.sendNowEmail);
 router.post('/outreach/emails/:emailId/convert-manual', requireRedeemOps('tasks.manage'), ctrl.convertEmailToManual);
+// Manual opt-out (Phase C) — any rep who works tasks may record a "stop
+// emailing us" the keyword matcher missed. Audited.
+router.post('/outreach/opt-out', requireRedeemOps('tasks.manage'), ctrl.recordOptOut);
 
 export default router;

--- a/backend/src/services/google/workspaceService.js
+++ b/backend/src/services/google/workspaceService.js
@@ -157,6 +157,33 @@ export function makeWorkspaceClient({ credentials, subject, scopes, fetchImpl = 
       const body = await api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/messages?maxResults=${maxResults}&q=${encodeURIComponent(q)}`);
       return body.messages || [];
     },
+    /**
+     * INBOX history since a cursor (the documented incremental-sync pattern).
+     * Throws err.status=404 when the cursor expired — callers MUST full-sync
+     * re-baseline then (Google's stated contract, plan F8).
+     */
+    async listInboxHistory(startHistoryId) {
+      const out = [];
+      let pageToken = '';
+      let latestHistoryId = startHistoryId;
+      do {
+        const body = await api(
+          `https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/history?startHistoryId=${encodeURIComponent(startHistoryId)}&historyTypes=messageAdded&labelId=INBOX${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ''}`
+        );
+        for (const h of body.history || []) {
+          for (const added of h.messagesAdded || []) {
+            if (added.message) out.push(added.message);
+          }
+        }
+        latestHistoryId = body.historyId || latestHistoryId;
+        pageToken = body.nextPageToken || '';
+      } while (pageToken);
+      return { messages: out, historyId: latestHistoryId };
+    },
+    /** One message, full payload (text extraction is the caller's job). */
+    async getMessage(id, { format = 'full' } = {}) {
+      return api(`https://gmail.googleapis.com/gmail/v1/users/${encodeURIComponent(subject)}/messages/${encodeURIComponent(id)}?format=${format}`);
+    },
     /** Metadata of one message — used to learn the REAL wire Message-ID (plan F4). */
     async getMessageHeaders(id, headerNames = ['Message-ID']) {
       const qs = headerNames.map((h) => `metadataHeaders=${encodeURIComponent(h)}`).join('&');

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -1043,7 +1043,7 @@ export function makeCadenceService(overrides = {}) {
    * contact-info hook can rescue it exactly like a materialization-time park.
    * Global lock order held: partner → enrollment → task.
    */
-  async function parkActiveEnrollment(enrollmentId, reason) {
+  async function parkActiveEnrollment(enrollmentId, reason, { expectedStepId = null } = {}) {
     return d.sequelize.transaction(async (t) => {
       const probe = await d.OutreachCadenceEnrollment.findByPk(enrollmentId, {
         attributes: ['id', 'partnerOrganisationId'], transaction: t,
@@ -1056,8 +1056,18 @@ export function makeCadenceService(overrides = {}) {
         transaction: t, lock: t.LOCK.UPDATE,
       });
       if (!partner || partner.mergedIntoId || !enrollment || enrollment.state !== 'active') return null;
+      // Staleness guard (same class as skip's): a concurrent completion may
+      // have advanced the enrollment — never park a step the caller didn't see.
+      if (expectedStepId && enrollment.currentStepId !== expectedStepId) return null;
       const step = await d.OutreachCadenceStep.findByPk(enrollment.currentStepId, { transaction: t });
       if (!step) return null;
+      // Un-park race: a contact-add can land between the caller's check and
+      // this lock — its hook saw an ACTIVE enrollment and no-op'd, so if the
+      // recipient resolves NOW, parking would strand a fixed record. Skip the
+      // park; the step degrades to a manual task (the caller cancelled the
+      // machine send already).
+      const nowResolved = await resolveRecipientTx(partner, step.channel, t);
+      if (nowResolved.ok) return null;
       await d.OutreachTask.update(
         { status: 'cancelled' },
         { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -1036,6 +1036,43 @@ export function makeCadenceService(overrides = {}) {
     });
   }
 
+  /**
+   * Park an ACTIVE enrollment from OUTSIDE the placement path — the sender's
+   * send-time no_email discovery (plan P5, deferred from Phase B): cancel the
+   * open task + queued sends, pause missing_info on the current step, so the
+   * contact-info hook can rescue it exactly like a materialization-time park.
+   * Global lock order held: partner → enrollment → task.
+   */
+  async function parkActiveEnrollment(enrollmentId, reason) {
+    return d.sequelize.transaction(async (t) => {
+      const probe = await d.OutreachCadenceEnrollment.findByPk(enrollmentId, {
+        attributes: ['id', 'partnerOrganisationId'], transaction: t,
+      });
+      if (!probe) return null;
+      const partner = await d.PartnerOrganisation.findByPk(probe.partnerOrganisationId, {
+        transaction: t, lock: t.LOCK.UPDATE,
+      });
+      const enrollment = await d.OutreachCadenceEnrollment.findByPk(enrollmentId, {
+        transaction: t, lock: t.LOCK.UPDATE,
+      });
+      if (!partner || partner.mergedIntoId || !enrollment || enrollment.state !== 'active') return null;
+      const step = await d.OutreachCadenceStep.findByPk(enrollment.currentStepId, { transaction: t });
+      if (!step) return null;
+      await d.OutreachTask.update(
+        { status: 'cancelled' },
+        { where: { cadenceEnrollmentId: enrollment.id, status: { [Op.in]: ['open', 'in_progress'] } }, transaction: t }
+      );
+      await cancelQueuedEmailsTx({ cadenceEnrollmentId: enrollment.id }, reason, t);
+      await pauseForInfoTx(
+        enrollment, partner, step,
+        { stepId: step.id, stepTitle: step.title, channel: step.channel, reason },
+        { delayDays: 0, timeWindow: 'any' }, null, t
+      );
+      await d.tasks.recomputeNextTaskAt(partner.id, t);
+      return enrollment;
+    });
+  }
+
   // ── Read model for the UI card ────────────────────────────────────────────
 
   async function getPartnerCadence(partnerId) {
@@ -1229,8 +1266,8 @@ export function makeCadenceService(overrides = {}) {
     enrollPartner, completeCadenceTask,
     pauseEnrollment, resumeEnrollment, stopEnrollment, skipCurrentStep,
     getPartnerCadence, hookHandlers, reconcile,
-    // exported for the auto-sender (send-time revalidation, plan §4)
-    resolveRecipientTx, isSuppressedTx,
+    // exported for the auto-sender (send-time revalidation + park, plan §4/P5)
+    resolveRecipientTx, isSuppressedTx, parkActiveEnrollment,
     // exported for tests
     sgtWindowClamp,
   };

--- a/backend/src/services/redeemOps/outreachInboxService.js
+++ b/backend/src/services/redeemOps/outreachInboxService.js
@@ -1,7 +1,8 @@
 import { Op } from 'sequelize';
 import {
   OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
-  OutreachSuppression, OutreachCadenceEnrollment, PartnerOrganisation, User, sequelize,
+  OutreachSuppression, OutreachCadenceEnrollment, PartnerOrganisation, User,
+  IdempotencyKey, sequelize,
 } from '../../models/index.js';
 import { logger } from '../../utils/logger.js';
 import { makeSecretBox } from '../../utils/secretBox.js';
@@ -34,6 +35,15 @@ const SCOPES = [
 
 const UNSUB_RE = /\b(unsubscribe|remove me|stop (emailing|contacting)|do ?n[o']t (email|contact))\b/i;
 const BOUNCE_FROM_RE = /(mailer-daemon|postmaster)@/i;
+// Foreign-MTA bounces that use neither a daemon From nor multipart/report
+// (review F4) — subject heuristic as the third signal.
+const BOUNCE_SUBJECT_RE = /(delivery status notification|undeliverable|delivery (has )?failed|mail delivery failed|returned mail|failure notice)/i;
+// Gmail's "(Delay)" notices come from mailer-daemon while it is still
+// RETRYING — suppressing on them blocks deliverable addresses (review F3).
+const DELAY_SUBJECT_RE = /\(delay\)|delivery incomplete|will keep trying/i;
+const MSG_IDEMPOTENCY_SCOPE = 'inbox:msg';
+const MSG_IDEMPOTENCY_TTL_MS = 7 * 24 * 3600_000;
+const POISON_SKIP_AFTER = 3;
 
 function headerOf(payload, name) {
   return payload?.headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || '';
@@ -67,6 +77,10 @@ export function makeOutreachInboxService(overrides = {}) {
     now: () => new Date(),
     ...overrides,
   };
+
+  // Consecutive per-message failure streaks (in-memory; resets on restart —
+  // the bound is against a permanently-poisoned message, not bookkeeping).
+  const failStreak = new Map();
 
   async function clientFor(account) {
     const withCreds = await d.OutreachAccount.scope('withCredentials').findByPk(account.id);
@@ -104,14 +118,15 @@ export function makeOutreachInboxService(overrides = {}) {
     const repUserId = partner.ownerUserId || task?.assigneeUserId || persona?.assignedUserId;
     const rep = repUserId ? await d.User.findByPk(repUserId, { attributes: ['id', 'email', 'fullName'] }) : null;
     if (!rep?.email) return false;
+    const headerSafe = (v) => String(v).replace(/[\r\n]+/g, ' ');
     const link = `https://ops.redeem.sg/redeem-ops/partners/${partner.id}`;
     const rfc822 = [
-      `From: "Redeem outreach" <${account.accountEmail}>`,
-      `To: <${rep.email}>`,
-      `Subject: Reply from ${String(partner.tradingName || partner.legalName || 'a prospect').replace(/[\r\n]+/g, ' ')} — answer them soon`,
+      `From: "Redeem outreach" <${headerSafe(account.accountEmail)}>`,
+      `To: <${headerSafe(rep.email)}>`,
+      `Subject: Reply from ${headerSafe(partner.tradingName || partner.legalName || 'a prospect')} — answer them soon`,
       'Content-Type: text/plain; charset=utf-8',
       '',
-      `They replied on the ${persona?.address || 'outreach'} thread (${String(subject).replace(/[\r\n]+/g, ' ')}):`,
+      `They replied on the ${persona?.address || 'outreach'} thread (${headerSafe(subject)}):`,
       '',
       String(text || '(no text body — open the thread in the shared mailbox)').slice(0, 4000),
       '',
@@ -120,38 +135,74 @@ export function makeOutreachInboxService(overrides = {}) {
       '',
       'The cadence has been stopped automatically. Reply from the shared mailbox or call them.',
     ].join('\r\n');
-    try {
-      await client.sendRaw(rfc822);
-      return true;
-    } catch (err) {
-      d.logger.warn({ partnerId: partner.id, err: err?.message }, '[inbox] reply forward failed (non-fatal)');
-      return false;
+    // One immediate retry; a soft double failure is recorded on the
+    // reply_received audit (forwarded:false) — queryable, never invisible.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        await client.sendRaw(rfc822);
+        return true;
+      } catch (err) {
+        if (attempt === 1) {
+          d.logger.warn({ partnerId: partner.id, err: err?.message }, '[inbox] reply forward failed twice (reply still on the timeline)');
+        }
+      }
     }
+    return false;
   }
 
-  /** Handle ONE new inbox message. Returns a label for counters/tests. */
+  /**
+   * Handle ONE new inbox message. Returns a label for counters/tests.
+   * Throws on TRANSIENT failures — the caller must NOT advance the cursor
+   * past an unprocessed message (review F1: a swallowed reply or opt-out
+   * under a green health light is exactly the blindness P1 forbids).
+   */
   async function handleMessage(account, client, personaAddresses, msgRef) {
-    const msg = await client.getMessage(msgRef.id).catch(() => null);
-    if (!msg) return 'fetch_failed';
+    let msg;
+    try {
+      msg = await client.getMessage(msgRef.id);
+    } catch (err) {
+      if (err?.status === 404) return 'gone'; // deleted — documented-safe skip
+      throw err; // transient: fail the PASS, not the message
+    }
+    if (!msg) return 'gone';
+
+    // At-least-once processing needs at-most-once SIDE EFFECTS: replays
+    // (crash-before-stamp, overlapping polls, Gmail's documented duplicate
+    // history records) are deduped on a per-message idempotency key (F2).
+    const [, fresh] = await IdempotencyKey.findOrCreate({
+      where: { scope: MSG_IDEMPOTENCY_SCOPE, key: msgRef.id },
+      defaults: { expiresAt: new Date(d.now().getTime() + MSG_IDEMPOTENCY_TTL_MS) },
+    }).then(([row, created]) => [row, created]);
+    if (!fresh) return 'duplicate';
+
     const payload = msg.payload || {};
     const from = headerOf(payload, 'From');
     const to = `${headerOf(payload, 'To')} ${headerOf(payload, 'Delivered-To')} ${headerOf(payload, 'Cc')}`.toLowerCase();
     const subject = headerOf(payload, 'Subject');
-    const isBounce = BOUNCE_FROM_RE.test(from) || payload.mimeType === 'multipart/report';
+    const isBounce = BOUNCE_FROM_RE.test(from) || payload.mimeType === 'multipart/report'
+      || BOUNCE_SUBJECT_RE.test(subject);
+    // Gmail delay notices = still retrying, NOT a failure — ignore entirely.
+    if (isBounce && DELAY_SUBJECT_RE.test(subject)) return 'delay_notice';
+    // Vacation responders must not exit cadences as "replied" (review F4b).
+    const autoSubmitted = headerOf(payload, 'Auto-Submitted');
+    const isAutoReply = (autoSubmitted && !/^no$/i.test(autoSubmitted))
+      || Boolean(headerOf(payload, 'X-Autoreply')) || Boolean(headerOf(payload, 'X-Autorespond'));
 
     // Tracked thread?
     const row = msg.threadId
       ? await d.OutreachEmail.findOne({
         where: { gmailThreadId: msg.threadId, status: { [Op.in]: ['sent', 'sending', 'failed'] } },
-        order: [['sentAt', 'DESC']],
+        order: [['sentAt', 'DESC NULLS LAST']],
       })
       : null;
 
     if (!row) {
       // Only persona-addressed HUMAN mail counts as "unmatched" — the shared
-      // account's ordinary mail is none of our business.
-      const toPersona = personaAddresses.some((a) => to.includes(a));
-      if (toPersona && !isBounce) {
+      // account's ordinary mail is none of our business. Bounded match, not
+      // substring (notemily@ must not count as emily@ — review F10).
+      const toTokens = to.split(/[\s,;<>"]+/).filter(Boolean);
+      const toPersona = personaAddresses.some((a) => toTokens.includes(a));
+      if (toPersona && !isBounce && !isAutoReply) {
         await d.OutreachAccount.increment('unmatchedInboxCount', { where: { id: account.id } });
         return 'unmatched_persona_mail';
       }
@@ -171,6 +222,12 @@ export function makeOutreachInboxService(overrides = {}) {
       return 'bounce';
     }
 
+    if (isAutoReply) {
+      // Out-of-office: real mailbox, no human intent — never an exit, never
+      // a "answer them soon" forward. Visible in the poll counters only.
+      return 'auto_reply';
+    }
+
     // ── Human reply on a tracked thread ──────────────────────────────────
     const partner = await livePartnerFor(row);
     if (!partner) return 'partner_gone';
@@ -186,24 +243,33 @@ export function makeOutreachInboxService(overrides = {}) {
     const actor = partner.ownerUserId
       ? { id: partner.ownerUserId }
       : { id: null, role: 'admin' };
+    // Transient log failures THROW (F1): the pass must not advance past an
+    // unrecorded reply. The idempotency key is deleted first so the retry
+    // pass re-enters this message instead of skipping it as a duplicate.
     try {
       await d.partners.logActivity(partner.id, {
         type: 'email_reply', direction: 'inbound',
         summary: `Replied by email: ${String(subject).slice(0, 120)}`,
       }, actor);
     } catch (err) {
-      d.logger.error({ partnerId: partner.id, err: err?.message }, '[inbox] reply activity failed');
-      return 'reply_log_failed';
+      await IdempotencyKey.destroy({ where: { scope: MSG_IDEMPOTENCY_SCOPE, key: msgRef.id } }).catch(() => {});
+      throw err;
     }
 
-    if (UNSUB_RE.test(`${subject} ${text}`)) {
+    const unsubscribe = UNSUB_RE.test(`${subject} ${text}`);
+    if (unsubscribe) {
+      // Suppresses the address WE WERE MAILING (row.toAddress) — the human
+      // may reply from a personal address; "stop emailing this address" is
+      // about the destination, not the replier's From. Deliberate (P18).
       await suppress(row.toAddress, 'opt_out');
     }
-    await forwardReplyToRep({ client, account, partner, persona, task, fromHeader: from, subject, text });
+    const forwarded = await forwardReplyToRep({
+      client, account, partner, persona, task, fromHeader: from, subject, text,
+    });
     await d.audit.recordAuditEvent({
       actorUser: null, actorType: 'system', action: 'outreach.reply_received',
       entityType: 'outreach_email', entityId: row.id,
-      after: { partnerId: partner.id, unsubscribe: UNSUB_RE.test(`${subject} ${text}`) },
+      after: { partnerId: partner.id, unsubscribe, forwarded },
     });
     return 'reply';
   }
@@ -237,43 +303,84 @@ export function makeOutreachInboxService(overrides = {}) {
       }
     }
 
+    // Gmail's sync guide: the same change may appear in multiple history
+    // records — dedupe by message id before processing (F2).
+    const seen = new Set();
+    const unique = messages.filter((m) => (seen.has(m.id) ? false : seen.add(m.id)));
+
     const counts = {};
-    for (const msgRef of messages) {
-      const label = await handleMessage(account, client, personaAddresses, msgRef)
-        .catch((err) => {
-          d.logger.error({ msgId: msgRef.id, err: err?.message }, '[inbox] message handling crashed');
-          return 'crashed';
-        });
+    for (const msgRef of unique) {
+      let label;
+      try {
+        label = await handleMessage(account, client, personaAddresses, msgRef);
+        failStreak.delete(msgRef.id);
+      } catch (err) {
+        // Transient failure: the PASS fails — cursor and stamp must not
+        // advance past an unprocessed message (F1). A message that fails
+        // POISON_SKIP_AFTER consecutive passes is skipped VISIBLY so one
+        // malformed mail can't wedge the loop (and the sender) forever.
+        const streak = (failStreak.get(msgRef.id) || 0) + 1;
+        failStreak.set(msgRef.id, streak);
+        if (streak >= POISON_SKIP_AFTER) {
+          d.logger.error({ msgId: msgRef.id, streak, err: err?.message }, '[inbox] message poisoned — SKIPPING it (check the shared mailbox manually)');
+          await d.OutreachAccount.update(
+            { lastError: `poll: skipped poisoned message ${msgRef.id} (${String(err?.message).slice(0, 120)})` },
+            { where: { id: account.id } }
+          ).catch(() => {});
+          failStreak.delete(msgRef.id);
+          label = 'poisoned_skipped';
+        } else {
+          d.logger.warn({ msgId: msgRef.id, streak, err: err?.message }, '[inbox] message handling failed — pass aborted, will retry');
+          throw err;
+        }
+      }
       counts[label] = (counts[label] || 0) + 1;
     }
 
     // The stamp that unlocks the sender — written on EVERY clean pass,
-    // including empty ones and re-baselines (the loop is demonstrably alive).
-    await d.OutreachAccount.update(
-      { historyCursor: cursor, lastSuccessfulPollAt: d.now(), lastError: null },
-      { where: { id: account.id } }
+    // including empty ones and re-baselines (the loop is demonstrably
+    // alive). It clears only errors the POLL wrote: the Phase-A health
+    // check shares lastError and a clean poll must not mask a send-as or
+    // directory failure it never tested (F5).
+    await d.sequelize.query(
+      `UPDATE outreach_accounts
+          SET "historyCursor" = :cursor, "lastSuccessfulPollAt" = NOW(),
+              "lastError" = CASE WHEN "lastError" LIKE 'poll:%' THEN NULL ELSE "lastError" END,
+              "updatedAt" = NOW()
+        WHERE id = :id`,
+      { replacements: { cursor, id: account.id } }
     );
-    if (messages.length > 0) d.logger.info({ accountId: account.id, ...counts }, '[inbox] poll done');
-    return { processed: messages.length, counts };
+    if (unique.length > 0) d.logger.info({ accountId: account.id, ...counts }, '[inbox] poll done');
+    return { processed: unique.length, counts };
   }
 
   /** Poll every active account. Failures are per-account, never cross-fatal. */
+  let polling = false;
   async function poll() {
-    const accounts = await d.OutreachAccount.findAll({ where: { isActive: true }, order: [['createdAt', 'ASC']] });
-    const results = [];
-    for (const account of accounts) {
-      try {
-        results.push(await pollAccount(account));
-      } catch (err) {
-        d.logger.warn({ accountId: account.id, err: err?.message }, '[inbox] poll failed — sender stays gated');
-        await d.OutreachAccount.update(
-          { lastError: `poll: ${String(err?.message).slice(0, 300)}` },
-          { where: { id: account.id } }
-        ).catch(() => {});
-        results.push({ error: err?.message });
+    // In-process mutual exclusion (F2): a fat batch must not overlap the
+    // next interval. Cross-process overlap (deploys) is bounded by the
+    // per-message idempotency keys.
+    if (polling) return [{ skipped: 'poll_in_progress' }];
+    polling = true;
+    try {
+      const accounts = await d.OutreachAccount.findAll({ where: { isActive: true }, order: [['createdAt', 'ASC']] });
+      const results = [];
+      for (const account of accounts) {
+        try {
+          results.push(await pollAccount(account));
+        } catch (err) {
+          d.logger.warn({ accountId: account.id, err: err?.message }, '[inbox] poll failed — sender stays gated');
+          await d.OutreachAccount.update(
+            { lastError: `poll: ${String(err?.message).slice(0, 300)}` },
+            { where: { id: account.id } }
+          ).catch(() => {});
+          results.push({ error: err?.message });
+        }
       }
+      return results;
+    } finally {
+      polling = false;
     }
-    return results;
   }
 
   /** Manual opt-out (the Replied-card classification, plan P18). */

--- a/backend/src/services/redeemOps/outreachInboxService.js
+++ b/backend/src/services/redeemOps/outreachInboxService.js
@@ -1,0 +1,293 @@
+import { Op } from 'sequelize';
+import {
+  OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
+  OutreachSuppression, OutreachCadenceEnrollment, PartnerOrganisation, User, sequelize,
+} from '../../models/index.js';
+import { logger } from '../../utils/logger.js';
+import { makeSecretBox } from '../../utils/secretBox.js';
+import { makeRedeemOpsAuditService } from './auditService.js';
+import { makePartnerService } from './partnerService.js';
+import { makeWorkspaceClient, parseServiceAccountKey, WORKSPACE_SCOPES } from '../google/workspaceService.js';
+
+/**
+ * The inbox loop — Phase C (docs/plans/redeem-ops-cadence-email-autosend.md §5).
+ *
+ * Every clean pass stamps `lastSuccessfulPollAt`, which is the ONLY thing
+ * that unlocks the Phase-B sender (plan P1). What a pass does:
+ * - Gmail history since the persisted cursor (404 ⇒ full re-sync re-baseline,
+ *   Google's documented contract — plan F8).
+ * - A message in a TRACKED thread: bounce ⇒ suppression(bounced) + outbox
+ *   failed; human reply ⇒ `email_reply` inbound activity under the partner
+ *   lock (the existing onInboundActivity hook exits the cadence and cancels
+ *   its tasks) + auto-FORWARD to the owning rep's real mailbox (plan P7) +
+ *   unsubscribe keywords ⇒ suppression(opt_out).
+ * - Replies to a MERGED partner chase `mergedIntoId` to the survivor (M4).
+ * - Unmatched human mail TO A PERSONA address bumps the health-card counter;
+ *   ordinary business@ mail is ignored entirely.
+ */
+
+const outreachBox = makeSecretBox('OUTREACH_MAILBOX_ENCRYPTION_KEY', 'outreach mailbox');
+const SCOPES = [
+  WORKSPACE_SCOPES.gmailSend, WORKSPACE_SCOPES.gmailReadonly,
+  WORKSPACE_SCOPES.gmailSettingsBasic, WORKSPACE_SCOPES.directoryReadonly,
+];
+
+const UNSUB_RE = /\b(unsubscribe|remove me|stop (emailing|contacting)|do ?n[o']t (email|contact))\b/i;
+const BOUNCE_FROM_RE = /(mailer-daemon|postmaster)@/i;
+
+function headerOf(payload, name) {
+  return payload?.headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || '';
+}
+
+/** Best-effort text/plain extraction from a Gmail full payload. */
+export function extractPlainText(payload, depth = 0) {
+  if (!payload || depth > 4) return '';
+  if (payload.mimeType === 'text/plain' && payload.body?.data) {
+    try {
+      return Buffer.from(payload.body.data, 'base64url').toString('utf8');
+    } catch {
+      return '';
+    }
+  }
+  for (const part of payload.parts || []) {
+    const text = extractPlainText(part, depth + 1);
+    if (text) return text;
+  }
+  return '';
+}
+
+export function makeOutreachInboxService(overrides = {}) {
+  const d = {
+    OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
+    OutreachSuppression, OutreachCadenceEnrollment, PartnerOrganisation, User, sequelize, logger,
+    audit: makeRedeemOpsAuditService(),
+    partners: makePartnerService(),
+    secretBox: outreachBox,
+    makeClient: makeWorkspaceClient,
+    now: () => new Date(),
+    ...overrides,
+  };
+
+  async function clientFor(account) {
+    const withCreds = await d.OutreachAccount.scope('withCredentials').findByPk(account.id);
+    if (!withCreds?.encryptedCredentials) throw new Error('account has no credentials');
+    const credentials = parseServiceAccountKey(d.secretBox.decrypt(withCreds.encryptedCredentials));
+    return d.makeClient({ credentials, subject: account.accountEmail, scopes: SCOPES });
+  }
+
+  /** Upsert into the suppression list — its FIRST real writers live here. */
+  async function suppress(email, reason) {
+    const value = String(email).toLowerCase();
+    const [row, created] = await d.OutreachSuppression.findOrCreate({
+      where: { channel: 'email', value },
+      defaults: { channel: 'email', value, reason, source: 'inbox_loop' },
+    });
+    if (!created && row.reason !== reason && reason === 'opt_out') {
+      // opt_out outranks bounced — an explicit "stop" is the stronger fact.
+      await row.update({ reason });
+    }
+    return row;
+  }
+
+  /** The partner a tracked row belongs to, merge-chased to the survivor (M4). */
+  async function livePartnerFor(row) {
+    let partner = await d.PartnerOrganisation.findByPk(row.partnerOrganisationId);
+    let hops = 0;
+    while (partner?.mergedIntoId && hops < 5) {
+      partner = await d.PartnerOrganisation.findByPk(partner.mergedIntoId);
+      hops += 1;
+    }
+    return partner && !partner.mergedIntoId ? partner : null;
+  }
+
+  async function forwardReplyToRep({ client, account, partner, persona, task, fromHeader, subject, text }) {
+    const repUserId = partner.ownerUserId || task?.assigneeUserId || persona?.assignedUserId;
+    const rep = repUserId ? await d.User.findByPk(repUserId, { attributes: ['id', 'email', 'fullName'] }) : null;
+    if (!rep?.email) return false;
+    const link = `https://ops.redeem.sg/redeem-ops/partners/${partner.id}`;
+    const rfc822 = [
+      `From: "Redeem outreach" <${account.accountEmail}>`,
+      `To: <${rep.email}>`,
+      `Subject: Reply from ${String(partner.tradingName || partner.legalName || 'a prospect').replace(/[\r\n]+/g, ' ')} — answer them soon`,
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      `They replied on the ${persona?.address || 'outreach'} thread (${String(subject).replace(/[\r\n]+/g, ' ')}):`,
+      '',
+      String(text || '(no text body — open the thread in the shared mailbox)').slice(0, 4000),
+      '',
+      `From: ${fromHeader}`,
+      `Business page: ${link}`,
+      '',
+      'The cadence has been stopped automatically. Reply from the shared mailbox or call them.',
+    ].join('\r\n');
+    try {
+      await client.sendRaw(rfc822);
+      return true;
+    } catch (err) {
+      d.logger.warn({ partnerId: partner.id, err: err?.message }, '[inbox] reply forward failed (non-fatal)');
+      return false;
+    }
+  }
+
+  /** Handle ONE new inbox message. Returns a label for counters/tests. */
+  async function handleMessage(account, client, personaAddresses, msgRef) {
+    const msg = await client.getMessage(msgRef.id).catch(() => null);
+    if (!msg) return 'fetch_failed';
+    const payload = msg.payload || {};
+    const from = headerOf(payload, 'From');
+    const to = `${headerOf(payload, 'To')} ${headerOf(payload, 'Delivered-To')} ${headerOf(payload, 'Cc')}`.toLowerCase();
+    const subject = headerOf(payload, 'Subject');
+    const isBounce = BOUNCE_FROM_RE.test(from) || payload.mimeType === 'multipart/report';
+
+    // Tracked thread?
+    const row = msg.threadId
+      ? await d.OutreachEmail.findOne({
+        where: { gmailThreadId: msg.threadId, status: { [Op.in]: ['sent', 'sending', 'failed'] } },
+        order: [['sentAt', 'DESC']],
+      })
+      : null;
+
+    if (!row) {
+      // Only persona-addressed HUMAN mail counts as "unmatched" — the shared
+      // account's ordinary mail is none of our business.
+      const toPersona = personaAddresses.some((a) => to.includes(a));
+      if (toPersona && !isBounce) {
+        await d.OutreachAccount.increment('unmatchedInboxCount', { where: { id: account.id } });
+        return 'unmatched_persona_mail';
+      }
+      return 'ignored';
+    }
+
+    if (isBounce) {
+      await suppress(row.toAddress, 'bounced');
+      await d.OutreachEmail.update(
+        { status: 'failed', lastError: 'bounced' },
+        { where: { id: row.id, status: { [Op.in]: ['sent', 'sending'] } } }
+      );
+      await d.audit.recordAuditEvent({
+        actorUser: null, actorType: 'system', action: 'outreach.email_bounced',
+        entityType: 'outreach_email', entityId: row.id, after: { toAddress: row.toAddress },
+      });
+      return 'bounce';
+    }
+
+    // ── Human reply on a tracked thread ──────────────────────────────────
+    const partner = await livePartnerFor(row);
+    if (!partner) return 'partner_gone';
+    const persona = row.personaId ? await d.OutreachPersona.findByPk(row.personaId) : null;
+    const task = await d.OutreachTask.findByPk(row.taskId);
+    const text = extractPlainText(payload) || msg.snippet || '';
+
+    // The honest inbound activity — the existing onInboundActivity hook exits
+    // the live cadence and cancels its tasks in the same transaction. Actor =
+    // the partner's CURRENT owner; an UNOWNED (released) partner logs under a
+    // synthetic admin-shaped system context (actorUserId null on the row) —
+    // a real reply is never dropped for lack of an owner (review M4).
+    const actor = partner.ownerUserId
+      ? { id: partner.ownerUserId }
+      : { id: null, role: 'admin' };
+    try {
+      await d.partners.logActivity(partner.id, {
+        type: 'email_reply', direction: 'inbound',
+        summary: `Replied by email: ${String(subject).slice(0, 120)}`,
+      }, actor);
+    } catch (err) {
+      d.logger.error({ partnerId: partner.id, err: err?.message }, '[inbox] reply activity failed');
+      return 'reply_log_failed';
+    }
+
+    if (UNSUB_RE.test(`${subject} ${text}`)) {
+      await suppress(row.toAddress, 'opt_out');
+    }
+    await forwardReplyToRep({ client, account, partner, persona, task, fromHeader: from, subject, text });
+    await d.audit.recordAuditEvent({
+      actorUser: null, actorType: 'system', action: 'outreach.reply_received',
+      entityType: 'outreach_email', entityId: row.id,
+      after: { partnerId: partner.id, unsubscribe: UNSUB_RE.test(`${subject} ${text}`) },
+    });
+    return 'reply';
+  }
+
+  /** One poll pass over one account. */
+  async function pollAccount(account) {
+    const client = await clientFor(account);
+    const personas = await d.OutreachPersona.findAll({ where: { accountId: account.id }, attributes: ['address'] });
+    const personaAddresses = personas.map((p) => p.address.toLowerCase());
+
+    let cursor = account.historyCursor;
+    let messages = [];
+    if (!cursor) {
+      // First run: baseline only — history starts NOW; old mail is not replayed.
+      const profile = await client.getProfile();
+      cursor = String(profile.historyId);
+    } else {
+      try {
+        const out = await client.listInboxHistory(cursor);
+        messages = out.messages;
+        cursor = String(out.historyId || cursor);
+      } catch (err) {
+        if (err?.status === 404) {
+          // Cursor expired (documented) — re-baseline and accept the gap, loudly.
+          const profile = await client.getProfile();
+          cursor = String(profile.historyId);
+          d.logger.warn({ accountId: account.id }, '[inbox] history cursor expired — re-baselined (gap accepted)');
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    const counts = {};
+    for (const msgRef of messages) {
+      const label = await handleMessage(account, client, personaAddresses, msgRef)
+        .catch((err) => {
+          d.logger.error({ msgId: msgRef.id, err: err?.message }, '[inbox] message handling crashed');
+          return 'crashed';
+        });
+      counts[label] = (counts[label] || 0) + 1;
+    }
+
+    // The stamp that unlocks the sender — written on EVERY clean pass,
+    // including empty ones and re-baselines (the loop is demonstrably alive).
+    await d.OutreachAccount.update(
+      { historyCursor: cursor, lastSuccessfulPollAt: d.now(), lastError: null },
+      { where: { id: account.id } }
+    );
+    if (messages.length > 0) d.logger.info({ accountId: account.id, ...counts }, '[inbox] poll done');
+    return { processed: messages.length, counts };
+  }
+
+  /** Poll every active account. Failures are per-account, never cross-fatal. */
+  async function poll() {
+    const accounts = await d.OutreachAccount.findAll({ where: { isActive: true }, order: [['createdAt', 'ASC']] });
+    const results = [];
+    for (const account of accounts) {
+      try {
+        results.push(await pollAccount(account));
+      } catch (err) {
+        d.logger.warn({ accountId: account.id, err: err?.message }, '[inbox] poll failed — sender stays gated');
+        await d.OutreachAccount.update(
+          { lastError: `poll: ${String(err?.message).slice(0, 300)}` },
+          { where: { id: account.id } }
+        ).catch(() => {});
+        results.push({ error: err?.message });
+      }
+    }
+    return results;
+  }
+
+  /** Manual opt-out (the Replied-card classification, plan P18). */
+  async function optOutAddress(email, user, requestId = null) {
+    const row = await suppress(email, 'opt_out');
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'outreach.opt_out_recorded', entityType: 'outreach_suppression',
+      entityId: row.id, after: { value: row.value }, requestId,
+    });
+    return row;
+  }
+
+  return { poll, pollAccount, optOutAddress, suppress };
+}
+
+const _default = makeOutreachInboxService();
+export default _default;

--- a/backend/src/services/redeemOps/outreachSenderService.js
+++ b/backend/src/services/redeemOps/outreachSenderService.js
@@ -194,6 +194,16 @@ export function makeOutreachSenderService(overrides = {}) {
   async function processRow(row) {
     const at = d.now();
     const checked = await revalidate(row, at);
+    if (checked.fail === 'no_email') {
+      // The address vanished since enqueue — cancel AND park the enrollment
+      // (plan P5): the contact-info hook then rescues it like any other park,
+      // instead of an active enrollment pointing at a dead address forever.
+      await cancelRow(row, 'no_email');
+      await d.cadences.parkActiveEnrollment(row.cadenceEnrollmentId, 'no_email').catch((err) => {
+        d.logger.warn({ outboxId: row.id, err: err?.message }, '[autosend] no_email park failed (task stays manual)');
+      });
+      return {};
+    }
     if (checked.fail) return cancelRow(row, checked.fail);
     if (checked.reschedule) {
       return row.update({ status: 'queued', nextAttemptAt: checked.reschedule, attempts: row.attempts - 1 });

--- a/backend/src/services/redeemOps/outreachSenderService.js
+++ b/backend/src/services/redeemOps/outreachSenderService.js
@@ -199,7 +199,10 @@ export function makeOutreachSenderService(overrides = {}) {
       // (plan P5): the contact-info hook then rescues it like any other park,
       // instead of an active enrollment pointing at a dead address forever.
       await cancelRow(row, 'no_email');
-      await d.cadences.parkActiveEnrollment(row.cadenceEnrollmentId, 'no_email').catch((err) => {
+      const parkTask = await d.OutreachTask.findByPk(row.taskId, { attributes: ['cadenceStepId'] });
+      await d.cadences.parkActiveEnrollment(row.cadenceEnrollmentId, 'no_email', {
+        expectedStepId: parkTask?.cadenceStepId || null,
+      }).catch((err) => {
         d.logger.warn({ outboxId: row.id, err: err?.message }, '[autosend] no_email park failed (task stays manual)');
       });
       return {};

--- a/backend/test/redeemOpsInboxLoop.test.js
+++ b/backend/test/redeemOpsInboxLoop.test.js
@@ -40,6 +40,7 @@ const google = {
   history: { messages: [], historyId: '2000' },
   historyError: null,
   messagesById: {},
+  failFetchOnce: null, // message id whose fetch throws 500 exactly once
   profileHistoryId: '1000',
   sendRaw: jest.fn(async () => ({ id: 'fwd-1', threadId: 'fwd-th-1' })),
 };
@@ -49,7 +50,15 @@ const mockClient = () => ({
     if (google.historyError) { const e = new Error('history 404'); e.status = google.historyError; throw e; }
     return google.history;
   },
-  getMessage: async (id) => google.messagesById[id] || null,
+  getMessage: async (id) => {
+    if (google.failFetchOnce === id) {
+      google.failFetchOnce = null;
+      const e = new Error('gmail 500');
+      e.status = 500;
+      throw e;
+    }
+    return google.messagesById[id] || null;
+  },
   sendRaw: google.sendRaw,
   getMessageHeaders: async () => ({ payload: { headers: [{ name: 'Message-ID', value: '<w@x>' }] } }),
   getThread: async () => ({ messages: [{ id: 'm', labelIds: ['SENT'] }] }),
@@ -92,6 +101,7 @@ beforeEach(async () => {
   google.history = { messages: [], historyId: '2000' };
   google.historyError = null;
   google.messagesById = {};
+  google.failFetchOnce = null;
   await OutreachAccount.update(
     { historyCursor: '1500', lastSuccessfulPollAt: null, unmatchedInboxCount: 0 },
     { where: { id: account.id } }
@@ -213,11 +223,39 @@ describe('replies on tracked threads', () => {
     });
     await inbox.poll();
     await OutreachAccount.update({ historyCursor: '1500' }, { where: { id: account.id } });
-    await inbox.poll(); // replay — findOrCreate must not violate the unique index
+    await inbox.poll(); // replay — the per-message idempotency key eats it
 
     const rows = await OutreachSuppression.findAll({ where: { value: 'unsubcafe@biz.sg' } });
     expect(rows).toHaveLength(1);
     expect(rows[0].reason).toBe('opt_out');
+    // …and the replay produced NO duplicate activity or forward (F2).
+    const acts = await OutreachActivity.findAll({
+      where: { partnerOrganisationId: p.id, type: 'email_reply' },
+    });
+    expect(acts).toHaveLength(1);
+    expect(google.sendRaw).toHaveBeenCalledTimes(1);
+  });
+
+  test('a transient fetch failure aborts the PASS — cursor and stamp do not advance past a lost reply (F1)', async () => {
+    const p = await ownedPartner('TransientCafe');
+    await trackedSend(p, { threadId: 'th-transient-1' });
+    google.history = { messages: [{ id: 'in-t1' }, { id: 'in-t2' }], historyId: '2600' };
+    google.messagesById['in-t1'] = inboundMsg('in-t1', { threadId: 'th-transient-1', from: 'Owner <o@transient.sg>' });
+    google.messagesById['in-t2'] = inboundMsg('in-t2', { threadId: 'th-none-9', from: 'X <x@y.sg>', to: 'business@mktr.sg' });
+    google.failFetchOnce = 'in-t1';
+
+    await inbox.poll(); // first pass fails on in-t1 → nothing stamps
+    let a = await OutreachAccount.findByPk(account.id);
+    expect(a.lastSuccessfulPollAt).toBeNull();
+    expect(a.historyCursor).toBe('1500'); // unchanged
+
+    await inbox.poll(); // retry pass: fetch works now — both processed
+    a = await OutreachAccount.findByPk(account.id);
+    expect(a.lastSuccessfulPollAt).toBeTruthy();
+    const acts = await OutreachActivity.findAll({
+      where: { partnerOrganisationId: p.id, type: 'email_reply' },
+    });
+    expect(acts).toHaveLength(1); // the reply survived the hiccup, exactly once
   });
 
   test('a reply to a MERGED partner lands on the survivor', async () => {
@@ -252,6 +290,19 @@ describe('bounces and unmatched mail', () => {
     const sup = await OutreachSuppression.findOne({ where: { value: row.toAddress.toLowerCase() } });
     expect(sup.reason).toBe('bounced');
     expect((await OutreachEmail.findByPk(row.id)).status).toBe('failed');
+  });
+
+  test('a Gmail DELAY notice never suppresses — the address is still being retried (F3)', async () => {
+    const p = await ownedPartner('DelayCafe');
+    const { row } = await trackedSend(p, { threadId: 'th-delay-1' });
+    google.history = { messages: [{ id: 'in-d1' }], historyId: '2700' };
+    google.messagesById['in-d1'] = inboundMsg('in-d1', {
+      threadId: 'th-delay-1', from: 'Mail Delivery Subsystem <mailer-daemon@googlemail.com>',
+      subject: 'Delivery Status Notification (Delay)', text: 'Delivery incomplete. Gmail will keep trying.',
+    });
+    await inbox.poll();
+    expect(await OutreachSuppression.findOne({ where: { value: row.toAddress.toLowerCase() } })).toBeNull();
+    expect((await OutreachEmail.findByPk(row.id)).status).toBe('sent'); // untouched
   });
 
   test('human mail TO a persona with no tracked thread bumps the unmatched counter; ordinary business@ mail is ignored', async () => {

--- a/backend/test/redeemOpsInboxLoop.test.js
+++ b/backend/test/redeemOpsInboxLoop.test.js
@@ -1,0 +1,304 @@
+/**
+ * Email auto-send Phase C — the inbox loop
+ * (docs/plans/redeem-ops-cadence-email-autosend.md §5/§8-C).
+ *
+ * Under test, all Google-mocked: the poll stamps lastSuccessfulPollAt (the
+ * ONLY key that unlocks the Phase-B sender), replies on tracked threads exit
+ * cadences + forward to the rep, bounces/unsubscribes write the FIRST
+ * outreach_suppressions rows, merged partners are chased to the survivor,
+ * cursor 404s re-baseline, unmatched persona mail is counted, and the
+ * send-time no_email discovery now PARKS the enrollment (deferred P5).
+ */
+process.env.REDEEM_OPS_ENABLED = 'true';
+process.env.REDEEM_OPS_CADENCES_ENABLED = 'true';
+process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED = 'true';
+process.env.OUTREACH_MAILBOX_ENCRYPTION_KEY = 'test-outreach-encryption-key-32chars!';
+
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser } from './helpers.js';
+import {
+  OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
+  OutreachSuppression, OutreachCadenceEnrollment, OutreachActivity,
+  PartnerOrganisation, sequelize,
+} from '../src/models/index.js';
+import { makeCadenceService } from '../src/services/redeemOps/cadenceService.js';
+import { makeOutreachInboxService, extractPlainText } from '../src/services/redeemOps/outreachInboxService.js';
+import { makeOutreachSenderService } from '../src/services/redeemOps/outreachSenderService.js';
+import { makePartnerService } from '../src/services/redeemOps/partnerService.js';
+import { makeClaimService } from '../src/services/redeemOps/claimService.js';
+import { makeSecretBox } from '../src/utils/secretBox.js';
+import { registerCadenceHooks, clearCadenceHooks } from '../src/services/redeemOps/cadenceHooks.js';
+
+let admin, exec;
+let account, persona;
+
+const svc = makeCadenceService();
+const partnerSvc = makePartnerService();
+const claimSvc = makeClaimService();
+
+const google = {
+  history: { messages: [], historyId: '2000' },
+  historyError: null,
+  messagesById: {},
+  profileHistoryId: '1000',
+  sendRaw: jest.fn(async () => ({ id: 'fwd-1', threadId: 'fwd-th-1' })),
+};
+const mockClient = () => ({
+  getProfile: async () => ({ emailAddress: 'business@mktr.sg', historyId: google.profileHistoryId }),
+  listInboxHistory: async () => {
+    if (google.historyError) { const e = new Error('history 404'); e.status = google.historyError; throw e; }
+    return google.history;
+  },
+  getMessage: async (id) => google.messagesById[id] || null,
+  sendRaw: google.sendRaw,
+  getMessageHeaders: async () => ({ payload: { headers: [{ name: 'Message-ID', value: '<w@x>' }] } }),
+  getThread: async () => ({ messages: [{ id: 'm', labelIds: ['SENT'] }] }),
+  listMessages: async () => [],
+});
+const inbox = makeOutreachInboxService({ makeClient: mockClient });
+const sender = makeOutreachSenderService({ makeClient: mockClient });
+
+let phoneSeq = 83000000;
+const nextPhone = () => `+65${phoneSeq++}`;
+
+beforeAll(async () => {
+  await getApp();
+  admin = await createTestUser({ role: 'admin' });
+  exec = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+  registerCadenceHooks(svc.hookHandlers());
+  const box = makeSecretBox('OUTREACH_MAILBOX_ENCRYPTION_KEY', 'outreach mailbox');
+  account = await OutreachAccount.create({
+    accountEmail: 'business@mktr.sg',
+    encryptedCredentials: box.encrypt(JSON.stringify({
+      type: 'service_account', client_email: 'sa@x.iam.gserviceaccount.com',
+      private_key: '-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n',
+    })),
+    historyCursor: '1500',
+  });
+  persona = await OutreachPersona.create({
+    accountId: account.id, address: 'emily@redeem.sg', displayName: 'Emily Wong',
+    assignedUserId: exec.user.id, sendAsRegistered: true, sendAsVerified: true,
+    isAccountAlias: true,
+  });
+});
+
+afterAll(async () => {
+  clearCadenceHooks();
+  await closeDb();
+});
+
+beforeEach(async () => {
+  google.sendRaw.mockClear();
+  google.history = { messages: [], historyId: '2000' };
+  google.historyError = null;
+  google.messagesById = {};
+  await OutreachAccount.update(
+    { historyCursor: '1500', lastSuccessfulPollAt: null, unmatchedInboxCount: 0 },
+    { where: { id: account.id } }
+  );
+});
+
+async function ownedPartner(name, patch = {}) {
+  const { partner } = await partnerSvc.createPartner(
+    { tradingName: name, primaryPhone: nextPhone(), primaryEmail: `${name.replace(/\W/g, '').toLowerCase()}@biz.sg` },
+    admin.user
+  );
+  await claimSvc.claimPartner(partner.id, exec.user);
+  if (Object.keys(patch).length) await partner.update(patch);
+  return PartnerOrganisation.findByPk(partner.id);
+}
+
+let seq = 0;
+async function trackedSend(partner, { threadId }) {
+  seq += 1;
+  const cadence = await svc.createCadence({
+    name: `Inbox Cad ${seq}`,
+    steps: [
+      { channel: 'email', title: `Step A ${seq}`, mode: 'auto', subject: 'Idea for {{partner_name}}', script: 'Hi {{contact_name}}.', delayDays: 0, timeWindow: 'any' },
+      { channel: 'email', title: `Step B ${seq}`, mode: 'auto', subject: 'Idea for {{partner_name}}', script: 'Bump.', delayDays: 3, timeWindow: 'any' },
+    ],
+  }, admin.user);
+  const { enrollment, firstTask } = await svc.enrollPartner(partner.id, { cadenceId: cadence.id }, exec.user);
+  const row = await OutreachEmail.findOne({ where: { taskId: firstTask.id } });
+  await row.update({ status: 'sent', sentAt: new Date(), gmailThreadId: threadId, wireMessageId: `<w-${seq}@mail>` });
+  await enrollment.update({ gmailThreadId: threadId, gmailThreadSubject: `Idea for ${partner.tradingName}` });
+  return { cadence, enrollment, firstTask, row };
+}
+
+const inboundMsg = (id, { threadId, from, to = 'emily@redeem.sg', subject = 'Re: Idea', text = 'Sounds interesting, tell me more', mime = 'text/plain' }) => ({
+  id, threadId, snippet: text.slice(0, 100),
+  payload: {
+    mimeType: mime,
+    headers: [
+      { name: 'From', value: from },
+      { name: 'To', value: to },
+      { name: 'Subject', value: subject },
+    ],
+    body: { data: Buffer.from(text, 'utf8').toString('base64url') },
+  },
+});
+
+describe('the poll stamp (what unlocks the sender)', () => {
+  test('a clean pass — even empty — stamps lastSuccessfulPollAt and advances the cursor', async () => {
+    const [result] = await inbox.poll();
+    expect(result.processed).toBe(0);
+    const a = await OutreachAccount.findByPk(account.id);
+    expect(a.lastSuccessfulPollAt).toBeTruthy();
+    expect(a.historyCursor).toBe('2000');
+  });
+
+  test('a 404 cursor re-baselines from the profile and STILL stamps (the loop is alive)', async () => {
+    google.historyError = 404;
+    google.profileHistoryId = '9999';
+    const [result] = await inbox.poll();
+    expect(result.processed).toBe(0);
+    const a = await OutreachAccount.findByPk(account.id);
+    expect(a.historyCursor).toBe('9999');
+    expect(a.lastSuccessfulPollAt).toBeTruthy();
+  });
+
+  test('a hard poll failure does NOT stamp — the sender stays gated', async () => {
+    google.historyError = 500;
+    await inbox.poll();
+    const a = await OutreachAccount.findByPk(account.id);
+    expect(a.lastSuccessfulPollAt).toBeNull();
+    expect(a.lastError).toMatch(/poll/);
+  });
+
+  test('end to end: dark sender → poll → sender sends', async () => {
+    const p = await ownedPartner('UnlockCafe');
+    await partnerSvc.addContact(p.id, { name: 'Zul', email: 'zul@unlock.sg' }, exec.user);
+    const cadence = await svc.createCadence({
+      name: 'Unlock Cad',
+      steps: [{ channel: 'email', title: 'Unlock step', mode: 'auto', subject: 'Hello {{partner_name}}', script: 'Hi {{contact_name}}.', delayDays: 0, timeWindow: 'any' }],
+    }, admin.user);
+    await sequelize.query('UPDATE outreach_cadences SET "autoSendApprovals" = 999 WHERE id = :id', { replacements: { id: cadence.id } });
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+    await OutreachEmail.update({ nextAttemptAt: new Date(Date.now() - 1000) }, { where: { taskId: firstTask.id } });
+
+    expect((await sender.tick()).skipped).toBe('reply_loop_dark');
+    await inbox.poll();
+    const out = await sender.tick();
+    expect(out.sent).toBe(1);
+  });
+});
+
+describe('replies on tracked threads', () => {
+  test('exits the cadence, cancels the NEXT queued step, forwards to the rep, audits', async () => {
+    const p = await ownedPartner('ReplyCafe');
+    const { enrollment } = await trackedSend(p, { threadId: 'th-reply-1' });
+    google.history = { messages: [{ id: 'in-1' }], historyId: '2100' };
+    google.messagesById['in-1'] = inboundMsg('in-1', { threadId: 'th-reply-1', from: 'Owner <owner@replycafe.sg>' });
+
+    await inbox.poll();
+
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('exited');
+    expect(e.exitReason).toBe('replied');
+    const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
+    expect(acts.some((a) => a.type === 'email_reply' && a.direction === 'inbound')).toBe(true);
+    // forward to the rep's real login mailbox
+    const fwd = google.sendRaw.mock.calls.at(-1)[0];
+    expect(fwd).toContain(`To: <${exec.user.email}>`);
+    expect(fwd).toContain('Reply from ReplyCafe');
+    expect(fwd).toContain('Sounds interesting');
+  });
+
+  test('an unsubscribe-phrased reply also writes the opt_out suppression (twice = upsert)', async () => {
+    const p = await ownedPartner('UnsubCafe');
+    await trackedSend(p, { threadId: 'th-unsub-1' });
+    google.history = { messages: [{ id: 'in-2' }], historyId: '2200' };
+    google.messagesById['in-2'] = inboundMsg('in-2', {
+      threadId: 'th-unsub-1', from: 'Owner <boss@unsub.sg>', text: 'Please unsubscribe me from these emails.',
+    });
+    await inbox.poll();
+    await OutreachAccount.update({ historyCursor: '1500' }, { where: { id: account.id } });
+    await inbox.poll(); // replay — findOrCreate must not violate the unique index
+
+    const rows = await OutreachSuppression.findAll({ where: { value: 'unsubcafe@biz.sg' } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].reason).toBe('opt_out');
+  });
+
+  test('a reply to a MERGED partner lands on the survivor', async () => {
+    const survivor = await ownedPartner('SurvivorCafe');
+    const dup = await ownedPartner('DupCafe');
+    const { enrollment } = await trackedSend(dup, { threadId: 'th-merge-1' });
+    // simulate a completed merge: dup points at survivor, dup's cadence exited
+    await svc.stopEnrollment(dup.id, exec.user).catch(() => {});
+    await sequelize.query(
+      'UPDATE partner_organisations SET "mergedIntoId" = :sid WHERE id = :did',
+      { replacements: { sid: survivor.id, did: dup.id } }
+    );
+    google.history = { messages: [{ id: 'in-3' }], historyId: '2300' };
+    google.messagesById['in-3'] = inboundMsg('in-3', { threadId: 'th-merge-1', from: 'Owner <o@dup.sg>' });
+    await inbox.poll();
+    const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: survivor.id } });
+    expect(acts.some((a) => a.type === 'email_reply')).toBe(true);
+    void enrollment;
+  });
+});
+
+describe('bounces and unmatched mail', () => {
+  test('a mailer-daemon message on a tracked thread suppresses the address and fails the row', async () => {
+    const p = await ownedPartner('BounceCafe');
+    const { row } = await trackedSend(p, { threadId: 'th-bounce-1' });
+    google.history = { messages: [{ id: 'in-4' }], historyId: '2400' };
+    google.messagesById['in-4'] = inboundMsg('in-4', {
+      threadId: 'th-bounce-1', from: 'Mail Delivery Subsystem <mailer-daemon@googlemail.com>',
+      subject: 'Delivery Status Notification (Failure)', text: 'Address not found',
+    });
+    await inbox.poll();
+    const sup = await OutreachSuppression.findOne({ where: { value: row.toAddress.toLowerCase() } });
+    expect(sup.reason).toBe('bounced');
+    expect((await OutreachEmail.findByPk(row.id)).status).toBe('failed');
+  });
+
+  test('human mail TO a persona with no tracked thread bumps the unmatched counter; ordinary business@ mail is ignored', async () => {
+    google.history = { messages: [{ id: 'in-5' }, { id: 'in-6' }], historyId: '2500' };
+    google.messagesById['in-5'] = inboundMsg('in-5', { threadId: 'th-none-1', from: 'Someone <x@y.sg>', to: 'emily@redeem.sg' });
+    google.messagesById['in-6'] = inboundMsg('in-6', { threadId: 'th-none-2', from: 'Vendor <v@z.sg>', to: 'business@mktr.sg' });
+    await inbox.poll();
+    expect((await OutreachAccount.findByPk(account.id)).unmatchedInboxCount).toBe(1);
+  });
+});
+
+describe('send-time no_email now PARKS (deferred P5)', () => {
+  test('recipient vanished → row cancelled, task cancelled, enrollment paused missing_info/no_email', async () => {
+    const p = await ownedPartner('VanishCafe');
+    const cadence = await svc.createCadence({
+      name: 'Vanish Cad',
+      steps: [{ channel: 'email', title: 'Vanish step', mode: 'auto', subject: 'Hi {{partner_name}}', script: 'Hi.', delayDays: 0, timeWindow: 'any' }],
+    }, admin.user);
+    await sequelize.query('UPDATE outreach_cadences SET "autoSendApprovals" = 999 WHERE id = :id', { replacements: { id: cadence.id } });
+    const { enrollment, firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+    await OutreachEmail.update({ nextAttemptAt: new Date(Date.now() - 1000) }, { where: { taskId: firstTask.id } });
+    await OutreachAccount.update({ lastSuccessfulPollAt: new Date() }, { where: { id: account.id } });
+    // every email source vanishes after enqueue
+    await sequelize.query('UPDATE partner_organisations SET "primaryEmail" = NULL WHERE id = :id', { replacements: { id: p.id } });
+
+    await sender.tick();
+
+    const row = await OutreachEmail.findOne({ where: { taskId: firstTask.id } });
+    expect(row.status).toBe('cancelled');
+    expect(row.lastError).toBe('no_email');
+    expect((await OutreachTask.findByPk(firstTask.id)).status).toBe('cancelled');
+    const e = await OutreachCadenceEnrollment.findByPk(enrollment.id);
+    expect(e.state).toBe('paused');
+    expect(e.pausedReason).toBe('missing_info');
+    expect(e.blockedReason).toBe('no_email');
+  });
+});
+
+describe('extractPlainText', () => {
+  test('walks multipart payloads and decodes base64url', () => {
+    const nested = {
+      mimeType: 'multipart/alternative',
+      parts: [
+        { mimeType: 'text/html', body: { data: Buffer.from('<b>hi</b>').toString('base64url') } },
+        { mimeType: 'text/plain', body: { data: Buffer.from('plain hello').toString('base64url') } },
+      ],
+    };
+    expect(extractPlainText(nested)).toBe('plain hello');
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -500,6 +500,10 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/outreach/emails/${emailId}/convert-manual`);
     return res.data?.email;
   },
+  async recordOutreachOptOut(email) {
+    const res = await apiClient.post('/redeem-ops/outreach/opt-out', { email });
+    return res.data?.suppression;
+  },
   async skipCadenceStep(partnerId, body = {}) {
     const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/cadence/skip-step`, body);
     return res.data;

--- a/src/components/redeemops/OutreachPersonasCard.jsx
+++ b/src/components/redeemops/OutreachPersonasCard.jsx
@@ -151,7 +151,7 @@ export default function OutreachPersonasCard() {
                 </RoTag>
               )}
               {(account.unmatchedInboxCount || 0) > 0 && (
-                <RoTag tone="paused" size="sm">{account.unmatchedInboxCount} unmatched replies in Gmail</RoTag>
+                <RoTag tone="paused" size="sm">{account.unmatchedInboxCount} unmatched replies since setup · check Gmail</RoTag>
               )}
               <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>
                 {account.lastHealthCheckAt

--- a/src/components/redeemops/OutreachPersonasCard.jsx
+++ b/src/components/redeemops/OutreachPersonasCard.jsx
@@ -145,6 +145,14 @@ export default function OutreachPersonasCard() {
               {account.lastError
                 ? <RoTag tone="lost" size="sm">health error</RoTag>
                 : account.lastHealthCheckAt && <RoTag tone="open" size="sm">healthy</RoTag>}
+              {account.lastSuccessfulPollAt && (
+                <RoTag tone="open" size="sm">
+                  inbox watched · {new Date(account.lastSuccessfulPollAt).toLocaleTimeString()}
+                </RoTag>
+              )}
+              {(account.unmatchedInboxCount || 0) > 0 && (
+                <RoTag tone="paused" size="sm">{account.unmatchedInboxCount} unmatched replies in Gmail</RoTag>
+              )}
               <span className="text-xs" style={{ color: 'var(--ro-text-3)' }}>
                 {account.lastHealthCheckAt
                   ? `checked ${new Date(account.lastHealthCheckAt).toLocaleString()}`


### PR DESCRIPTION
The final phase of cadence email auto-send (plan = PR #440 v4; Phases A #441 + B #442 merged dark). Two commits: the build, then fixes from a Fable 5 adversarial review (HIGH: transient Gmail failures could silently lose a reply — or an unsubscribe — while every health surface showed green; now a transient failure aborts the pass so the cursor never advances past an unprocessed message, with per-message idempotency keys making the retry exactly-once and a visible poison-skip bound).

## What it adds
- **The 2-minute inbox poll** per account: Gmail history cursor sync (404 → documented full re-sync re-baseline; first run baselines at NOW), stamping `lastSuccessfulPollAt` on every clean pass — **the only key the Phase B sender accepts**. Hard failures don't stamp: the sender stays dark. Clean polls clear only their own errors (send-as/directory health failures stay visible).
- **Replies end cadences instantly**: honest `email_reply` inbound activity (the existing hook exits + cancels remaining steps and queued sends), merge-chased to the surviving business, **auto-forwarded to the owning rep's real mailbox** (reply text + business link, one retry, outcome recorded on the audit). Released/unowned partners log under a system context — a real reply is never dropped. Out-of-office auto-replies are recognized and never exit a cadence or ping the rep.
- **First `outreach_suppressions` writers** (closes the parent-plan precondition): tracked-thread bounces → `(email, bounced)` + row failed — with Gmail *delay* notices correctly ignored (still retrying ≠ dead) and a subject heuristic catching foreign plain-text bounces; unsubscribe-phrased replies → `(email, opt_out)` (outranks bounced); `POST /outreach/opt-out` for human-tap classifications.
- **Deferred P5 delivered**: the sender's send-time no-email discovery now cancels AND parks the enrollment (`missing_info`/`no_email`) via a new lock-ordered `parkActiveEnrollment` — with a staleness guard and an under-lock recipient re-resolve so a concurrent contact-add can't be stranded.
- **Health surfaces**: Settings card shows "inbox watched · time" + a lifetime unmatched-replies gauge. Migration 121.

## Ships dark
Same three locks as before: env flag off, auto-step authoring env-gated, and — now that this exists — the sender unlocks only while this loop demonstrably polls. Merging changes nothing until the activation runbook (#441) runs and the flag flips, starting with the plan's one-persona/one-cadence pilot.

## Tests
13 inbox-loop (dark→poll→send unlock end-to-end, pass-abort-then-exactly-once recovery, replay idempotency incl. single activity+forward, merged-partner chase, delay-DSN non-suppression, bounce suppression, unmatched bounding, re-baseline, send-time park) · 16 autosend · 119 regression · 23 migrations · 52 vitest · lint ×2 · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S