### PR TITLE
feat(redeem-ops): upload the service-account key file (no copy-paste)

### DIFF
--- a/src/components/redeemops/OutreachPersonasCard.jsx
+++ b/src/components/redeemops/OutreachPersonasCard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { redeemOpsApi } from '@/api/redeemOps';
@@ -29,7 +29,24 @@ export default function OutreachPersonasCard() {
   const [importOpen, setImportOpen] = useState(false);
   const [accountEmail, setAccountEmail] = useState('business@mktr.sg');
   const [keyJson, setKeyJson] = useState('');
+  const [keyFileName, setKeyFileName] = useState('');
   const [picked, setPicked] = useState({});
+  const fileInputRef = useRef(null);
+
+  // The key arrives as a DOWNLOADED .json file — read it directly instead of
+  // making the admin open it and copy-paste (Shawn, 2026-08-11).
+  const onKeyFile = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setKeyJson(String(reader.result || ''));
+      setKeyFileName(file.name);
+    };
+    reader.onerror = () => toast.error('Could not read the file — paste the JSON instead');
+    reader.readAsText(file);
+    e.target.value = ''; // same file can be re-picked after a failed attempt
+  };
 
   const accountQuery = useQuery({ queryKey: ACCOUNT_KEY, queryFn: () => redeemOpsApi.getOutreachAccount() });
   const personasQuery = useQuery({ queryKey: PERSONAS_KEY, queryFn: () => redeemOpsApi.listOutreachPersonas() });
@@ -240,12 +257,30 @@ export default function OutreachPersonasCard() {
             placeholder="business@mktr.sg"
             aria-label="Account email"
           />
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              className="hidden"
+              aria-label="Service account key file"
+              onChange={onKeyFile}
+            />
+            <Button type="button" variant="outline" size="sm" onClick={() => fileInputRef.current?.click()}>
+              Upload key file (.json)
+            </Button>
+            {keyFileName && (
+              <span className="text-xs font-medium truncate" style={{ color: 'var(--ro-text-2)' }}>
+                ✓ {keyFileName} loaded
+              </span>
+            )}
+          </div>
           <textarea
             value={keyJson}
-            onChange={(e) => setKeyJson(e.target.value)}
-            placeholder='{"type": "service_account", "client_email": …}'
+            onChange={(e) => { setKeyJson(e.target.value); setKeyFileName(''); }}
+            placeholder='…or paste the JSON here: {"type": "service_account", …}'
             aria-label="Service account key JSON"
-            rows={6}
+            rows={keyFileName ? 3 : 6}
             className="w-full rounded-md border border-border bg-white p-2 font-mono text-xs"
           />
           <DialogFooter>

--- a/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
+++ b/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
@@ -82,6 +82,26 @@ describe('OutreachPersonasCard', () => {
     }));
   });
 
+  it('uploading the downloaded .json key file fills the form without any copy-paste', async () => {
+    api.getOutreachAccount.mockResolvedValue({ configured: false });
+    api.setupOutreachAccount.mockResolvedValue({ health: { aliasCount: 4 } });
+    const user = userEvent.setup();
+    wrap(<OutreachPersonasCard />);
+
+    await user.click(await screen.findByRole('button', { name: /connect account/i }));
+    const keyContents = '{"type":"service_account","client_email":"sa@x.iam.gserviceaccount.com"}';
+    await user.upload(
+      screen.getByLabelText(/service account key file/i),
+      new File([keyContents], 'mktr-platform-abc123.json', { type: 'application/json' })
+    );
+    await screen.findByText(/mktr-platform-abc123\.json loaded/);
+    await user.click(screen.getByRole('button', { name: /connect & check/i }));
+    await waitFor(() => expect(api.setupOutreachAccount).toHaveBeenCalledWith({
+      accountEmail: 'business@mktr.sg',
+      serviceAccountJson: keyContents,
+    }));
+  });
+
   it('renders persona rows with status and reassigns via the rep select (server enforces 1:1)', async () => {
     api.getOutreachAccount.mockResolvedValue(configuredAccount);
     api.listOutreachPersonas.mockResolvedValue([


### PR DESCRIPTION
Shawn's ask during activation: the key is a downloaded .json — the Connect dialog now has an Upload button (FileReader → same field; paste stays as fallback, filename confirmed inline). +1 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S