### PR TITLE
fix(ui): clamp select popovers to the viewport

### DIFF
--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -58,7 +58,9 @@ const SelectContent = React.forwardRef(({ className, children, position = "poppe
  className={cn(
  "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
  position === "popper" &&
- "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+ // Never taller than the space to the screen edge — long lists (48 categories)
+ // must scroll inside the popover, not run off the bottom of the viewport.
+ "max-h-[min(24rem,var(--radix-select-content-available-height))] data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
  className
  )}
  position={position}


### PR DESCRIPTION
The category picker (now 48 entries after #449) rendered past the bottom of the screen — Radix popper mode doesn't shrink content when neither side fits. SelectContent now consumes `--radix-select-content-available-height`, so long lists scroll inside the popover instead of running off screen. Applies to every select app-wide; strictly shrink-only. Lint clean, 52 component tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S