### PR TITLE
fix(outreach): clean MIME headers + one-click Send email on manual email steps

### DIFF
--- a/backend/src/controllers/redeemOps/outreachController.js
+++ b/backend/src/controllers/redeemOps/outreachController.js
@@ -91,6 +91,13 @@ export const convertEmailToManual = asyncHandler(async (req, res) => {
   res.json({ success: true, data: { email } });
 });
 
+// One-click send for a manual email cadence step — creates the outbox row
+// (queued, no ramp hold) and lets the worker's guards take it from there.
+export const sendTaskEmail = asyncHandler(async (req, res) => {
+  const email = await outreachSenderService.sendTaskEmail(req.params.taskId, req.user, req.id);
+  res.status(201).json({ success: true, data: { email } });
+});
+
 const optOutSchema = Joi.object({ email: Joi.string().email().required() });
 
 // The Replied-card classification (plan P18): a "please stop" phrased outside

--- a/backend/src/routes/redeemOpsOutreach.js
+++ b/backend/src/routes/redeemOpsOutreach.js
@@ -41,6 +41,8 @@ router.post('/outreach/personas/:personaId/test-send', requireRedeemOps('setting
 router.post('/outreach/emails/:emailId/approve', requireRedeemOps('tasks.manage'), ctrl.approveEmail);
 router.post('/outreach/emails/:emailId/send-now', requireRedeemOps('tasks.manage'), ctrl.sendNowEmail);
 router.post('/outreach/emails/:emailId/convert-manual', requireRedeemOps('tasks.manage'), ctrl.convertEmailToManual);
+// Manual email steps get a one-click CRM send too — same worker, same guards.
+router.post('/outreach/tasks/:taskId/send-email', requireRedeemOps('tasks.manage'), ctrl.sendTaskEmail);
 // Manual opt-out (Phase C) — any rep who works tasks may record a "stop
 // emailing us" the keyword matcher missed. Audited.
 router.post('/outreach/opt-out', requireRedeemOps('tasks.manage'), ctrl.recordOptOut);

--- a/backend/src/services/google/workspaceService.js
+++ b/backend/src/services/google/workspaceService.js
@@ -24,6 +24,25 @@ export const WORKSPACE_SCOPES = {
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const TOKEN_TTL_SLACK_MS = 60_000;
 
+/**
+ * RFC 2047 encoded-word for header values: ASCII passes through untouched;
+ * anything else (em-dashes, accented or CJK business names) becomes
+ * =?UTF-8?B?…?= words — raw UTF-8 bytes in a header render as mojibake
+ * ("Ã¢Â€Â"") in every client. Chunked at codepoint boundaries so each word
+ * decodes independently and emoji never split.
+ */
+export function encodeMimeHeader(value) {
+  const v = String(value ?? '');
+  if (/^[\x20-\x7E]*$/.test(v)) return v;
+  const codepoints = Array.from(v);
+  const words = [];
+  for (let i = 0; i < codepoints.length; i += 16) {
+    const chunk = codepoints.slice(i, i + 16).join('');
+    words.push(`=?UTF-8?B?${Buffer.from(chunk, 'utf8').toString('base64')}?=`);
+  }
+  return words.join(' ');
+}
+
 /** Parse + sanity-check a pasted service-account JSON key. Throws plain Error. */
 export function parseServiceAccountKey(raw) {
   let parsed;

--- a/backend/src/services/redeemOps/outreachInboxService.js
+++ b/backend/src/services/redeemOps/outreachInboxService.js
@@ -8,7 +8,7 @@ import { logger } from '../../utils/logger.js';
 import { makeSecretBox } from '../../utils/secretBox.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import { makePartnerService } from './partnerService.js';
-import { makeWorkspaceClient, parseServiceAccountKey, WORKSPACE_SCOPES } from '../google/workspaceService.js';
+import { makeWorkspaceClient, parseServiceAccountKey, encodeMimeHeader, WORKSPACE_SCOPES } from '../google/workspaceService.js';
 
 /**
  * The inbox loop — Phase C (docs/plans/redeem-ops-cadence-email-autosend.md §5).
@@ -123,7 +123,7 @@ export function makeOutreachInboxService(overrides = {}) {
     const rfc822 = [
       `From: "Redeem outreach" <${headerSafe(account.accountEmail)}>`,
       `To: <${headerSafe(rep.email)}>`,
-      `Subject: Reply from ${headerSafe(partner.tradingName || partner.legalName || 'a prospect')} — answer them soon`,
+      `Subject: ${encodeMimeHeader(`Reply from ${headerSafe(partner.tradingName || partner.legalName || 'a prospect')} — answer them soon`)}`,
       'Content-Type: text/plain; charset=utf-8',
       '',
       `They replied on the ${persona?.address || 'outreach'} thread (${headerSafe(subject)}):`,

--- a/backend/src/services/redeemOps/outreachPersonaService.js
+++ b/backend/src/services/redeemOps/outreachPersonaService.js
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { makeSecretBox } from '../../utils/secretBox.js';
 import { makeRedeemOpsAuditService } from './auditService.js';
 import {
-  makeWorkspaceClient, parseServiceAccountKey, WORKSPACE_SCOPES,
+  makeWorkspaceClient, parseServiceAccountKey, encodeMimeHeader, WORKSPACE_SCOPES,
 } from '../google/workspaceService.js';
 
 /**
@@ -339,9 +339,9 @@ export function makeOutreachPersonaService(overrides = {}) {
 
     const minted = `<outreach-test-${persona.id}-${Date.now()}@mktr.sg>`;
     const rfc822 = [
-      `From: "${persona.displayName.replace(/"/g, '')}" <${persona.address}>`,
+      `From: "${encodeMimeHeader(persona.displayName.replace(/"/g, ''))}" <${persona.address}>`,
       `To: <${account.accountEmail}>`,
-      `Subject: Redeem Ops test send — ${persona.address}`,
+      `Subject: ${encodeMimeHeader(`Redeem Ops test send — ${persona.address}`)}`,
       `Message-ID: ${minted}`,
       'Content-Type: text/plain; charset=utf-8',
       '',

--- a/backend/src/services/redeemOps/outreachSenderService.js
+++ b/backend/src/services/redeemOps/outreachSenderService.js
@@ -1,7 +1,8 @@
 import { Op } from 'sequelize';
 import {
   OutreachEmail, OutreachAccount, OutreachPersona, OutreachTask,
-  OutreachCadence, OutreachCadenceEnrollment, PartnerOrganisation, sequelize,
+  OutreachCadence, OutreachCadenceEnrollment, OutreachCadenceStep,
+  PartnerOrganisation, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/appError.js';
 import { logger } from '../../utils/logger.js';
@@ -10,7 +11,7 @@ import { makeRedeemOpsAuditService } from './auditService.js';
 import { makeCadenceService } from './cadenceService.js';
 import { makePartnerService } from './partnerService.js';
 import { canActOnPartnerRow } from './permissions.js';
-import { makeWorkspaceClient, parseServiceAccountKey, WORKSPACE_SCOPES } from '../google/workspaceService.js';
+import { makeWorkspaceClient, parseServiceAccountKey, encodeMimeHeader, WORKSPACE_SCOPES } from '../google/workspaceService.js';
 
 /**
  * The auto-send worker — Phase B (docs/plans/redeem-ops-cadence-email-autosend.md §4).
@@ -58,7 +59,8 @@ function nextSgtMorning(at) {
 export function makeOutreachSenderService(overrides = {}) {
   const d = {
     OutreachEmail, OutreachAccount, OutreachPersona, OutreachTask,
-    OutreachCadence, OutreachCadenceEnrollment, PartnerOrganisation, sequelize, logger,
+    OutreachCadence, OutreachCadenceEnrollment, OutreachCadenceStep,
+    PartnerOrganisation, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     cadences: makeCadenceService(),
     partners: makePartnerService(),
@@ -178,10 +180,12 @@ export function makeOutreachSenderService(overrides = {}) {
     const subject = headerSafe(threaded && !/^re:/i.test(baseSubject) ? `Re: ${baseSubject}` : baseSubject)
       .slice(0, 220);
     const body = `${task.description || ''}\n\n--\n${FOOTER}\n`;
+    // Non-ASCII header values (em-dashes, accented/CJK business names) MUST
+    // be RFC-2047 encoded — raw UTF-8 in a header renders as mojibake.
     const headers = [
-      `From: "${headerSafe(persona.displayName).replace(/"/g, '')}" <${headerSafe(persona.address)}>`,
+      `From: "${encodeMimeHeader(headerSafe(persona.displayName).replace(/"/g, ''))}" <${headerSafe(persona.address)}>`,
       `To: <${headerSafe(row.toAddress)}>`,
-      `Subject: ${subject}`,
+      `Subject: ${encodeMimeHeader(subject)}`,
       'Content-Type: text/plain; charset=utf-8',
     ];
     if (threaded && references) {
@@ -537,9 +541,86 @@ export function makeOutreachSenderService(overrides = {}) {
     return d.OutreachEmail.findByPk(row.id);
   }
 
+  /**
+   * One-click CRM send for a MANUAL email cadence step (a task with no outbox
+   * row — cadences authored before auto-send, or steps left on Manual). The
+   * rep is looking at the exact rendered message, so it queues directly with
+   * no ramp/lint hold — the enqueue twin of Send now. Every send-time guard
+   * (revalidation, caps, suppression, reply-loop freshness) still runs in the
+   * worker; this only creates the row.
+   */
+  async function sendTaskEmail(taskId, user, requestId = null) {
+    const task = await d.OutreachTask.findByPk(taskId);
+    if (!task || !task.cadenceEnrollmentId) throw new AppError('Cadence task not found', 404);
+    if (!['open', 'in_progress'].includes(task.status)) throw new AppError('This task is already closed', 409);
+    const step = task.cadenceStepId ? await d.OutreachCadenceStep.findByPk(task.cadenceStepId) : null;
+    if (!step || step.channel !== 'email') throw new AppError('Only email steps can be sent by the CRM', 409);
+    const enrollment = await d.OutreachCadenceEnrollment.findByPk(task.cadenceEnrollmentId);
+    if (!enrollment || enrollment.state !== 'active' || enrollment.currentStepId !== task.cadenceStepId) {
+      throw new AppError('This step is no longer the active cadence step', 409);
+    }
+    const partner = await d.PartnerOrganisation.findByPk(task.partnerOrganisationId);
+    if (!partner || partner.mergedIntoId || partner.archivedAt) throw new AppError('Business not found', 404);
+    if (!canActOnPartnerRow(user, partner)) {
+      throw new AppError('You can only send on businesses you own', 403);
+    }
+    if (partner.autoEmailOptOut) {
+      throw new AppError('This business is set to manual sending only — copy the message and send it yourself', 409);
+    }
+    const live = await d.OutreachEmail.findOne({
+      where: { taskId: task.id, status: { [Op.in]: ['queued', 'needs_approval', 'sending'] } },
+    });
+    if (live) throw new AppError('A send is already scheduled for this task — use its buttons', 409);
+
+    // The send goes out as the TASK ASSIGNEE's persona (the conversation
+    // owner), matching what send-time revalidation enforces — not as whoever
+    // clicked (an admin can trigger it, the identity stays the rep's).
+    if (!task.assigneeUserId) throw new AppError('This task has no assignee to send as', 409);
+    const persona = await d.OutreachPersona.findOne({
+      where: { assignedUserId: task.assigneeUserId, isActive: true },
+    });
+    if (!persona) {
+      throw new AppError('No sending identity is mapped to the task owner yet — assign one in Settings → Email outreach', 409);
+    }
+    if (!persona.sendAsVerified) {
+      throw new AppError(`${persona.address} is not verified to send yet — run the health check in Settings`, 409);
+    }
+    const account = await d.OutreachAccount.findByPk(persona.accountId);
+    if (!account?.isActive) throw new AppError('The outreach mailbox is not connected', 409);
+
+    const resolved = await d.sequelize.transaction((t) => d.cadences.resolveRecipientTx(partner, 'email', t));
+    if (!resolved.ok) throw new AppError('This business has no email address on file — add one first', 409);
+    const suppressed = await d.sequelize.transaction((t) => d.cadences.isSuppressedTx('email', resolved.recipient, t));
+    if (suppressed) throw new AppError('This address unsubscribed or bounced — sending is blocked', 409);
+
+    let row;
+    try {
+      row = await d.OutreachEmail.create({
+        taskId: task.id, cadenceEnrollmentId: enrollment.id, partnerOrganisationId: partner.id,
+        contactId: resolved.contactId || null, personaId: persona.id, accountId: persona.accountId,
+        toAddress: resolved.recipient,
+        // Deliberate human click: sends immediately, may cross the SGT window.
+        status: 'queued', windowOverride: true, nextAttemptAt: d.now(),
+      });
+    } catch (err) {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
+        throw new AppError('A send is already scheduled for this task — use its buttons', 409);
+      }
+      throw err;
+    }
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'outreach.email_manual_send_queued', entityType: 'outreach_email',
+      entityId: row.id,
+      after: { taskId: task.id, toAddress: resolved.recipient, personaAddress: persona.address },
+      requestId,
+    });
+    tick().catch(() => {});
+    return row;
+  }
+
   return {
     tick, reclaimStranded, reapDisabled,
-    approve, sendNow, convertToManual,
+    approve, sendNow, convertToManual, sendTaskEmail,
     // exported for tests
     replyLoopHealthy, buildRfc822, nextSgtMorning,
   };

--- a/backend/test/redeemOpsAutosend.test.js
+++ b/backend/test/redeemOpsAutosend.test.js
@@ -382,3 +382,95 @@ describe('the sender', () => {
     expect((await OutreachTask.findByPk(firstTask.id)).status).toBe('open');
   });
 });
