### PR TITLE
fix(redeem-ops): email subjects are never task titles

### DIFF
--- a/backend/src/database/migrations/123-email-step-subject-backfill.js
+++ b/backend/src/database/migrations/123-email-step-subject-backfill.js
@@ -1,0 +1,44 @@
+/**
+ * 123 — every email step gets a real subject line.
+ *
+ * Before this, email steps authored without a subject stored NULL, and the
+ * sender fell back to the TASK TITLE — a rep instruction, not wire content
+ * ("Email the partnership idea" arrived as a live subject, 2026-08-11).
+ * Authoring now defaults blank email-step subjects to the house template
+ * (cadenceService.DEFAULT_EMAIL_SUBJECT); this backfills what already exists:
+ *
+ * 1. Cadence email steps (every version) with a NULL/blank subjectTemplate.
+ * 2. OPEN email cadence tasks, whose emailSubject snapshot was materialized
+ *    before the step had a subject — rendered here with the partner's name,
+ *    mirroring renderTemplate's {{partner_name}} merge.
+ *
+ * Down is a no-op: restoring NULL subjects would restore the bug.
+ */
+
+const DEFAULT_TEMPLATE = 'Bringing new customers to {{partner_name}}';
+
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(
+    `UPDATE outreach_cadence_steps
+        SET "subjectTemplate" = :template
+      WHERE channel = 'email'
+        AND ("subjectTemplate" IS NULL OR btrim("subjectTemplate") = '')`,
+    { replacements: { template: DEFAULT_TEMPLATE } }
+  );
+  await queryInterface.sequelize.query(
+    `UPDATE outreach_tasks t
+        SET "emailSubject" = left(
+              'Bringing new customers to '
+              || COALESCE(NULLIF(btrim(p."tradingName"), ''), 'your business'), 220)
+       FROM outreach_cadence_steps s, partner_organisations p
+      WHERE s.id = t."cadenceStepId"
+        AND p.id = t."partnerOrganisationId"
+        AND s.channel = 'email'
+        AND t.status IN ('open', 'in_progress')
+        AND (t."emailSubject" IS NULL OR btrim(t."emailSubject") = '')`
+  );
+}
+
+export async function down() {
+  // Deliberate no-op — see header.
+}

