### PR TITLE
fix(redeem-ops): no unsubscribe line in email bodies + restore #451 guards

### DIFF
--- a/backend/src/services/redeemOps/outreachSenderService.js
+++ b/backend/src/services/redeemOps/outreachSenderService.js
@@ -39,11 +39,10 @@ const RETRY_BACKOFF_MS = [2 * 60_000, 10 * 60_000, 30 * 60_000];
 const STALE_SENDING_MS = 10 * 60_000;
 const POLL_FRESHNESS_MS = 10 * 60_000;
 const CLAIM_BATCH = 5;
-// Soft, human opt-out — the word "unsubscribe" is load-bearing: the inbox
-// loop's UNSUB_RE keys on it, and Gmail's own list-detection does too. The
-// old '--\nMKTR PTE. LTD. · reply "unsubscribe" to opt out' block read as
-// bulk mail to Gmail's classifier (live send landed in Promotions).
-const OPT_OUT_LINE = 'If this isn’t for you, just reply "unsubscribe" and I won’t write again.';
+// No visible opt-out line — Shawn's call (2026-08-11): the body ends at the
+// signature, nothing that smells like a mailing list. Opt-outs still work
+// invisibly: the inbox loop's UNSUB_RE suppresses any reply that says
+// unsubscribe/stop/remove me, and reps have the manual opt-out button.
 const SGT_OFFSET_MS = 8 * 3600_000;
 /** Closings that mean the script already signs off — don't add a second one. */
 const SIGN_OFF_RE = /best regards|warm regards|kind regards|regards,|cheers,|sincerely|thanks,|thank you,/i;