+
+describe('one-click send on MANUAL email steps', () => {
+  async function manualCadence(steps) {
+    cadenceSeq += 1;
+    return svc.createCadence({
+      name: `Manual Mail ${cadenceSeq}`,
+      steps: steps || [{
+        channel: 'email', title: `Manual intro ${cadenceSeq}`,
+        script: 'Hi {{contact_name}}, note for {{partner_name}}.', delayDays: 0, timeWindow: 'any',
+      }],
+    }, admin.user);
+  }
+
+  test('queues a window-override row with no ramp hold; the worker sends and completes it', async () => {
+    const cadence = await manualCadence();
+    const p = await ownedPartner('ManualSendCafe');
+    await partnerSvc.addContact(p.id, { name: 'Nora', email: 'nora@manualsend.sg' }, exec.user);
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+    expect(await liveRow(firstTask.id)).toBeNull(); // manual step — nothing enqueued
+
+    let row = await sender.sendTaskEmail(firstTask.id, exec.user);
+    expect(row.status).toBe('queued');
+    expect(row.holdReason).toBeNull(); // human reviewed it — no ramp
+    expect(row.windowOverride).toBe(true);
+    expect(row.toAddress).toBe('nora@manualsend.sg');
+
+    // The service fires a best-effort tick itself; settle to a terminal state
+    // regardless of which pass wins the claim.
+    const until = Date.now() + 4000;
+    row = await OutreachEmail.findByPk(row.id);
+    while (row.status !== 'sent' && Date.now() < until) {
+      await sender.tick();
+      row = await OutreachEmail.findByPk(row.id);
+      if (row.status !== 'sent') await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(row.status).toBe('sent');
+    // Ticks may also flush stale queued rows from earlier tests — find OUR wire message.
+    const rfc = google.sendRaw.mock.calls.map((c) => c[0]).find((r) => r.includes('To: <nora@manualsend.sg>'));
+    expect(rfc).toBeTruthy();
+    expect(rfc).toContain('From: "Emily Wong" <emily@redeem.sg>');
+    expect(rfc).toContain('Subject: Manual intro'); // title fallback — no authored subject
+    expect((await OutreachTask.findByPk(firstTask.id)).status).toBe('completed');
+    const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
+    expect(acts.some((a) => a.type === 'email_sent' && /auto-sent as emily@redeem\.sg/.test(a.summary))).toBe(true);
+  });
+
+  test('route: creating the row does not need reply-loop health (sending does); a second click 409s', async () => {
+    // Loop dark → the inline tick refuses to SEND, so the row deterministically
+    // stays queued — proving creation and dispatch are separate gates.
+    await OutreachAccount.update({ lastSuccessfulPollAt: null }, { where: { id: account.id } });
+    const cadence = await manualCadence();
+    const p = await ownedPartner('ManualDupCafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+
+    const res = await request(app)
+      .post(`/api/redeem-ops/outreach/tasks/${firstTask.id}/send-email`)
+      .set(auth(exec.token));
+    expect(res.status).toBe(201);
+    expect(res.body.data.email.status).toBe('queued');
+
+    const dup = await request(app)
+      .post(`/api/redeem-ops/outreach/tasks/${firstTask.id}/send-email`)
+      .set(auth(exec.token));
+    expect(dup.status).toBe(409);
+    expect(await OutreachEmail.count({ where: { taskId: firstTask.id } })).toBe(1);
+  });
+
+  test('refuses non-email steps, opted-out partners, and assignees with no persona — creating nothing', async () => {
+    const callCadence = await manualCadence([{ channel: 'call', title: 'Call them', delayDays: 0, timeWindow: 'any' }]);
+    const p1 = await ownedPartner('ManualCallCafe');
+    const r1 = await svc.enrollPartner(p1.id, { cadenceId: callCadence.id }, exec.user);
+    await expect(sender.sendTaskEmail(r1.firstTask.id, exec.user))
+      .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/email steps/i) });
+
+    const emailCadence = await manualCadence();
+    const p2 = await ownedPartner('ManualOptOutCafe', { autoEmailOptOut: true });
+    const r2 = await svc.enrollPartner(p2.id, { cadenceId: emailCadence.id }, exec.user);
+    await expect(sender.sendTaskEmail(r2.firstTask.id, exec.user))
+      .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/manual sending only/i) });
+
+    await OutreachPersona.update({ isActive: false }, { where: { id: persona.id } });
+    try {
+      const p3 = await ownedPartner('ManualNoPersonaCafe');
+      const r3 = await svc.enrollPartner(p3.id, { cadenceId: emailCadence.id }, exec.user);
+      await expect(sender.sendTaskEmail(r3.firstTask.id, exec.user))
+        .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/sending identity/i) });
+      expect(await liveRow(r3.firstTask.id)).toBeNull();
+    } finally {
+      await OutreachPersona.update({ isActive: true }, { where: { id: persona.id } });
+    }
+  });
+});

