### PR TITLE
fix(test): seed helper must override pre-seeded category rows

### DIFF
--- a/backend/test/helpers.js
+++ b/backend/test/helpers.js
@@ -307,9 +307,14 @@ export async function createTestLeadPackageAssignment(agentId, packageId, overri
  * with a category must seed it first. Idempotent (case-insensitive).
  */
 export async function seedRedeemOpsCategory(name, overrides = {}) {
-  const [category] = await RedeemOpsCategory.findOrCreate({
+  // Migration 122 pre-seeds a real taxonomy, so a fixture naming a seeded
+  // category ('Cafe', 'Nail Salon', …) FINDS a row instead of creating one —
+  // apply the fixture's field values on found rows too, or tests silently
+  // run against the seed's values (CI-only failure, 2026-08-11).
+  const [category, created] = await RedeemOpsCategory.findOrCreate({
     where: { name },
     defaults: { name, isActive: true, ...overrides },
   });
+  if (!created) await category.update({ isActive: true, ...overrides });
   return category;
 }


### PR DESCRIPTION
CI-only failure after #449: migration 122 pre-seeds 'Cafe', so `seedRedeemOpsCategory('Cafe', {categoryFilterWords})` found the seeded row and dropped the fixture's fields (findOrCreate ignores defaults on find). Helper now updates found rows with the overrides. 152/152 across all six dependent suites on a fresh seeded DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S