### PR TITLE
feat(redeem-ops): persona assignment reflects deactivated reps

### DIFF
--- a/backend/src/services/redeemOps/outreachPersonaService.js
+++ b/backend/src/services/redeemOps/outreachPersonaService.js
@@ -279,6 +279,9 @@ export function makeOutreachPersonaService(overrides = {}) {
         } else {
           const rep = await d.User.findByPk(body.assignedUserId, { transaction: t });
           if (!rep) throw new AppError('Rep not found', 404);
+          if (rep.isActive === false) {
+            throw new AppError(`${rep.fullName || 'That rep'} is deactivated — reactivate them first or pick someone else`, 409);
+          }
           const clash = await d.OutreachPersona.findOne({
             where: { assignedUserId: rep.id }, transaction: t,
           });

--- a/backend/test/redeemOpsOutreachPersonas.test.js
+++ b/backend/test/redeemOpsOutreachPersonas.test.js
@@ -176,6 +176,12 @@ describe('persona mapping (who-is-who)', () => {
     await expect(svc.updatePersona(jeremy.id, { assignedUserId: exec.user.id }, admin.user))
       .rejects.toMatchObject({ statusCode: 409 });
 
+    // a deactivated rep cannot receive a sending identity
+    const departed = await createTestUser({ role: 'redeem_ops', redeemOpsRole: 'outreach_exec' });
+    await departed.user.update({ isActive: false });
+    await expect(svc.updatePersona(jeremy.id, { assignedUserId: departed.user.id }, admin.user))
+      .rejects.toMatchObject({ statusCode: 409 });
+
     // cap bounds enforced
     await expect(svc.updatePersona(emily.id, { dailySendCap: 0 }, admin.user))
       .rejects.toMatchObject({ statusCode: 400 });

--- a/src/components/redeemops/OutreachPersonasCard.jsx
+++ b/src/components/redeemops/OutreachPersonasCard.jsx
@@ -123,7 +123,11 @@ export default function OutreachPersonasCard() {
 
   const account = accountQuery.data;
   const personas = personasQuery.data || [];
-  const team = teamQuery.data || [];
+  // Actives first; deactivated staff stay visible (an existing assignment
+  // must render honestly) but can't receive a NEW sending identity.
+  const team = [...(teamQuery.data || [])].sort(
+    (a, b) => (a.isActive === false ? 1 : 0) - (b.isActive === false ? 1 : 0)
+  );
   const takenUserIds = new Set(personas.map((p) => p.assignedUserId).filter(Boolean));
 
   const personaStatus = (p) => {
@@ -218,8 +222,13 @@ export default function OutreachPersonasCard() {
                       >
                         <option value="">Unassigned</option>
                         {team.map((u) => (
-                          <option key={u.id} value={u.id} disabled={takenUserIds.has(u.id) && p.assignedUserId !== u.id}>
-                            {u.fullName || u.email}
+                          <option
+                            key={u.id}
+                            value={u.id}
+                            disabled={p.assignedUserId !== u.id
+                              && (takenUserIds.has(u.id) || u.isActive === false)}
+                          >
+                            {u.isActive === false ? 'DEACTIVATED — ' : ''}{u.fullName || u.email}
                           </option>
                         ))}
                       </select>

--- a/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
+++ b/src/components/redeemops/__tests__/OutreachPersonasCard.test.jsx
@@ -60,8 +60,9 @@ const emily = {
 beforeEach(() => {
   vi.clearAllMocks();
   api.getTeam.mockResolvedValue([
-    { id: 'u-emily', fullName: 'Emily Wong' },
-    { id: 'u-jeremy', fullName: 'Jeremy Ho Wei Kang' },
+    { id: 'u-emily', fullName: 'Emily Wong', isActive: true },
+    { id: 'u-jeremy', fullName: 'Jeremy Ho Wei Kang', isActive: true },
+    { id: 'u-gone', fullName: 'Departed Rep', isActive: false },
   ]);
   api.listOutreachPersonas.mockResolvedValue([]);
 });
@@ -119,7 +120,12 @@ describe('OutreachPersonasCard', () => {
     await user.selectOptions(screen.getByLabelText('Rep for jeremy@redeem.sg'), 'u-jeremy');
     await waitFor(() => expect(api.updateOutreachPersona).toHaveBeenCalledWith('op-2', { assignedUserId: 'u-jeremy' }));
     // Emily already holds u-emily — that option is disabled for Jeremy's row.
-    expect(screen.getByLabelText('Rep for jeremy@redeem.sg').querySelector('option[value="u-emily"]').disabled).toBe(true);
+    const jeremySelect = screen.getByLabelText('Rep for jeremy@redeem.sg');
+    expect(jeremySelect.querySelector('option[value="u-emily"]').disabled).toBe(true);
+    // Deactivated staff are labelled and can't receive a NEW identity.
+    const gone = jeremySelect.querySelector('option[value="u-gone"]');
+    expect(gone.textContent).toBe('DEACTIVATED — Departed Rep');
+    expect(gone.disabled).toBe(true);
   });
 
   it('import dialog lists ONLY the account aliases, disables taken ones, and imports the picked set', async () => {


### PR DESCRIPTION
Shawn's ask: the assign dropdown now shows 'DEACTIVATED — name' (sorted last, unselectable for new assignments; existing ones stay visible), and the service 409s a deactivated assignee. 9 backend + 6 vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S