### PR TITLE
feat(redeem-ops): every timeline entry is admin-deletable

### DIFF
--- a/backend/src/controllers/redeemOps/partnersController.js
+++ b/backend/src/controllers/redeemOps/partnersController.js
@@ -284,6 +284,21 @@ export const voidActivity = asyncHandler(async (req, res) => {
   res.json({ success: true, message: 'Activity voided' });
 });
 
+const hideTimelineSchema = Joi.object({
+  kind: Joi.string().valid('stage', 'assignment', 'audit', 'task').required(),
+  refKey: Joi.string().max(100).required(),
+  reason: Joi.string().trim().min(1).max(500).required(),
+});
+
+// Display-level delete for non-activity timeline entries (admin tier) —
+// the source rows stay; a marker hides the rendered entry. Audited.
+export const hideTimelineEntry = asyncHandler(async (req, res) => {
+  const { error, value } = hideTimelineSchema.validate(req.body || {}, { abortEarly: false });
+  if (error) throw new AppError(error.details.map((x) => x.message).join(', '), 400);
+  await partnerService.hideTimelineEntry(req.params.id, value, req.user, req.id);
+  res.json({ success: true, message: 'Timeline entry deleted' });
+});
+
 const contactSchema = Joi.object({
   name: Joi.string().max(120).required(),
   roleTitle: Joi.string().max(80).allow('', null),

--- a/backend/src/database/migrations/124-timeline-hidden-entries.js
+++ b/backend/src/database/migrations/124-timeline-hidden-entries.js
@@ -1,0 +1,47 @@
+/**
+ * 124 — admin-hideable timeline entries (display-level delete).
+ *
+ * The partner timeline renders five heterogeneous sources (activities, stage
+ * events, assignment events, audit rows, task events). Activities already
+ * soft-void; the others BACK live machinery — deleting a stage event skews
+ * stageSince, deleting a task row cascades its sent-email record, deleting
+ * audit rows erases the trail. So "delete" for those is a MARKER: one row
+ * here hides one timeline entry, the source row stays intact. Audited, with
+ * a required reason; admin tier only (partners.delete).
+ */
+
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('timeline_hidden_entries', {
+    id: { type: Sequelize.UUID, defaultValue: Sequelize.literal('gen_random_uuid()'), primaryKey: true },
+    partnerOrganisationId: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: { model: 'partner_organisations', key: 'id' },
+      onDelete: 'CASCADE',
+    },
+    // 'stage' | 'assignment' | 'audit' | 'task'
+    kind: { type: Sequelize.STRING(20), allowNull: false },
+    // Source row id; task entries use `${taskId}:${event}` so hiding
+    // "Task created" leaves "Task completed" visible.
+    refKey: { type: Sequelize.STRING(100), allowNull: false },
+    reason: { type: Sequelize.TEXT, allowNull: false },
+    hiddenBy: {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: { model: 'users', key: 'id' },
+      onDelete: 'SET NULL',
+    },
+    createdAt: { type: Sequelize.DATE, allowNull: false },
+    updatedAt: { type: Sequelize.DATE, allowNull: false },
+  });
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_the_kind_ref ON timeline_hidden_entries (kind, "refKey")`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_the_partner ON timeline_hidden_entries ("partnerOrganisationId")`
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('timeline_hidden_entries');
+}

