### PR TITLE
fix(redeem-ops): send-as entries without verificationStatus are verified

### DIFF
--- a/backend/src/services/redeemOps/outreachPersonaService.js
+++ b/backend/src/services/redeemOps/outreachPersonaService.js
@@ -147,7 +147,11 @@ export function makeOutreachPersonaService(overrides = {}) {
       await p.update({
         isAccountAlias: aliasSet.has(addr),
         sendAsRegistered: Boolean(s),
-        sendAsVerified: Boolean(s && (s.verificationStatus === 'accepted' || s.isPrimary)),
+        // Same-account aliases never REQUIRED verification, so Gmail returns
+        // their sendAs entries with NO verificationStatus at all — absence
+        // means "none needed", not "pending". Only an explicit 'pending'
+        // (a genuine external verification in flight) blocks sending.
+        sendAsVerified: Boolean(s && (s.isPrimary || s.verificationStatus !== 'pending')),
       });
     }
 

--- a/backend/test/redeemOpsOutreachPersonas.test.js
+++ b/backend/test/redeemOpsOutreachPersonas.test.js
@@ -32,7 +32,10 @@ const google = {
   aliases: ['emily@redeem.sg', 'jeremy@redeem.sg', 'emily@mktr.sg.test-google-a.com'],
   sendAs: [
     { sendAsEmail: 'business@mktr.sg', isPrimary: true, verificationStatus: 'accepted' },
-    { sendAsEmail: 'emily@redeem.sg', verificationStatus: 'accepted' },
+    // Same-account aliases come back with NO verificationStatus — Gmail never
+    // required verification for them. Note the capitalized local part too:
+    // matching must be case-insensitive (real tenant data does this).
+    { sendAsEmail: 'Emily@redeem.sg' },
     { sendAsEmail: 'jeremy@redeem.sg', verificationStatus: 'pending' },
   ],
   users: [


### PR DESCRIPTION
Found live: Shawn's redeem.sg send-as identities already existed in Gmail, but same-account aliases carry NO verificationStatus (verification was never required) and the health check demanded an explicit 'accepted' — every persona read as pending. Absence now counts as verified; only an explicit 'pending' blocks. 38 outreach tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S