--- a/backend/src/services/redeemOps/cadenceService.js
+++ b/backend/src/services/redeemOps/cadenceService.js
@@ -103,6 +103,11 @@ function activityForDisposition(channel, disposition) {
  * Digits are suspicious in CONTACT names only — plenty of legit businesses
  * carry them ("7-Eleven").
  */
+
+/** What an email step's subject falls back to when the author leaves it blank
+ *  (and what migration 123 backfilled onto pre-existing steps/tasks). */
+export const DEFAULT_EMAIL_SUBJECT = 'Bringing new customers to {{partner_name}}';
+
 export function autoSendLint({ partnerName = '', contactName = '', recipient = '', subject = '', body = '' }) {
   const junkWords = ['test', 'asdf', 'qwerty', 'unknown', 'na', 'n/a', 'abc'];
   const junkName = (raw, { digitsAreBad }) => {
@@ -228,10 +233,11 @@ export function makeCadenceService(overrides = {}) {
       if (mode === 'auto' && channel !== 'email') {
         throw new AppError(`Step ${i + 1}: only email steps can auto-send`, 400);
       }
-      const subject = s.subject ? String(s.subject).trim().slice(0, 160) : null;
-      if (mode === 'auto' && !subject) {
-        throw new AppError(`Step ${i + 1}: auto-send needs a subject line`, 400);
-      }
+      // Every email step carries a REAL subject: a blank one falls back to
+      // the house default template. Task titles ("Email the partnership
+      // idea") must never become wire subjects — seen live 2026-08-11.
+      const subject = String(s.subject ?? '').trim().slice(0, 160)
+        || (channel === 'email' ? DEFAULT_EMAIL_SUBJECT : null);
       return {
         channel, title, continueOn, delayDays, timeWindow, priority, mode, subject,
         script: s.script ? String(s.script).slice(0, 5000) : null,

--- a/backend/src/services/redeemOps/outreachSenderService.js
+++ b/backend/src/services/redeemOps/outreachSenderService.js
@@ -134,6 +134,10 @@ export function makeOutreachSenderService(overrides = {}) {
     const enrollment = await d.OutreachCadenceEnrollment.findByPk(row.cadenceEnrollmentId);
     if (!enrollment || enrollment.state !== 'active') return { fail: 'enrollment_not_active' };
     if (enrollment.currentStepId !== task.cadenceStepId) return { fail: 'not_current_step' };
+    // A fresh (non-threaded) send needs a real subject — the task TITLE is a
+    // rep instruction, never wire content. Threaded follow-ups reuse the
+    // thread's subject, so a blank here is fine there.
+    if (!enrollment.gmailThreadId && !String(task.emailSubject || '').trim()) return { fail: 'no_subject' };
     const partner = await d.PartnerOrganisation.findByPk(row.partnerOrganisationId);
     if (!partner || partner.mergedIntoId || partner.archivedAt) return { fail: 'partner_gone' };
     if (partner.autoEmailOptOut) return { fail: 'partner_opted_out' };
@@ -174,9 +178,12 @@ export function makeOutreachSenderService(overrides = {}) {
 
   function buildRfc822({ persona, row, task, enrollment, references }) {
     const threaded = Boolean(enrollment.gmailThreadId);
+    // Fresh sends use ONLY the authored subject (revalidate guarantees it);
+    // threaded replies stay on the thread's subject. task.title is a rep
+    // instruction and must never reach the wire.
     const baseSubject = threaded
       ? (enrollment.gmailThreadSubject || task.emailSubject || task.title)
-      : (task.emailSubject || task.title);
+      : task.emailSubject;
     const subject = headerSafe(threaded && !/^re:/i.test(baseSubject) ? `Re: ${baseSubject}` : baseSubject)
       .slice(0, 220);
     const body = `${task.description || ''}\n\n--\n${FOOTER}\n`;
@@ -575,6 +582,9 @@ export function makeOutreachSenderService(overrides = {}) {
     // The send goes out as the TASK ASSIGNEE's persona (the conversation
     // owner), matching what send-time revalidation enforces — not as whoever
     // clicked (an admin can trigger it, the identity stays the rep's).
+    if (!enrollment.gmailThreadId && !String(task.emailSubject || '').trim()) {
+      throw new AppError('This email has no subject line yet — add one in the message box first', 409);
+    }
     if (!task.assigneeUserId) throw new AppError('This task has no assignee to send as', 409);
     const persona = await d.OutreachPersona.findOne({
       where: { assignedUserId: task.assigneeUserId, isActive: true },

--- a/backend/test/redeemOpsAutosend.test.js
+++ b/backend/test/redeemOpsAutosend.test.js
@@ -18,8 +18,8 @@ import { jest } from '@jest/globals';
 import { getApp, closeDb, createTestUser } from './helpers.js';
 import {
   OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
-  OutreachCadence, OutreachCadenceEnrollment, OutreachActivity,
-  PartnerOrganisation, sequelize,
+  OutreachCadence, OutreachCadenceEnrollment, OutreachCadenceStep,
+  OutreachActivity, PartnerOrganisation, sequelize,
 } from '../src/models/index.js';
 import { makeCadenceService, autoSendLint } from '../src/services/redeemOps/cadenceService.js';
 import { makeOutreachSenderService } from '../src/services/redeemOps/outreachSenderService.js';
@@ -135,7 +135,11 @@ describe('authoring gate & lint helper', () => {
     } finally {
       process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED = before;
     }
-    await expect(svc.createCadence(def({ subject: null }), admin.user)).rejects.toMatchObject({ statusCode: 400 });
+    // A blank subject no longer refuses — it lands the house default, so the
+    // wire never carries a task title.
+    const defaulted = await svc.createCadence(def({ subject: null, name: `Gate default ${Date.now()}` }), admin.user);
+    const step = await OutreachCadenceStep.findOne({ where: { cadenceId: defaulted.id } });
+    expect(step.subjectTemplate).toBe('Bringing new customers to {{partner_name}}');
     await expect(svc.createCadence(def({ channel: 'call', subject: 'S' }), admin.user)).rejects.toMatchObject({ statusCode: 400 });
   });
 
@@ -402,6 +406,10 @@ describe('one-click send on MANUAL email steps', () => {
     const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
     expect(await liveRow(firstTask.id)).toBeNull(); // manual step — nothing enqueued
 
+    // Materialization rendered the DEFAULT subject (the step was authored
+    // without one) — the task title never reaches the wire.
+    expect(firstTask.emailSubject).toBe('Bringing new customers to ManualSendCafe');
+
     let row = await sender.sendTaskEmail(firstTask.id, exec.user);
     expect(row.status).toBe('queued');
     expect(row.holdReason).toBeNull(); // human reviewed it — no ramp
@@ -422,7 +430,8 @@ describe('one-click send on MANUAL email steps', () => {
     const rfc = google.sendRaw.mock.calls.map((c) => c[0]).find((r) => r.includes('To: <nora@manualsend.sg>'));
     expect(rfc).toBeTruthy();
     expect(rfc).toContain('From: "Emily Wong" <emily@redeem.sg>');
-    expect(rfc).toContain('Subject: Manual intro'); // title fallback — no authored subject
+    expect(rfc).toContain('Subject: Bringing new customers to ManualSendCafe');
+    expect(rfc).not.toContain('Subject: Manual intro'); // the task title is NOT a subject
     expect((await OutreachTask.findByPk(firstTask.id)).status).toBe('completed');
     const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
     expect(acts.some((a) => a.type === 'email_sent' && /auto-sent as emily@redeem\.sg/.test(a.summary))).toBe(true);
@@ -447,6 +456,31 @@ describe('one-click send on MANUAL email steps', () => {
       .set(auth(exec.token));
     expect(dup.status).toBe(409);
     expect(await OutreachEmail.count({ where: { taskId: firstTask.id } })).toBe(1);
+  });
+
+  test('a blanked subject blocks sending: the button 409s, and the worker cancels a queued row', async () => {
+    const cadence = await manualCadence();
+    const p = await ownedPartner('NoSubjectCafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+
+    await OutreachTask.update({ emailSubject: '' }, { where: { id: firstTask.id } });
+    await expect(sender.sendTaskEmail(firstTask.id, exec.user))
+      .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/subject/i) });
+
+    // Queue a valid send while the loop is dark (holds the row), then blank
+    // the subject before the worker claims it — send-time revalidation must
+    // cancel, never fall back to the task title.
+    await OutreachTask.update({ emailSubject: 'Real subject' }, { where: { id: firstTask.id } });
+    await OutreachAccount.update({ lastSuccessfulPollAt: null }, { where: { id: account.id } });
+    await sender.sendTaskEmail(firstTask.id, exec.user);
+    await OutreachTask.update({ emailSubject: '' }, { where: { id: firstTask.id } });
+    await OutreachAccount.update({ lastSuccessfulPollAt: new Date() }, { where: { id: account.id } });
+    await sender.tick();
+    const row = await liveRow(firstTask.id);
+    expect(row.status).toBe('cancelled');
+    expect(row.lastError).toBe('no_subject');
+    // Ticks may flush other tests' stale rows — assert OUR address never sent.
+    expect(google.sendRaw.mock.calls.some((c) => c[0].includes('nosubjectcafe'))).toBe(false);
   });
 
   test('refuses non-email steps, opted-out partners, and assignees with no persona — creating nothing', async () => {

--- a/src/components/redeemops/__tests__/cadence.test.jsx
+++ b/src/components/redeemops/__tests__/cadence.test.jsx
@@ -883,7 +883,8 @@ describe('ScheduledSendStrip — one-click send on manual email steps', () => {
     api.sendTaskOutreachEmail.mockResolvedValue({ id: 'e1', status: 'queued' });
     const task = {
       id: 't-manual-1', cadenceEnrollmentId: 'en1', partnerOrganisationId: 'p1',
-      cadenceStep: { channel: 'email' }, title: 'Email the offer', emailSubject: null,
+      cadenceStep: { channel: 'email' }, title: 'Email the offer',
+      emailSubject: 'Bringing new customers to Owner Biz',
       snapshotRecipient: 'owner@biz.sg', outboxEmails: [],
     };
     wrap(<ScheduledSendStrip task={task} canManage />);
@@ -892,11 +893,26 @@ describe('ScheduledSendStrip — one-click send on manual email steps', () => {
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText(/send this email now\?/i)).toBeInTheDocument();
     expect(within(dialog).getByText(/owner@biz\.sg/)).toBeInTheDocument();
-    // subject preview falls back to the task title when no subject was authored
-    expect(within(dialog).getByText('Email the offer')).toBeInTheDocument();
+    // the REAL subject shows — never the task title
+    expect(within(dialog).getByText('Bringing new customers to Owner Biz')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Email the offer')).not.toBeInTheDocument();
 
     await userEvent.click(within(dialog).getByRole('button', { name: /send email/i }));
     await waitFor(() => expect(api.sendTaskOutreachEmail).toHaveBeenCalledWith('t-manual-1'));
+  });
+
+  it('a task with no subject shows the gap and disables the confirm', async () => {
+    const task = {
+      id: 't-nosubj', cadenceEnrollmentId: 'en1', partnerOrganisationId: 'p1',
+      cadenceStep: { channel: 'email' }, title: 'Email the offer', emailSubject: null,
+      snapshotRecipient: 'owner@biz.sg', outboxEmails: [],
+    };
+    wrap(<ScheduledSendStrip task={task} canManage />);
+    await userEvent.click(screen.getByRole('button', { name: /send email/i }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/no subject set/i)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: /send email/i })).toBeDisabled();
+    expect(api.sendTaskOutreachEmail).not.toHaveBeenCalled();
   });
 
   it('renders nothing for non-email steps, non-cadence tasks, or viewers without manage rights', () => {

--- a/src/components/redeemops/cadence.jsx
+++ b/src/components/redeemops/cadence.jsx
@@ -465,6 +465,7 @@ const CANCELLED_SEND_COPY = {
   reassigned_review: 'This business changed owner — the drafted send was cancelled for your review.',
   autosend_disabled: 'Auto-send was switched off — send it yourself and log the outcome.',
   reply_in_thread: 'They replied in this thread — read it before doing anything else.',
+  no_subject: 'No subject line — add one in the message box, then send again.',
 };
 
 export function ScheduledSendStrip({ task, canManage = true }) {
@@ -521,11 +522,16 @@ export function ScheduledSendStrip({ task, canManage = true }) {
               </DialogDescription>
             </DialogHeader>
             <p className="text-sm mb-0" style={{ color: 'var(--ro-text-2)' }}>
-              Subject: <span className="font-semibold">{task.emailSubject || task.title}</span>
+              Subject: <span className="font-semibold">
+                {task.emailSubject || '(no subject set — edit the message first)'}
+              </span>
             </p>
             <DialogFooter>
               <Button variant="outline" onClick={() => setConfirmSend(false)}>Back</Button>
-              <Button disabled={sendEmailMutation.isPending} onClick={() => sendEmailMutation.mutate()}>
+              <Button
+                disabled={sendEmailMutation.isPending || !task.emailSubject}
+                onClick={() => sendEmailMutation.mutate()}
+              >
                 {sendEmailMutation.isPending ? 'Sending…' : 'Send email'}
               </Button>
             </DialogFooter>
@@ -622,7 +628,9 @@ function TaskScriptBox({ task, canManage = false }) {
   const [draft, setDraft] = useState('');
   const [subjectDraft, setSubjectDraft] = useState('');
   const clampable = text.length > SCRIPT_CLAMP_CHARS || text.split('\n').length > 3;
-  const hasSubject = task.emailSubject != null && task.cadenceStep?.channel === 'email';
+  // Email steps ALWAYS show/edit the subject — legacy tasks may still carry
+  // null (pre-backfill), and the send button refuses until one is set.
+  const hasSubject = task.cadenceStep?.channel === 'email';
 
   const saveMutation = useMutation({
     mutationFn: () => redeemOpsApi.updateTask(task.id, {
@@ -686,7 +694,7 @@ function TaskScriptBox({ task, canManage = false }) {
     <div className="mt-2 rounded-[10px] px-3 py-2" style={{ background: 'var(--ro-subtle)' }}>
       {hasSubject && (
         <p className="text-xs font-semibold m-0 mb-1" style={{ color: 'var(--ro-text-2)' }}>
-          Subject: {task.emailSubject}
+          Subject: {task.emailSubject || <em>(not set — edit to add one)</em>}
         </p>
       )}
       <p

--- a/src/pages/redeemops/CadenceEditorPage.jsx
+++ b/src/pages/redeemops/CadenceEditorPage.jsx
@@ -149,7 +149,8 @@ function StepCard({ step, index, total, dayMark, onChange, onRemove, onMove }) {
         {EMAIL_AUTOSEND_ENABLED && step.mode === 'auto' && step.channel === 'email' && (
           <p className="text-[12px] m-0" style={{ color: 'var(--ro-tag-yellow-fg, #8F6400)' }}>
             The CRM sends this email itself at the scheduled time, from the rep’s outreach
-            address. A subject is required; the first sends of a new version hold for approval.
+            address. A blank subject falls back to “Bringing new customers to {'{{partner_name}}'}”;
+            the first sends of a new version hold for approval.
           </p>
         )}
 


### PR DESCRIPTION
A live send went out with the TASK TITLE as its subject ("Email the partnership idea"). Closed at four layers: blank email-step subjects now default to 'Bringing new customers to {{partner_name}}' at authoring (hand-built + AI); migration 123 backfills every existing email step and open task; fresh sends refuse without a subject (button 409 + worker cancels to a visible 'no subject' strip); the business-page task card always shows and edits the Subject line, and the send confirm disables without one. Backend 73/73 + migrations 23/23 + frontend 47/47, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S