--- a/backend/test/redeemOpsInboxLoop.test.js
+++ b/backend/test/redeemOpsInboxLoop.test.js
@@ -207,10 +207,17 @@ describe('replies on tracked threads', () => {
     expect(e.exitReason).toBe('replied');
     const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
     expect(acts.some((a) => a.type === 'email_reply' && a.direction === 'inbound')).toBe(true);
-    // forward to the rep's real login mailbox
+    // forward to the rep's real login mailbox — subject rides RFC-2047
+    // encoded (it carries an em-dash); decode before asserting.
     const fwd = google.sendRaw.mock.calls.at(-1)[0];
     expect(fwd).toContain(`To: <${exec.user.email}>`);
-    expect(fwd).toContain('Reply from ReplyCafe');
+    const subjectLine = fwd.split('\r\n').find((l) => l.startsWith('Subject: '));
+    const decodedSubject = subjectLine.replace('Subject: ', '').split(' ')
+      .map((w) => (w.startsWith('=?UTF-8?B?')
+        ? Buffer.from(w.replace(/^=\?UTF-8\?B\?/, '').replace(/\?=$/, ''), 'base64').toString('utf8')
+        : w))
+      .join('');
+    expect(decodedSubject).toContain('Reply from ReplyCafe');
     expect(fwd).toContain('Sounds interesting');
   });
 