--- a/backend/src/models/TimelineHiddenEntry.js
+++ b/backend/src/models/TimelineHiddenEntry.js
@@ -1,0 +1,26 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Display-level "deleted" marker for partner-timeline entries (migration 124).
+ * One row hides one rendered entry; the SOURCE row (stage event, assignment
+ * event, audit row, task) stays intact — those back live machinery and the
+ * audit trail. Activities are not marked here: they soft-void on their own
+ * table (voidedAt), which predates this.
+ */
+const TimelineHiddenEntry = sequelize.define('TimelineHiddenEntry', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  partnerOrganisationId: { type: DataTypes.UUID, allowNull: false },
+  kind: { type: DataTypes.STRING(20), allowNull: false },
+  refKey: { type: DataTypes.STRING(100), allowNull: false },
+  reason: { type: DataTypes.TEXT, allowNull: false },
+  hiddenBy: { type: DataTypes.UUID, allowNull: true },
+}, {
+  tableName: 'timeline_hidden_entries',
+  indexes: [
+    { name: 'uq_the_kind_ref', unique: true, fields: ['kind', 'refKey'] },
+    { name: 'idx_the_partner', fields: ['partnerOrganisationId'] },
+  ],
+});
+
+export default TimelineHiddenEntry;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -403,7 +403,7 @@ export const {
   WaMessageStatus, WaMessageSend, ConsumerObservation, ConsumerProfile, EnrichmentJob,
   EnrichmentScoringConfig, EnrichmentSweepRun,
   MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection,
-  OutreachAccount, OutreachPersona, OutreachEmail
+  OutreachAccount, OutreachPersona, OutreachEmail, TimelineHiddenEntry
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/redeemOpsPartners.js
+++ b/backend/src/routes/redeemOpsPartners.js
@@ -55,6 +55,9 @@ router.get('/partners/:id/timeline', requireRedeemOps('partners.view'), ctrl.get
 router.post('/partners/:id/activities', requireRedeemOps('activities.log'), ctrl.logActivity);
 router.patch('/activities/:activityId', requireRedeemOps('activities.edit'), ctrl.editActivity);
 router.post('/activities/:activityId/void', requireRedeemOps('activities.edit'), ctrl.voidActivity);
+// Hiding stage/assignment/audit/task entries is custodial work — same tier
+// as deleting the business itself.
+router.post('/partners/:id/timeline/hide', requireRedeemOps('partners.delete'), ctrl.hideTimelineEntry);
 
 // Contacts
 router.post('/partners/:id/contacts', requireRedeemOps('contacts.manage'), ctrl.addContact);

--- a/backend/src/services/redeemOps/partnerService.js
+++ b/backend/src/services/redeemOps/partnerService.js
@@ -4,7 +4,7 @@ import {
   PartnerStageEvent, OutreachActivity, OutreachTask, ProspectingPoolMember,
   PartnerOnboardingItem, RewardOffer, Activation,
   RewardEntitlement, Redemption, RewardInventoryEvent, RedemptionEvent, Draw,
-  RedeemOpsAuditEvent, User, sequelize,
+  RedeemOpsAuditEvent, TimelineHiddenEntry, User, sequelize,
 } from '../../models/index.js';
 import { AppError } from '../../middleware/appError.js';
 import { logger } from '../../utils/logger.js';
@@ -41,7 +41,7 @@ export function makePartnerService(overrides = {}) {
     PartnerStageEvent, OutreachActivity, OutreachTask, ProspectingPoolMember,
     PartnerOnboardingItem, RewardOffer, Activation,
     RewardEntitlement, Redemption, RewardInventoryEvent, RedemptionEvent, Draw,
-    RedeemOpsAuditEvent, User, sequelize, logger,
+    RedeemOpsAuditEvent, TimelineHiddenEntry, User, sequelize, logger,
     audit: makeRedeemOpsAuditService(),
     dedupe: makeDedupeService(),
     categories: makeCategoryService(),
@@ -590,15 +590,75 @@ export function makePartnerService(overrides = {}) {
       }
     }
 
+    // Admin-hidden entries (migration 124): display-level delete — the source
+    // rows stay (they back stageSince, cadence provenance, and the audit
+    // trail); one marker hides one rendered entry.
+    const hiddenRows = await d.TimelineHiddenEntry.findAll({
+      where: { partnerOrganisationId: id }, attributes: ['kind', 'refKey'], raw: true,
+    });
+    const hidden = new Set(hiddenRows.map((h) => `${h.kind}:${h.refKey}`));
+
     const entries = [
       ...activities.map((a) => ({ kind: 'activity', at: a.occurredAt, data: a })),
       ...stageEvents.map((e) => ({ kind: 'stage', at: e.createdAt, data: e })),
       ...assignmentEvents.map((e) => ({ kind: 'assignment', at: e.createdAt, data: e })),
       ...auditEvents.map((e) => ({ kind: 'audit', at: e.createdAt, data: e })),
       ...taskEntries,
-    ].sort((x, y) => new Date(y.at) - new Date(x.at)).slice(0, limit);
+    ].filter((entry) => !hidden.has(
+      entry.kind === 'task'
+        ? `task:${entry.data.task.id}:${entry.data.event}`
+        : `${entry.kind}:${entry.data.id}`
+    )).sort((x, y) => new Date(y.at) - new Date(x.at)).slice(0, limit);
 
     return { entries };
+  }
+
+  const TIMELINE_HIDEABLE_KINDS = ['stage', 'assignment', 'audit', 'task'];
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  /**
+   * Hide one timeline entry (admin tier — routed behind partners.delete).
+   * Activities void on their own table; every other kind gets a marker here.
+   * The refKey is verified to belong to THIS partner — no blind cross-partner
+   * hides — and the hide itself is audited with the required reason.
+   */
+  async function hideTimelineEntry(id, { kind, refKey, reason } = {}, user, requestId = null) {
+    if (!TIMELINE_HIDEABLE_KINDS.includes(kind)) throw new AppError('This entry type cannot be deleted', 400);
+    const why = String(reason ?? '').trim();
+    if (!why) throw new AppError('A reason is required', 400);
+    const ref = String(refKey ?? '');
+    await getLivePartner(id, { attributes: ['id', 'mergedIntoId'] });
+
+    let found = null;
+    if (kind === 'task') {
+      const [taskId, event] = ref.split(':');
+      if (!UUID_RE.test(taskId || '') || !['created', 'completed', 'cancelled'].includes(event)) {
+        throw new AppError('Bad entry reference', 400);
+      }
+      found = await d.OutreachTask.findOne({ where: { id: taskId, partnerOrganisationId: id } });
+    } else {
+      if (!UUID_RE.test(ref)) throw new AppError('Bad entry reference', 400);
+      if (kind === 'stage') {
+        found = await d.PartnerStageEvent.findOne({ where: { id: ref, partnerOrganisationId: id } });
+      } else if (kind === 'assignment') {
+        found = await d.PartnerAssignmentEvent.findOne({ where: { id: ref, partnerOrganisationId: id } });
+      } else {
+        found = await d.RedeemOpsAuditEvent.findOne({
+          where: { id: ref, entityType: 'partner_organisation', entityId: String(id) },
+        });
+      }
+    }
+    if (!found) throw new AppError('Entry not found on this business', 404);
+
+    const [row] = await d.TimelineHiddenEntry.findOrCreate({
+      where: { kind, refKey: ref },
+      defaults: { partnerOrganisationId: id, kind, refKey: ref, reason: why, hiddenBy: user.id },
+    });
+    await d.audit.recordAuditEvent({
+      actorUser: user, action: 'partner.timeline_entry_hidden', entityType: 'partner_organisation',
+      entityId: id, after: { kind, refKey: ref }, reason: why, requestId,
+    });
+    return row;
   }
 
   async function logActivityTx(id, body, user, t, { requestId = null, suppressCadenceHooks = false } = {}) {
@@ -1064,7 +1124,7 @@ export function makePartnerService(overrides = {}) {
   return {
     listPartners, getPartner, createPartner, updatePartner, changeStage, changeStageBulk, undoStageChange,
     snoozePartner, unsnoozePartner,
-    importPartners, getTimeline, logActivity, editActivity, voidActivity,
+    importPartners, getTimeline, logActivity, editActivity, voidActivity, hideTimelineEntry,
     addContact, updateContact, archiveContact, addLocation, updateLocation,
     mergePartners, deletePartner, canActOnRow,
     // P0 caller-transaction primitives (cadence engine + composed flows)

--- a/backend/test/redeemOpsAutosend.test.js
+++ b/backend/test/redeemOpsAutosend.test.js
@@ -508,6 +508,19 @@ describe('one-click send on MANUAL email steps', () => {
     expect(google.sendRaw.mock.calls.some((c) => c[0].includes('nosubjectcafe'))).toBe(false);
   });
 
+  test('the Task-created timeline entry hides via the task refKey path', async () => {
+    const cadence = await manualCadence();
+    const p = await ownedPartner('HideTaskCafe');
+    const { firstTask } = await svc.enrollPartner(p.id, { cadenceId: cadence.id }, exec.user);
+    await partnerSvc.hideTimelineEntry(
+      p.id, { kind: 'task', refKey: `${firstTask.id}:created`, reason: 'noise' }, admin.user
+    );
+    const { entries } = await partnerSvc.getTimeline(p.id);
+    expect(entries.some((e) => e.kind === 'task' && e.data.task.id === firstTask.id && e.data.event === 'created')).toBe(false);
+    await expect(partnerSvc.hideTimelineEntry(p.id, { kind: 'task', refKey: 'garbage', reason: 'x' }, admin.user))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+
   test('deleting a business cascades its cadence enrollment, tasks, and outbox rows', async () => {
     // Guards the FK-cascade invariant — a future migration flipping one of
     // these to RESTRICT would break the admin Delete-business flow with a 500.

--- a/backend/test/redeemOpsPartners.test.js
+++ b/backend/test/redeemOpsPartners.test.js
@@ -853,3 +853,52 @@ describe('list carries who ADDED the row, not just who owns it', () => {
     expect(row.creator.id).toBe(execB.user.id);
   });
 });
+
+describe('timeline entry deletion (admin display-level hide, migration 124)', () => {
+  test('admin hides stage/assignment/audit entries; sources survive; bdm refused; cross-partner 404', async () => {
+    const psvc = makePartnerService();
+    const { partner } = await psvc.createPartner(
+      { tradingName: `HideCo ${Date.now()}`, primaryPhone: `+65899${Math.floor(10000 + Math.random() * 89999)}` },
+      admin.user
+    );
+    const stageEv = await PartnerStageEvent.create({
+      partnerOrganisationId: partner.id, fromStage: 'NEW', toStage: 'CONTACTED', actorUserId: admin.user.id,
+    });
+    const auditRow = await RedeemOpsAuditEvent.findOne({
+      where: { entityType: 'partner_organisation', entityId: String(partner.id), action: 'partner.created' },
+    });
+
+    // bdm is NOT custodial tier — the route refuses before any lookup
+    const forbidden = await request(app)
+      .post(`/api/redeem-ops/partners/${partner.id}/timeline/hide`)
+      .set(auth(bdm.token)).send({ kind: 'stage', refKey: stageEv.id, reason: 'x' });
+    expect(forbidden.status).toBe(403);
+
+    const ok = await request(app)
+      .post(`/api/redeem-ops/partners/${partner.id}/timeline/hide`)
+      .set(auth(admin.token)).send({ kind: 'stage', refKey: stageEv.id, reason: 'test noise' });
+    expect(ok.status).toBe(200);
+    await psvc.hideTimelineEntry(partner.id, { kind: 'audit', refKey: auditRow.id, reason: 'noise' }, admin.user);
+
+    const { entries } = await psvc.getTimeline(partner.id);
+    expect(entries.some((e) => e.kind === 'stage' && e.data.id === stageEv.id)).toBe(false);
+    expect(entries.some((e) => e.kind === 'audit' && e.data.id === auditRow.id)).toBe(false);
+    // display-level ONLY: the source rows are untouched
+    expect(await PartnerStageEvent.findByPk(stageEv.id)).not.toBeNull();
+    expect(await RedeemOpsAuditEvent.findByPk(auditRow.id)).not.toBeNull();
+
+    // re-hiding is idempotent, not a unique-constraint crash
+    await psvc.hideTimelineEntry(partner.id, { kind: 'audit', refKey: auditRow.id, reason: 'again' }, admin.user);
+
+    // another business's entry cannot be blind-hidden through this partner
+    const { partner: other } = await psvc.createPartner(
+      { tradingName: `OtherCo ${Date.now()}`, primaryPhone: `+65898${Math.floor(10000 + Math.random() * 89999)}` },
+      admin.user
+    );
+    const otherEv = await PartnerStageEvent.create({
+      partnerOrganisationId: other.id, fromStage: 'NEW', toStage: 'CONTACTED', actorUserId: admin.user.id,
+    });
+    await expect(psvc.hideTimelineEntry(partner.id, { kind: 'stage', refKey: otherEv.id, reason: 'x' }, admin.user))
+      .rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/src/api/redeemOps.js
+++ b/src/api/redeemOps.js
@@ -194,6 +194,10 @@ export const redeemOpsApi = {
     const res = await apiClient.post(`/redeem-ops/activities/${activityId}/void`, { reason });
     return res.data?.activity;
   },
+  async hidePartnerTimelineEntry(partnerId, body) {
+    const res = await apiClient.post(`/redeem-ops/partners/${partnerId}/timeline/hide`, body);
+    return res.data;
+  },
   async logActivity(id, body) {
     const res = await apiClient.post(`/redeem-ops/partners/${id}/activities`, body);
     return res.data?.activity;

--- a/src/pages/redeemops/PartnerDetail.jsx
+++ b/src/pages/redeemops/PartnerDetail.jsx
@@ -223,12 +223,12 @@ function TimelineEntry({ entry, onDeleteLog }) {
       <div className="min-w-0">
         <div className="flex items-start justify-between gap-2">
           <p className="text-sm font-bold m-0">{title}</p>
-          {entry.kind === 'activity' && onDeleteLog && (
+          {onDeleteLog && (
             <button
               type="button"
               aria-label="Delete log entry"
               className="shrink-0 -mt-0.5 p-1 rounded border-0 bg-transparent cursor-pointer"
-              onClick={() => onDeleteLog(entry.data)}
+              onClick={() => onDeleteLog(entry)}
             >
               <Trash2 className="w-3.5 h-3.5" style={{ color: 'var(--ro-text-3)' }} aria-hidden="true" />
             </button>
@@ -471,12 +471,18 @@ export default function PartnerDetail() {
   });
   const setEdit = (k) => (e) => setEditForm((f) => ({ ...f, [k]: e.target.value }));
 
-  // Timeline log deletion (admin tier): soft-voids the activity server-side —
-  // it vanishes from the timeline but stays in the audit record. Reason required.
-  const [voidTarget, setVoidTarget] = useState(null);
+  // Timeline entry deletion (admin tier): activities soft-void on their own
+  // table; every other kind (stage, claim, task, audit) gets a display-level
+  // hide marker — the source record stays for audit/machinery. Reason required.
+  const [voidTarget, setVoidTarget] = useState(null); // the full timeline entry
   const [voidReason, setVoidReason] = useState('');
   const voidMutation = useMutation({
-    mutationFn: () => redeemOpsApi.voidPartnerActivity(voidTarget.id, voidReason.trim()),
+    mutationFn: () => {
+      const e = voidTarget;
+      if (e.kind === 'activity') return redeemOpsApi.voidPartnerActivity(e.data.id, voidReason.trim());
+      const refKey = e.kind === 'task' ? `${e.data.task.id}:${e.data.event}` : e.data.id;
+      return redeemOpsApi.hidePartnerTimelineEntry(id, { kind: e.kind, refKey, reason: voidReason.trim() });
+    },
     onSuccess: () => {
       setVoidTarget(null);
       toast.success('Log entry deleted');
@@ -773,7 +779,7 @@ export default function PartnerDetail() {
                   key={`${entry.kind}-${entry.data.id || i}`}
                   entry={entry}
                   onDeleteLog={hasCapability(user, 'partners.delete')
-                    ? (a) => { setVoidTarget(a); setVoidReason(''); }
+                    ? (e) => { setVoidTarget(e); setVoidReason(''); }
                     : undefined}
                 />
               ))}
@@ -1019,9 +1025,9 @@ export default function PartnerDetail() {
               A short reason is required.
             </DialogDescription>
           </DialogHeader>
-          {voidTarget?.summary && (
+          {voidTarget?.kind === 'activity' && voidTarget.data?.summary && (
             <p className="text-[13px] m-0 line-clamp-2" style={{ color: 'var(--ro-text-2)' }}>
-              “{voidTarget.summary}”
+              “{voidTarget.data.summary}”
             </p>
           )}
           <Input


### PR DESCRIPTION
Extends #455's trash to ALL timeline entry kinds. Stage moves, claims, task events, and system entries back live machinery + the audit trail, so they hide via a marker table (migration 124) instead of hard deletes — entry disappears, source record survives. Reason-required, audited, cross-partner-guarded, idempotent; task entries key per-event. UI: one trash + dialog on every entry, admin tier (partners.delete). 67/67 + 23/23 + 11/11, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiexqwJM2L4fA4rpZAA38S