### PR TITLE
fix(redeem-ops): domain-alias twins are the account's aliases (redeem.sg import)

### DIFF
--- a/backend/src/services/google/workspaceService.js
+++ b/backend/src/services/google/workspaceService.js
@@ -119,10 +119,16 @@ export function makeWorkspaceClient({ credentials, subject, scopes, fetchImpl = 
       } while (pageToken);
       return users;
     },
-    /** The aliases OF ONE user — the plan-F2 parentage source of truth. */
+    /**
+     * The aliases OF ONE user — the plan-F2 parentage source of truth.
+     * Reads the USER resource, not the aliases collection: domain-alias
+     * twins (redeem.sg as a user-alias domain of mktr.sg) live only in
+     * `nonEditableAliases[]` and never appear in aliases.list — they are
+     * real, deliver to this user, and must count as the user's own.
+     */
     async listUserAliases(email) {
-      const body = await api(`https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(email)}/aliases`);
-      return (body.aliases || []).map((a) => a.alias);
+      const user = await api(`https://admin.googleapis.com/admin/directory/v1/users/${encodeURIComponent(email)}?projection=full`);
+      return [...new Set([...(user.aliases || []), ...(user.nonEditableAliases || [])])];
     },
 
     // ── Gmail (impersonated subject's mailbox) ───────────────────────────

--- a/backend/src/services/redeemOps/outreachPersonaService.js
+++ b/backend/src/services/redeemOps/outreachPersonaService.js
@@ -50,6 +50,16 @@ export function makeOutreachPersonaService(overrides = {}) {
     return d.makeClient({ credentials, subject: account.accountEmail, scopes: ACCOUNT_SCOPES });
   }
 
+  /**
+   * The account's sendable alias set: editable alternates + domain-alias
+   * twins, minus Google's `*.test-google-a.com` noise (every tenant carries
+   * those; nobody sends as them).
+   */
+  async function usableAliases(client, accountEmail) {
+    const all = await client.listUserAliases(accountEmail);
+    return all.filter((a) => !a.toLowerCase().endsWith('.test-google-a.com'));
+  }
+
   async function decryptedClient(account) {
     if (!account?.encryptedCredentials) {
       throw new AppError('Connect the Workspace account first — paste the service-account key in Settings.', 409);
@@ -120,7 +130,7 @@ export function makeOutreachPersonaService(overrides = {}) {
     try {
       profile = await client.getProfile();
       sendAs = await client.listSendAs();
-      aliases = await client.listUserAliases(account.accountEmail);
+      aliases = await usableAliases(client, account.accountEmail);
       await account.update({ lastHealthCheckAt: d.now(), lastError: null });
     } catch (err) {
       await account.update({ lastHealthCheckAt: d.now(), lastError: String(err.message).slice(0, 500) });
@@ -178,7 +188,7 @@ export function makeOutreachPersonaService(overrides = {}) {
 
     const [users, accountAliases] = await Promise.all([
       client.listUsers(),
-      client.listUserAliases(account.accountEmail),
+      usableAliases(client, account.accountEmail),
     ]);
     const aliasSet = new Set(accountAliases.map((a) => a.toLowerCase()));
     const existing = await d.OutreachPersona.findAll({ attributes: ['address'] });
@@ -216,7 +226,7 @@ export function makeOutreachPersonaService(overrides = {}) {
     const account = await d.OutreachAccount.scope('withCredentials').findOne({ order: [['createdAt', 'ASC']] });
     if (!account) throw new AppError('No Workspace account configured yet', 404);
     const client = await decryptedClient(account);
-    const aliasSet = new Set((await client.listUserAliases(account.accountEmail)).map((a) => a.toLowerCase()));
+    const aliasSet = new Set((await usableAliases(client, account.accountEmail)).map((a) => a.toLowerCase()));
 
     const wanted = [...new Set((addresses || []).map((a) => String(a).trim().toLowerCase()).filter(Boolean))];
     if (wanted.length === 0) throw new AppError('Pick at least one address to import', 400);

--- a/backend/test/redeemOpsOutreachPersonas.test.js
+++ b/backend/test/redeemOpsOutreachPersonas.test.js
@@ -28,7 +28,8 @@ const KEY_JSON = JSON.stringify({
 
 /** Mutable Google fixture each test can shape. */
 const google = {
-  aliases: ['emily@redeem.sg', 'jeremy@redeem.sg'],
+  // Includes a Google test-domain twin — the picker must never offer it.
+  aliases: ['emily@redeem.sg', 'jeremy@redeem.sg', 'emily@mktr.sg.test-google-a.com'],
   sendAs: [
     { sendAsEmail: 'business@mktr.sg', isPrimary: true, verificationStatus: 'accepted' },
     { sendAsEmail: 'emily@redeem.sg', verificationStatus: 'accepted' },


### PR DESCRIPTION
Found live during activation: redeem.sg is a **user alias domain** of mktr.sg, so the redeem.sg addresses are automatic twins of the @mktr.sg alternates — delivered to business@, but reported only in nonEditableAliases[], which the picker/parentage/health never read. Now merged from the User resource (with *.test-google-a.com filtered). Re-running Import after deploy lists the full redeem.sg set. 38 outreach tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S