--- a/backend/test/redeemOpsOutreachPersonas.test.js
+++ b/backend/test/redeemOpsOutreachPersonas.test.js
@@ -15,6 +15,7 @@ import { jest } from '@jest/globals';
 import { getApp, closeDb, createTestUser } from './helpers.js';
 import { OutreachAccount, OutreachPersona, RedeemOpsAuditEvent } from '../src/models/index.js';
 import { makeOutreachPersonaService } from '../src/services/redeemOps/outreachPersonaService.js';
+import { encodeMimeHeader } from '../src/services/google/workspaceService.js';
 import { makeSecretBox } from '../src/utils/secretBox.js';
 
 let app;
@@ -219,7 +220,19 @@ describe('test send (and the plan-F4 Message-ID probe)', () => {
     const rfc = google.sendRaw.mock.calls[0][0];
     expect(rfc).toContain('From: "Emily" <emily@redeem.sg>');
     expect(rfc).toContain('To: <business@mktr.sg>'); // never a prospect
+    // The em-dash subject must ride as an RFC-2047 encoded word — raw UTF-8
+    // in a header renders as mojibake (seen live: "Ã¢Â€Â"").
+    expect(rfc).toMatch(/Subject: =\?UTF-8\?B\?/);
+    expect(rfc).not.toMatch(/Subject: [^\r\n]*—/);
     expect(result.mintedPreserved).toBe(true); // fixture echoes the minted id
+
+    // The encoder itself: ASCII untouched; non-ASCII decodes back losslessly.
+    expect(encodeMimeHeader('Plain subject')).toBe('Plain subject');
+    const fancy = 'Idea for Café 北京 — trial 😀';
+    const decoded = encodeMimeHeader(fancy).split(' ')
+      .map((w) => Buffer.from(w.replace(/^=\?UTF-8\?B\?/, '').replace(/\?=$/, ''), 'base64').toString('utf8'))
+      .join('');
+    expect(decoded).toBe(fancy);
 
     const audit = await RedeemOpsAuditEvent.findOne({
       where: { action: 'outreach.test_send', entityId: emily.id },

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -500,6 +500,10 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/outreach/emails/${emailId}/convert-manual`);
     return res.data?.email;
   },
+  async sendTaskOutreachEmail(taskId) {
+    const res = await apiClient.post(`/redeem-ops/outreach/tasks/${taskId}/send-email`);
+    return res.data?.email;
+  },
   async recordOutreachOptOut(email) {
     const res = await apiClient.post('/redeem-ops/outreach/opt-out', { email });
     return res.data?.suppression;

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -5,7 +5,7 @@
  * 3. not_interested confirms first and can mark the business Lost in the same call.
  * redeemOpsApi is fully mocked — no network.
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -13,6 +13,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 vi.hoisted(() => {
   vi.stubEnv('VITE_REDEEM_OPS_CADENCES_ENABLED', 'true');
+  vi.stubEnv('VITE_REDEEM_OPS_EMAIL_AUTOSEND_ENABLED', 'true');
 });
 
 const api = vi.hoisted(() => ({
@@ -30,6 +31,7 @@ const api = vi.hoisted(() => ({
   suggestCadence: vi.fn(),
   listTasks: vi.fn(),
   updateTask: vi.fn(),
+  sendTaskOutreachEmail: vi.fn(),
 }));
 vi.mock('@/api/redeemOps', () => ({ redeemOpsApi: api }));
 
@@ -43,7 +45,7 @@ const toastMock = vi.hoisted(() => {
 vi.mock('sonner', () => ({ toast: toastMock }));
 
 import {
-  CadenceOutcomeButton, CadenceChip, CadencePanel,
+  CadenceOutcomeButton, CadenceChip, CadencePanel, ScheduledSendStrip,
   unreachableChannels, needsSentence, blockedStepToast, blockedReasonLabel,
 } from '../cadence';
 import { toBuilderSteps } from '../cadenceBuilder';
@@ -873,5 +875,44 @@ describe('blocked-reason copy helpers', () => {
     expect(blockedReasonLabel('no_active_location')).toBe('no outlet address on record');
     expect(blockedReasonLabel('suppressed')).toMatch(/do-not-contact/);
     expect(blockedReasonLabel('unknown_thing')).toBe('needs attention');
+  });
+});
+
+describe('ScheduledSendStrip — one-click send on manual email steps', () => {
+  it('offers Send email on a rowless email cadence task, confirms, and hits the endpoint', async () => {
+    api.sendTaskOutreachEmail.mockResolvedValue({ id: 'e1', status: 'queued' });
+    const task = {
+      id: 't-manual-1', cadenceEnrollmentId: 'en1', partnerOrganisationId: 'p1',
+      cadenceStep: { channel: 'email' }, title: 'Email the offer', emailSubject: null,
+      snapshotRecipient: 'owner@biz.sg', outboxEmails: [],
+    };
+    wrap(<ScheduledSendStrip task={task} canManage />);
+    await userEvent.click(screen.getByRole('button', { name: /send email/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/send this email now\?/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/owner@biz\.sg/)).toBeInTheDocument();
+    // subject preview falls back to the task title when no subject was authored
+    expect(within(dialog).getByText('Email the offer')).toBeInTheDocument();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: /send email/i }));
+    await waitFor(() => expect(api.sendTaskOutreachEmail).toHaveBeenCalledWith('t-manual-1'));
+  });
+
+  it('renders nothing for non-email steps, non-cadence tasks, or viewers without manage rights', () => {
+    const emailTask = {
+      id: 't2', cadenceEnrollmentId: 'en1', partnerOrganisationId: 'p1',
+      cadenceStep: { channel: 'email' }, title: 'T', outboxEmails: [],
+    };
+    const { container: c1 } = wrap(
+      <ScheduledSendStrip task={{ ...emailTask, cadenceStep: { channel: 'call' } }} canManage />
+    );
+    expect(c1.querySelector('button')).toBeNull();
+    const { container: c2 } = wrap(
+      <ScheduledSendStrip task={{ ...emailTask, cadenceEnrollmentId: null }} canManage />
+    );
+    expect(c2.querySelector('button')).toBeNull();
+    const { container: c3 } = wrap(<ScheduledSendStrip task={emailTask} canManage={false} />);
+    expect(c3.querySelector('button')).toBeNull();
   });
 });

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -25,6 +25,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { RoTag } from '@/components/redeemops/ui';
+import { EMAIL_AUTOSEND_ENABLED } from '@/components/redeemops/OutreachPersonasCard';
 
 export const CADENCES_ENABLED = import.meta.env.VITE_REDEEM_OPS_CADENCES_ENABLED === 'true';
 
@@ -489,7 +490,50 @@ export function ScheduledSendStrip({ task, canManage = true }) {
     onSuccess: () => { toast.success('Sending — it goes out within a minute'); done(); },
     onError: (err) => toast.error('Could not send now', { description: err.message }),
   });
-  if (!row) return null;
+  const [confirmSend, setConfirmSend] = useState(false);
+  const sendEmailMutation = useMutation({
+    mutationFn: () => redeemOpsApi.sendTaskOutreachEmail(task.id),
+    onSuccess: () => { setConfirmSend(false); toast.success('Sending — it goes out within a minute'); done(); },
+    onError: (err) => { setConfirmSend(false); toast.error('Could not send', { description: err.message }); },
+  });
+  if (!row) {
+    // Manual email steps still get a one-click CRM send: it queues directly
+    // (the rep reviewed this exact message — no ramp hold) and rides the same
+    // worker guards. Sends as the task owner's outreach persona.
+    if (!EMAIL_AUTOSEND_ENABLED || !canManage || !task.cadenceEnrollmentId || task.cadenceStep?.channel !== 'email') {
+      return null;
+    }
+    return (
+      <>
+        <div className="mt-1.5">
+          <Button size="sm" variant="outline" className="h-7 px-2.5 text-[11.5px]" onClick={() => setConfirmSend(true)}>
+            <SendHorizontal className="w-3.5 h-3.5 mr-1.5" aria-hidden="true" /> Send email
+          </Button>
+        </div>
+        <Dialog open={confirmSend} onOpenChange={setConfirmSend}>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>Send this email now?</DialogTitle>
+              <DialogDescription>
+                Sends the message on this task from the task owner’s outreach address to the
+                business email on file{task.snapshotRecipient ? ` (${task.snapshotRecipient})` : ''},
+                and completes the task once it’s out.
+              </DialogDescription>
+            </DialogHeader>
+            <p className="text-sm mb-0" style={{ color: 'var(--ro-text-2)' }}>
+              Subject: <span className="font-semibold">{task.emailSubject || task.title}</span>
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setConfirmSend(false)}>Back</Button>
+              <Button disabled={sendEmailMutation.isPending} onClick={() => sendEmailMutation.mutate()}>
+                {sendEmailMutation.isPending ? 'Sending…' : 'Send email'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  }
 
   const when = row.nextAttemptAt
     ? new Date(row.nextAttemptAt).toLocaleString(undefined, { weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })


### PR DESCRIPTION
Two Lock-1 activation follow-ups from live testing:

**1. Mojibake subjects (fix)** — the first real test send arrived with a garbled subject: a raw UTF-8 em-dash written directly into the MIME header. New `encodeMimeHeader()` (RFC 2047 encoded-words, ASCII passthrough, codepoint-safe chunking) applied at every header build site: test-send From/Subject, worker `buildRfc822` From/Subject, inbox reply-forward Subject. Tests assert the encoded wire form and a lossless decode of a CJK/emoji/dash subject.

**2. Send email on manual email steps (feat)** — cadences authored before auto-send (and every version-pinned existing enrollment) had rendered email messages with no way to send from the CRM. Rowless email cadence tasks now show a **Send email** button (confirm dialog with recipient + subject preview). It creates the outbox row directly as `queued` — the rep reviewed this exact message, so no ramp/lint hold — with `windowOverride`, sending as the **task assignee's** persona. All send-time guards (revalidation, caps, suppression, reply-loop freshness, threading) still run in the worker; a live-row check + the partial unique index kill double-clicks.

Tests: backend 41/41 (3 new: worker send+completion with auto-sent-as attribution, dark-loop row creation + duplicate 409, guard refusals), frontend 46/46 (2 new strip tests). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S