@@ -140,6 +139,10 @@ export function makeOutreachSenderService(overrides = {}) {
     const enrollment = await d.OutreachCadenceEnrollment.findByPk(row.cadenceEnrollmentId);
     if (!enrollment || enrollment.state !== 'active') return { fail: 'enrollment_not_active' };
     if (enrollment.currentStepId !== task.cadenceStepId) return { fail: 'not_current_step' };
+    // A fresh (non-threaded) send needs a real subject — the task TITLE is a
+    // rep instruction, never wire content. Threaded follow-ups reuse the
+    // thread's subject, so a blank here is fine there.
+    if (!enrollment.gmailThreadId && !String(task.emailSubject || '').trim()) return { fail: 'no_subject' };
     const partner = await d.PartnerOrganisation.findByPk(row.partnerOrganisationId);
     if (!partner || partner.mergedIntoId || partner.archivedAt) return { fail: 'partner_gone' };
     if (partner.autoEmailOptOut) return { fail: 'partner_opted_out' };
@@ -180,9 +183,12 @@ export function makeOutreachSenderService(overrides = {}) {
 
   function buildRfc822({ persona, row, task, enrollment, references }) {
     const threaded = Boolean(enrollment.gmailThreadId);
+    // Fresh sends use ONLY the authored subject (revalidate guarantees it);
+    // threaded replies stay on the thread's subject. task.title is a rep
+    // instruction and must never reach the wire.
     const baseSubject = threaded
       ? (enrollment.gmailThreadSubject || task.emailSubject || task.title)
-      : (task.emailSubject || task.title);
+      : task.emailSubject;
     const subject = headerSafe(threaded && !/^re:/i.test(baseSubject) ? `Re: ${baseSubject}` : baseSubject)
       .slice(0, 220);
     // Sign off AS THE SENDER (the persona in the From header — it can never
@@ -196,7 +202,7 @@ export function makeOutreachSenderService(overrides = {}) {
     const signature = alreadySigned
       ? ''
       : `\n\nBest regards,\n${persona.displayName}\nRedeem · redeem.sg`;
-    const body = `${script}${signature}\n\n${OPT_OUT_LINE}\n`;
+    const body = `${script}${signature}\n`;
     // Non-ASCII header values (em-dashes, accented/CJK business names) MUST
     // be RFC-2047 encoded — raw UTF-8 in a header renders as mojibake.
     const headers = [
@@ -593,6 +599,9 @@ export function makeOutreachSenderService(overrides = {}) {
     // The send goes out as the TASK ASSIGNEE's persona (the conversation
     // owner), matching what send-time revalidation enforces — not as whoever
     // clicked (an admin can trigger it, the identity stays the rep's).
+    if (!enrollment.gmailThreadId && !String(task.emailSubject || '').trim()) {
+      throw new AppError('This email has no subject line yet — add one in the message box first', 409);
+    }
     if (!task.assigneeUserId) throw new AppError('This task has no assignee to send as', 409);
     const persona = await d.OutreachPersona.findOne({
       where: { assignedUserId: task.assigneeUserId, isActive: true },

--- a/backend/test/redeemOpsAutosend.test.js
+++ b/backend/test/redeemOpsAutosend.test.js
@@ -18,7 +18,7 @@ import { jest } from '@jest/globals';
 import { getApp, closeDb, createTestUser } from './helpers.js';
 import {
   OutreachAccount, OutreachPersona, OutreachEmail, OutreachTask,
-  OutreachCadence, OutreachCadenceEnrollment, OutreachActivity,
+  OutreachCadence, OutreachCadenceEnrollment, OutreachCadenceStep, OutreachActivity,
   PartnerOrganisation, sequelize,
 } from '../src/models/index.js';
 import { makeCadenceService, autoSendLint } from '../src/services/redeemOps/cadenceService.js';
@@ -135,7 +135,11 @@ describe('authoring gate & lint helper', () => {
     } finally {
       process.env.REDEEM_OPS_EMAIL_AUTOSEND_ENABLED = before;
     }
-    await expect(svc.createCadence(def({ subject: null }), admin.user)).rejects.toMatchObject({ statusCode: 400 });
+    // A blank subject no longer refuses — it lands the house default, so the
+    // wire never carries a task title.
+    const defaulted = await svc.createCadence(def({ subject: null, name: `Gate default ${Date.now()}` }), admin.user);
+    const step = await OutreachCadenceStep.findOne({ where: { cadenceId: defaulted.id } });
+    expect(step.subjectTemplate).toBe('Bringing new customers to {{partner_name}}');
     await expect(svc.createCadence(def({ channel: 'call', subject: 'S' }), admin.user)).rejects.toMatchObject({ statusCode: 400 });
   });
 
@@ -230,11 +234,11 @@ describe('the sender', () => {
     expect(rfc).toContain('From: "Emily Wong" <emily@redeem.sg>');
     expect(rfc).toContain('To: <wei@happycafe.sg>');
     expect(rfc).toContain('Subject: Bring customers to HappyCafe');
-    // Every send signs off AS the sending persona and carries the soft
-    // opt-out — never the old corporate bulk-mail footer.
+    // Every send signs off AS the sending persona — and the body ends there:
+    // no unsubscribe line, no corporate footer (Shawn's call, 2026-08-11).
     expect(rfc).toContain('Best regards');
     expect(rfc).toContain('Redeem · redeem.sg');
-    expect(rfc).toContain('unsubscribe');
+    expect(rfc).not.toContain('unsubscribe');
     expect(rfc).not.toContain('MKTR PTE. LTD.');
 
     const row = await OutreachEmail.findOne({ where: { taskId: firstTask.id } });
@@ -266,7 +270,7 @@ describe('the sender', () => {
     expect(rfc).toBeTruthy();
     expect(rfc).toContain('Cheers,');
     expect(rfc).not.toContain('Best regards'); // the script's own closing stands alone
-    expect(rfc).toContain('unsubscribe'); // the opt-out line still rides every send
+    expect(rfc).not.toContain('unsubscribe'); // body ends at the closing — nothing appended
   });
 
   test('a rep completing the task manually kills the queued machine send in the same transaction (C1b)', async () => {
@@ -427,6 +431,9 @@ describe('one-click send on MANUAL email steps', () => {
     await partnerSvc.addContact(p.id, { name: 'Nora', email: 'nora@manualsend.sg' }, exec.user);
     const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
     expect(await liveRow(firstTask.id)).toBeNull(); // manual step — nothing enqueued
+    // Materialization rendered the DEFAULT subject (the step was authored
+    // without one) — the task title never reaches the wire.
+    expect(firstTask.emailSubject).toBe('Bringing new customers to ManualSendCafe');
 
     let row = await sender.sendTaskEmail(firstTask.id, exec.user);
     expect(row.status).toBe('queued');
@@ -448,7 +455,8 @@ describe('one-click send on MANUAL email steps', () => {
     const rfc = google.sendRaw.mock.calls.map((c) => c[0]).find((r) => r.includes('To: <nora@manualsend.sg>'));
     expect(rfc).toBeTruthy();
     expect(rfc).toContain('From: "Emily Wong" <emily@redeem.sg>');
-    expect(rfc).toContain('Subject: Manual intro'); // title fallback — no authored subject
+    expect(rfc).toContain('Subject: Bringing new customers to ManualSendCafe');
+    expect(rfc).not.toContain('Subject: Manual intro'); // the task title is NOT a subject
     expect((await OutreachTask.findByPk(firstTask.id)).status).toBe('completed');
     const acts = await OutreachActivity.findAll({ where: { partnerOrganisationId: p.id } });
     expect(acts.some((a) => a.type === 'email_sent' && /auto-sent as emily@redeem\.sg/.test(a.summary))).toBe(true);
@@ -473,6 +481,31 @@ describe('one-click send on MANUAL email steps', () => {
       .set(auth(exec.token));
     expect(dup.status).toBe(409);
     expect(await OutreachEmail.count({ where: { taskId: firstTask.id } })).toBe(1);
+  });
+
+  test('a blanked subject blocks sending: the button 409s, and the worker cancels a queued row', async () => {
+    const cadence = await manualCadence();
+    const p = await ownedPartner('NoSubjectCafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+
+    await OutreachTask.update({ emailSubject: '' }, { where: { id: firstTask.id } });
+    await expect(sender.sendTaskEmail(firstTask.id, exec.user))
+      .rejects.toMatchObject({ statusCode: 409, message: expect.stringMatching(/subject/i) });
+
+    // Queue a valid send while the loop is dark (holds the row), then blank
+    // the subject before the worker claims it — send-time revalidation must
+    // cancel, never fall back to the task title.
+    await OutreachTask.update({ emailSubject: 'Real subject' }, { where: { id: firstTask.id } });
+    await OutreachAccount.update({ lastSuccessfulPollAt: null }, { where: { id: account.id } });
+    await sender.sendTaskEmail(firstTask.id, exec.user);
+    await OutreachTask.update({ emailSubject: '' }, { where: { id: firstTask.id } });
+    await OutreachAccount.update({ lastSuccessfulPollAt: new Date() }, { where: { id: account.id } });
+    await sender.tick();
+    const row = await liveRow(firstTask.id);
+    expect(row.status).toBe('cancelled');
+    expect(row.lastError).toBe('no_subject');
+    // Ticks may flush other tests' stale rows — assert OUR address never sent.
+    expect(google.sendRaw.mock.calls.some((c) => c[0].includes('nosubjectcafe'))).toBe(false);
   });
 
   test('refuses non-email steps, opted-out partners, and assignees with no persona — creating nothing', async () => {


### PR DESCRIPTION
Removes the visible opt-out line completely — the body ends at the persona signature (reply-keyword suppression and the rep opt-out button still cover opt-outs invisibly). Also restores the three #451 subject guards that #453 accidentally reverted from a stale branch base (no_subject revalidation, send-button 409, no title fallback), with their tests. 74/74 on a fresh DB, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S