### PR TITLE
feat(ads): Google Ads browser tag — third network on the shared suppression gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,17 @@ VITE_TIKTOK_PIXEL_ID=
 # Staging only; empty in production.
 VITE_TIKTOK_TEST_EVENT_CODE=
 
+# Google Ads account-level conversion ID, format AW-XXXXXXXXX (Google Ads →
+# Goals → Conversions → the conversion action's tag setup). Loader gated on this.
+VITE_GOOGLE_ADS_CONVERSION_ID=
+# Conversion ACTION label that pairs with the ID above — the second half of
+# gtag's `send_to`, shown next to the ID on the same tag-setup screen. A
+# conversion fired without it is discarded by Google, so BOTH must be set.
+VITE_GOOGLE_ADS_LEAD_LABEL=
+# Google has no test-event-code equivalent, so dev firing needs an explicit
+# opt-in. Any non-empty value enables it. Staging only; empty in production.
+VITE_GOOGLE_ADS_DEV_MODE=
+
 # -----------------------------------------------------------------------------
 # Per-build page chrome & SEO (substituted into index.html)
 # -----------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ so the schema tests run against is prod's BY CONSTRUCTION. Consequences:
 
 - **Meta**: browser Pixel (`src/lib/metaPixel.js`) + fire-and-forget CAPI (`backend/src/services/metaCapiService.js`), gated by `shouldFireCapi` (skips Retell + Meta-Lead-Ads origins). Ad account `act_2170132703771607`, pixel `1402034528611431`.
 - **TikTok**: mirror of Meta — Pixel (`src/lib/tiktokPixel.js`) + Events API (`backend/src/services/tiktokEventsService.js`). Pixel `D8GJ6T3C77UDLID6746G`. Live in prod.
+- **Google Ads**: browser gtag tag only (`src/lib/googleAds.js`), same shared suppression gate + event ids; conversions need BOTH `VITE_GOOGLE_ADS_CONVERSION_ID` and `VITE_GOOGLE_ADS_LEAD_LABEL` (unset = dark). No click-id capture / server-side by design — deferred until the channel proves.
 - **Down-funnel**: agent-confirmed SC/PR fires `ConfirmedResident`/`ClosedWon` back from Lyfe → `POST /api/integrations/lyfe/lead-outcome`.
 - **Lead quality**: per-campaign `design_config.sgPrOnly` gate (client-side, self-declared) + Meta customer-list exclusion sync (`redeemedAudienceService`).
 

--- a/docs/reference/ads-and-tracking.md
+++ b/docs/reference/ads-and-tracking.md
@@ -1,4 +1,4 @@
-# Ads & Tracking Reference (Meta + TikTok)
+# Ads & Tracking Reference (Meta + TikTok + Google)
 
 > Extracted from `CLAUDE.md` 2026-07-15 to keep per-session context lean. This is
 > lookup material — read it when doing ads / pixel / CAPI / audience work.
@@ -113,3 +113,51 @@ The TikTok counterpart of the Meta funnel — a browser **Pixel** (`ttq`) plus a
 **Live status (verified 2026-06-17):** browser Pixel live on **redeem.sg** and **mktr.sg** (both static sites bake `VITE_TIKTOK_PIXEL_ID`); backend Events API firing `Lead` + `CompleteRegistration` successfully — `tiktok.lead.sent` appears continuously in `mktr-backend-jo6r` Render logs (2026-06-04 → 2026-06-16). Note: `.env.example` ships `TIKTOK_EVENTS_API_ENABLED=false` + blank ids — that is the example default, NOT prod state; check the live deploy/logs.
 
 **TODO:** add TikTok's **domain verification** for `redeem.sg` in TikTok Events Manager (the Meta `facebook-domain-verification` TXT is already present; TikTok needs its own record). Not required for the Events API to fire, but it improves pixel attribution / event match quality.
+
+## Google Ads — browser tag only (no server-side yet)
+
+The third network, added 2026-08-12 for the SG new-advertiser promo (spend S$600
+in 60 days → S$600 credit) pointed at the Tokyo Getaway draw via **Demand Gen**.
+Browser `gtag.js` conversion tag ONLY — deliberately the "just enough" tier:
+no Enhanced Conversions for Leads, no offline conversion import, and **no
+gclid/gbraid/wbraid capture** (gtag.js persists click ids itself in its `_gcl_aw`
+first-party cookie, and Google rejects offline conversions for clicks >90 days
+old, so there is no click history worth banking before the upload exists). The
+upgrade path hangs off the existing `POST /api/integrations/lyfe/lead-outcome`
+reverse path, exactly like Meta's `ConfirmedResident`/`ClosedWon`.
+
+### Tracking code
+
+- `index.html` — dataLayer/`gtag` queue stub, gated on `VITE_GOOGLE_ADS_CONVERSION_ID`
+  (defines the queue only; does NOT inject gtag.js and does NOT call `config` —
+  same `charAt(0)==='%'` unset-guard as the other two stubs).
+- `src/lib/googleAds.js` — `initGoogleAds` (lazily injects gtag.js + `config`s the
+  id, only after `shouldTrackGoogle` passes, so the SDK never loads on
+  admin/preview surfaces); `trackGoogleConversion`/`trackGoogleLead`. Google
+  quirks encoded there: conversions are addressed as `send_to:
+  "{AW-id}/{label}"` (BOTH halves required — a missing label is silently
+  discarded by Google, so the lib refuses to emit instead); `gtag('config')`
+  emits its own page_view, so config IS the view event (no separate ViewContent;
+  it rides the shared `vc:{campaignId}` session guard as `firedGoogle`); dedup is
+  `transaction_id`, fed the SAME stable event id Meta/TikTok use.
+- Suppression via shared `src/lib/pixelSuppression.js`, resolution via
+  `src/lib/pixelIds.js` (`resolveGoogleAdsConversionId` / `resolveGoogleAdsLeadLabel`
+  read a per-campaign override first — no DB column exists yet, so env-only today).
+- Wired on the three public surfaces alongside Meta/TikTok: `MarketplaceOffer`
+  (config = view), `MarketplaceFlow` + `LeadCapture` (config + Lead conversion at
+  successful `/prospects` submit; no value/currency — same rationale as the Meta
+  `value: 0` desync note in `LeadCapture.jsx`).
+
+### Google env vars
+
+(public — embedded in page source; there is no secret half until a server-side
+integration exists)
+
+| Var | Component | Value / Notes |
+|---|---|---|
+| `VITE_GOOGLE_ADS_CONVERSION_ID` | Frontend build (both static sites) | `AW-XXXXXXXXX` from the conversion action's tag-setup screen. Unset ⇒ whole tag is dark. |
+| `VITE_GOOGLE_ADS_LEAD_LABEL` | Frontend build (both static sites) | Conversion-action label (the part after `/` in `send_to`). Unset ⇒ view tracking only, Lead conversions refuse to emit. |
+| `VITE_GOOGLE_ADS_DEV_MODE` | Dev/staging only | Google has no test-event-code; any non-empty value lets dev builds fire. Empty in production. |
+
+**Status:** shipped dark — the account (and therefore both values) doesn't exist
+yet; set both on `redeem-frontend` + `mktr-platform` in Render when it does.

--- a/index.html
+++ b/index.html
@@ -51,6 +51,21 @@
         }(window, document, 'ttq');
       })();
     </script>
+
+    <!-- Google Ads gtag base stub (gated on VITE_GOOGLE_ADS_CONVERSION_ID).
+         Defines dataLayer + the gtag queue but does NOT inject gtag.js and does
+         NOT call gtag('config') — React (googleAds.initGoogleAds) does both, and
+         only on the live public campaign surfaces, so the SDK never loads on
+         admin/preview pages (same contract as the ttq stub above). -->
+    <script>
+      (function () {
+        var CONVERSION_ID = '%VITE_GOOGLE_ADS_CONVERSION_ID%';
+        if (!CONVERSION_ID || CONVERSION_ID.charAt(0) === '%') return;
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () { window.dataLayer.push(arguments); };
+        window.gtag('js', new Date());
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/lib/__tests__/googleAds.test.js
+++ b/src/lib/__tests__/googleAds.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  shouldTrackGoogle,
+  initGoogleAds,
+  trackGoogleConversion,
+  trackGoogleLead,
+  __resetGoogleAdsStateForTests,
+} from '../googleAds.js';
+
+const CONVERSION_ID = 'AW-123456789';
+const OTHER_ID = 'AW-987654321';
+const LEAD_LABEL = 'AbC-D_efG-h12_34-567';
+
+const GTAG_SELECTOR = 'script[src*="googletagmanager.com/gtag/js"]';
+
+function stubProdWithId() {
+  vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', CONVERSION_ID);
+  vi.stubEnv('MODE', 'production');
+  vi.stubEnv('PROD', true);
+  vi.stubEnv('DEV', false);
+}
+
+describe('shouldTrackGoogle', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    stubProdWithId();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true on /LeadCapture with all conditions met', () => {
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture', search: '' })).toBe(true);
+  });
+
+  it('returns true on the marketplace campaign surfaces', () => {
+    expect(shouldTrackGoogle({ pathname: '/offers/tokyo-draw' })).toBe(true);
+    expect(shouldTrackGoogle({ pathname: '/flow/tokyo-draw' })).toBe(true);
+  });
+
+  it('returns false when VITE_GOOGLE_ADS_CONVERSION_ID is empty', () => {
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', '');
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture' })).toBe(false);
+  });
+
+  it('prefers the caller-resolved conversionId over the build env id', () => {
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', '');
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture', conversionId: OTHER_ID })).toBe(true);
+  });
+
+  it('returns false on /preview, /LeadCapture/demo, and /p/:slug (shared suppression)', () => {
+    expect(shouldTrackGoogle({ pathname: '/preview' })).toBe(false);
+    expect(shouldTrackGoogle({ pathname: '/preview/atelier' })).toBe(false);
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture/demo' })).toBe(false);
+    expect(shouldTrackGoogle({ pathname: '/p/some-slug' })).toBe(false);
+  });
+
+  it('returns false when ?preview=true querystring is present', () => {
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture', search: '?preview=true' })).toBe(false);
+  });
+
+  it('returns false when campaign.is_test_data is true', () => {
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture', campaign: { is_test_data: true } })).toBe(false);
+  });
+
+  it('returns false in dev mode without VITE_GOOGLE_ADS_DEV_MODE', () => {
+    vi.stubEnv('PROD', false);
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_GOOGLE_ADS_DEV_MODE', '');
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture' })).toBe(false);
+  });
+
+  it('returns true in dev mode when VITE_GOOGLE_ADS_DEV_MODE is set', () => {
+    vi.stubEnv('PROD', false);
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_GOOGLE_ADS_DEV_MODE', '1');
+    expect(shouldTrackGoogle({ pathname: '/LeadCapture' })).toBe(true);
+  });
+
+  it('returns false on non-allowlisted paths', () => {
+    expect(shouldTrackGoogle({ pathname: '/Pricing' })).toBe(false);
+    expect(shouldTrackGoogle({ pathname: '/' })).toBe(false);
+  });
+
+  it('handles missing pathname gracefully (returns false)', () => {
+    expect(shouldTrackGoogle({})).toBe(false);
+  });
+});
+
+describe('initGoogleAds', () => {
+  let gtag;
+
+  beforeEach(() => {
+    __resetGoogleAdsStateForTests();
+    document.querySelectorAll(GTAG_SELECTOR).forEach((s) => s.remove());
+    gtag = vi.fn();
+    window.gtag = gtag;
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+    document.querySelectorAll(GTAG_SELECTOR).forEach((s) => s.remove());
+  });
+
+  it('configures the id and injects gtag.js', () => {
+    initGoogleAds(CONVERSION_ID);
+    expect(gtag).toHaveBeenCalledWith('config', CONVERSION_ID);
+    const scripts = document.querySelectorAll(GTAG_SELECTOR);
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0].src).toContain(CONVERSION_ID);
+    expect(scripts[0].async).toBe(true);
+  });
+
+  it('is idempotent per id — a repeat call neither reconfigures nor re-injects', () => {
+    initGoogleAds(CONVERSION_ID);
+    initGoogleAds(CONVERSION_ID);
+    expect(gtag).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(1);
+  });
+
+  it('configures a second id but injects the script only once', () => {
+    initGoogleAds(CONVERSION_ID);
+    initGoogleAds(OTHER_ID);
+    expect(gtag).toHaveBeenCalledTimes(2);
+    expect(gtag).toHaveBeenLastCalledWith('config', OTHER_ID);
+    expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(1);
+  });
+
+  it('no-ops on a falsy id', () => {
+    initGoogleAds('');
+    initGoogleAds(undefined);
+    expect(gtag).not.toHaveBeenCalled();
+    expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(0);
+  });
+
+  it('no-ops when the index.html gtag stub is absent (env id unset at build)', () => {
+    delete window.gtag;
+    expect(() => initGoogleAds(CONVERSION_ID)).not.toThrow();
+    expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(0);
+  });
+});
+
+describe('trackGoogleConversion', () => {
+  let gtag;
+
+  beforeEach(() => {
+    gtag = vi.fn();
+    window.gtag = gtag;
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+  });
+
+  it('addresses the conversion as {conversionId}/{label}', () => {
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL);
+    expect(gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: `${CONVERSION_ID}/${LEAD_LABEL}`,
+    });
+  });
+
+  it('passes transactionId through as the Google dedup key', () => {
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL, { transactionId: 'evt-abc' });
+    expect(gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: `${CONVERSION_ID}/${LEAD_LABEL}`,
+      transaction_id: 'evt-abc',
+    });
+  });
+
+  it('omits value/currency entirely when no value is given', () => {
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL, { transactionId: 'evt-abc' });
+    const payload = gtag.mock.calls[0][2];
+    expect(payload).not.toHaveProperty('value');
+    expect(payload).not.toHaveProperty('currency');
+  });
+
+  it('omits value when it is not a finite number', () => {
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL, { value: Number.NaN });
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL, { value: '25' });
+    expect(gtag.mock.calls[0][2]).not.toHaveProperty('value');
+    expect(gtag.mock.calls[1][2]).not.toHaveProperty('value');
+  });
+
+  it('includes value with SGD by default when a real value is given', () => {
+    trackGoogleConversion(CONVERSION_ID, LEAD_LABEL, { value: 12.5 });
+    expect(gtag.mock.calls[0][2]).toMatchObject({ value: 12.5, currency: 'SGD' });
+  });
+
+  it('refuses to emit when either half of send_to is missing', () => {
+    trackGoogleConversion(CONVERSION_ID, '');
+    trackGoogleConversion('', LEAD_LABEL);
+    trackGoogleConversion(undefined, undefined);
+    expect(gtag).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the gtag stub is absent', () => {
+    delete window.gtag;
+    expect(() => trackGoogleConversion(CONVERSION_ID, LEAD_LABEL)).not.toThrow();
+  });
+});
+
+describe('trackGoogleLead', () => {
+  let gtag;
+
+  beforeEach(() => {
+    gtag = vi.fn();
+    window.gtag = gtag;
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+  });
+
+  it('fires the conversion with the lead label and dedup id', () => {
+    trackGoogleLead(CONVERSION_ID, LEAD_LABEL, { transactionId: 'lead-1' });
+    expect(gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: `${CONVERSION_ID}/${LEAD_LABEL}`,
+      transaction_id: 'lead-1',
+    });
+  });
+
+  it('stays silent when the lead label is unconfigured', () => {
+    trackGoogleLead(CONVERSION_ID, '', { transactionId: 'lead-1' });
+    expect(gtag).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/pixelIds.test.js
+++ b/src/lib/__tests__/pixelIds.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { resolveMetaPixelId, resolveTikTokPixelId, resolvePixelIds } from '../pixelIds';
+import {
+  resolveMetaPixelId,
+  resolveTikTokPixelId,
+  resolveGoogleAdsConversionId,
+  resolveGoogleAdsLeadLabel,
+  resolvePixelIds,
+} from '../pixelIds';
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -9,36 +15,56 @@ describe('resolvePixelIds', () => {
   it('prefers the per-campaign override over the build env id', () => {
     vi.stubEnv('VITE_META_PIXEL_ID', 'env-meta');
     vi.stubEnv('VITE_TIKTOK_PIXEL_ID', 'env-tiktok');
-    const campaign = { metaPixelId: 'camp-meta', tiktokPixelId: 'camp-tiktok' };
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', 'env-google');
+    const campaign = {
+      metaPixelId: 'camp-meta',
+      tiktokPixelId: 'camp-tiktok',
+      googleAdsConversionId: 'camp-google',
+    };
     expect(resolvePixelIds(campaign)).toEqual({
       metaPixelId: 'camp-meta',
       tiktokPixelId: 'camp-tiktok',
+      googleAdsConversionId: 'camp-google',
     });
   });
 
   it('falls back to the env id when the campaign has no override', () => {
     vi.stubEnv('VITE_META_PIXEL_ID', 'env-meta');
     vi.stubEnv('VITE_TIKTOK_PIXEL_ID', 'env-tiktok');
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', 'env-google');
+    vi.stubEnv('VITE_GOOGLE_ADS_LEAD_LABEL', 'env-label');
     expect(resolveMetaPixelId({})).toBe('env-meta');
     expect(resolveTikTokPixelId({})).toBe('env-tiktok');
+    expect(resolveGoogleAdsConversionId({})).toBe('env-google');
+    expect(resolveGoogleAdsLeadLabel({})).toBe('env-label');
   });
 
   it('resolves each platform independently — one override does not affect the other', () => {
     vi.stubEnv('VITE_META_PIXEL_ID', 'env-meta');
     vi.stubEnv('VITE_TIKTOK_PIXEL_ID', 'env-tiktok');
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', 'env-google');
     const campaign = { metaPixelId: 'camp-meta' };
     expect(resolvePixelIds(campaign)).toEqual({
       metaPixelId: 'camp-meta',
       tiktokPixelId: 'env-tiktok',
+      googleAdsConversionId: 'env-google',
     });
   });
 
   it('returns empty strings (never undefined) when neither source has an id', () => {
     vi.stubEnv('VITE_META_PIXEL_ID', '');
     vi.stubEnv('VITE_TIKTOK_PIXEL_ID', '');
-    expect(resolvePixelIds({})).toEqual({ metaPixelId: '', tiktokPixelId: '' });
+    vi.stubEnv('VITE_GOOGLE_ADS_CONVERSION_ID', '');
+    vi.stubEnv('VITE_GOOGLE_ADS_LEAD_LABEL', '');
+    expect(resolvePixelIds({})).toEqual({
+      metaPixelId: '',
+      tiktokPixelId: '',
+      googleAdsConversionId: '',
+    });
     expect(resolveMetaPixelId(null)).toBe('');
     expect(resolveTikTokPixelId(undefined)).toBe('');
+    expect(resolveGoogleAdsConversionId(null)).toBe('');
+    expect(resolveGoogleAdsLeadLabel(undefined)).toBe('');
   });
 
   it('an override works with no env id at all (the server-side path relies on this)', () => {

--- a/src/lib/googleAds.js
+++ b/src/lib/googleAds.js
@@ -1,0 +1,136 @@
+/**
+ * Google Ads (gtag.js) client utilities — the Google counterpart of
+ * metaPixel.js / tiktokPixel.js for the public lead-capture funnel.
+ *
+ * Google differs from the other two networks in three ways that shape this file:
+ *
+ *   1. There is no "pixel id + event name" pair. A Google conversion is addressed
+ *      by `send_to: "{conversionId}/{label}"`, where the conversion id is the
+ *      account-level `AW-XXXXXXXXX` and the label is minted per conversion ACTION
+ *      in the Google Ads UI. Both halves are required — a conversion fired without
+ *      its label is silently discarded by Google, not attributed to the account.
+ *   2. `gtag('config', id)` sends its own page_view, so there is no separate
+ *      ViewContent call. Configuring the id IS the view event. It is still routed
+ *      through the shared session guard so offer → flow navigation configures once.
+ *   3. Dedup uses `transaction_id`, not a per-event id parameter. We pass the SAME
+ *      stable event id the Meta/TikTok calls already use, so all three networks
+ *      dedup on one value and the funnel stays comparable across platforms.
+ *
+ * The gtag/dataLayer stub lives in index.html, gated on
+ * VITE_GOOGLE_ADS_CONVERSION_ID, and defines the queue ONLY — it neither injects
+ * gtag.js nor calls `config`. initGoogleAds() does both, and is invoked only after
+ * shouldTrackGoogle passes, so the SDK never loads on admin/preview surfaces
+ * (mirrors how tiktokPixel defers `ttq.load()` to React).
+ *
+ * Suppression rules — see shouldTrackGoogle; identical page/preview/test-data
+ * gating as Meta and TikTok via the shared isTrackableLeadCapture predicate.
+ *
+ * NO CLICK-ID CAPTURE HERE, deliberately. Meta and TikTok need `captureFbcFromUrl`
+ * / `captureTtclidFromUrl` because their SERVER-side counterparts (CAPI, Events
+ * API) must be handed the click id explicitly. gtag.js reads `gclid`/`gbraid`/
+ * `wbraid` off the landing URL itself and persists them in its own first-party
+ * `_gcl_aw` cookie, so browser-side attribution already works with nothing extra.
+ * A parallel capture would only serve a future offline-conversion upload — and
+ * Google rejects offline conversions for clicks older than 90 days, so there is
+ * no click history worth banking in advance. Add capture WITH that upload, not
+ * before it.
+ *
+ * Also not handled here: Enhanced Conversions for Leads (needs hashed PII wired
+ * through the submit) and the offline outcome upload itself, which belongs with
+ * the backend lead-outcome path rather than in a browser tag.
+ *
+ * All functions are SSR-safe (defensive against missing window/document).
+ */
+import { isTrackableLeadCapture } from './pixelSuppression';
+
+const configuredIds = new Set();
+let sdkInjected = false;
+
+/**
+ * `conversionId` is the CALLER-RESOLVED id for this campaign (see lib/pixelIds.js)
+ * — pass it so a per-campaign override is honoured instead of being vetoed by the
+ * build env var. Omitted → falls back to the env id (matches Meta/TikTok).
+ */
+export function shouldTrackGoogle({ campaign, pathname, search, conversionId } = {}) {
+  const resolvedId = conversionId ?? import.meta.env.VITE_GOOGLE_ADS_CONVERSION_ID;
+  if (!resolvedId) return false;
+  // Google has no test-event-code equivalent, so dev firing needs an explicit
+  // opt-in flag rather than a code. Same intent as VITE_META_TEST_EVENT_CODE:
+  // keep dev traffic out of production conversion stats.
+  if (!import.meta.env.PROD && !import.meta.env.VITE_GOOGLE_ADS_DEV_MODE) return false;
+  // Shared page/preview/test-data suppression (kept in lock-step with Meta/TikTok).
+  return isTrackableLeadCapture({ campaign, pathname, search });
+}
+
+/**
+ * Inject gtag.js and configure the conversion id. Idempotent per id; the script
+ * tag itself is injected at most once per page regardless of how many ids are
+ * configured (gtag multiplexes internally).
+ *
+ * Only called after shouldTrackGoogle passes, so the SDK never loads on
+ * admin/preview pages. The `config` call emits Google's page_view — that is the
+ * view event for this network, which is why there is no separate view function.
+ */
+export function initGoogleAds(conversionId) {
+  if (!conversionId) return;
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  if (configuredIds.has(conversionId)) return;
+
+  if (!sdkInjected) {
+    if (typeof document === 'undefined') return;
+    try {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(conversionId)}`;
+      const first = document.getElementsByTagName('script')[0];
+      if (first && first.parentNode) first.parentNode.insertBefore(script, first);
+      else document.head.appendChild(script);
+      sdkInjected = true;
+    } catch {
+      return;
+    }
+  }
+
+  window.gtag('config', conversionId);
+  configuredIds.add(conversionId);
+}
+
+/**
+ * Fire a Google Ads conversion.
+ *
+ * Both `conversionId` and `label` are required — `send_to` is meaningless
+ * without the pair, and Google drops a malformed one silently rather than
+ * erroring, so we refuse to emit it instead of shipping an invisible no-op.
+ *
+ * `transactionId` becomes Google's dedup key. Pass the same stable event id used
+ * for the Meta/TikTok events so a retried submit cannot double-count.
+ */
+export function trackGoogleConversion(conversionId, label, { value, currency = 'SGD', transactionId } = {}) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  if (!conversionId || !label) return;
+
+  const payload = { send_to: `${conversionId}/${label}` };
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    payload.value = value;
+    payload.currency = currency;
+  }
+  if (transactionId) payload.transaction_id = transactionId;
+
+  window.gtag('event', 'conversion', payload);
+}
+
+/**
+ * The funnel's single conversion action: a completed signup. In the marketplace
+ * flow this point is reached only AFTER phone OTP verification, so it is already
+ * a phone-verified lead — the strongest signal available to bid on without the
+ * offline-outcome upload.
+ */
+export function trackGoogleLead(conversionId, label, opts = {}) {
+  trackGoogleConversion(conversionId, label, opts);
+}
+
+/** Test seam — resets the module-level idempotency state. */
+export function __resetGoogleAdsStateForTests() {
+  configuredIds.clear();
+  sdkInjected = false;
+}

--- a/src/lib/pixelIds.js
+++ b/src/lib/pixelIds.js
@@ -26,10 +26,30 @@ export function resolveTikTokPixelId(campaign) {
   return campaign?.tiktokPixelId || import.meta.env.VITE_TIKTOK_PIXEL_ID || '';
 }
 
-/** Both ids for a campaign: `{ metaPixelId, tiktokPixelId }`. */
+/**
+ * Google's account-level conversion id (`AW-XXXXXXXXX`). The per-campaign
+ * override is read the same way as the other two platforms even though no
+ * `googleAdsConversionId` column exists yet — a campaign simply never carries
+ * one today, and adding the column later needs no change here.
+ */
+export function resolveGoogleAdsConversionId(campaign) {
+  return campaign?.googleAdsConversionId || import.meta.env.VITE_GOOGLE_ADS_CONVERSION_ID || '';
+}
+
+/**
+ * The conversion ACTION label that pairs with the id above (see googleAds.js —
+ * `send_to` needs both halves). Account-level like the id; a campaign override
+ * would let one campaign report into its own conversion action.
+ */
+export function resolveGoogleAdsLeadLabel(campaign) {
+  return campaign?.googleAdsLeadLabel || import.meta.env.VITE_GOOGLE_ADS_LEAD_LABEL || '';
+}
+
+/** Every platform id for a campaign. */
 export function resolvePixelIds(campaign) {
   return {
     metaPixelId: resolveMetaPixelId(campaign),
     tiktokPixelId: resolveTikTokPixelId(campaign),
+    googleAdsConversionId: resolveGoogleAdsConversionId(campaign),
   };
 }

--- a/src/lib/pixelSession.js
+++ b/src/lib/pixelSession.js
@@ -47,25 +47,35 @@ function writeState(campaignId, state) {
 
 /** Get (or mint) the campaign's ViewContent state for this session. */
 export function getOrCreateVcState(campaignId) {
-  if (!campaignId) return { eventId: generateEventId(), firedMeta: false, firedTiktok: false };
+  if (!campaignId) {
+    return { eventId: generateEventId(), firedMeta: false, firedTiktok: false, firedGoogle: false };
+  }
   const existing = readState(campaignId);
   if (existing) {
     return {
       eventId: existing.eventId,
       firedMeta: existing.firedMeta === true,
       firedTiktok: existing.firedTiktok === true,
+      firedGoogle: existing.firedGoogle === true,
     };
   }
-  const fresh = { eventId: generateEventId(), firedMeta: false, firedTiktok: false };
+  const fresh = { eventId: generateEventId(), firedMeta: false, firedTiktok: false, firedGoogle: false };
   writeState(campaignId, fresh);
   return fresh;
 }
 
-/** Record that a platform's ViewContent fired for this campaign this session. */
+/**
+ * Record that a platform's ViewContent fired for this campaign this session.
+ *
+ * Google has no explicit ViewContent call — `gtag('config')` emits its own
+ * page_view — so 'google' marks that the id has been CONFIGURED, which is the
+ * same once-per-session guarantee expressed in that network's terms.
+ */
 export function markVcFired(campaignId, platform) {
   if (!campaignId) return;
   const state = getOrCreateVcState(campaignId);
   if (platform === 'meta') state.firedMeta = true;
   if (platform === 'tiktok') state.firedTiktok = true;
+  if (platform === 'google') state.firedGoogle = true;
   writeState(campaignId, state);
 }

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -41,7 +41,11 @@ import {
   trackTikTokLead,
 } from '../lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '../lib/pixelSession';
-import { resolveMetaPixelId, resolveTikTokPixelId } from '../lib/pixelIds';
+import {
+  resolveMetaPixelId, resolveTikTokPixelId,
+  resolveGoogleAdsConversionId, resolveGoogleAdsLeadLabel,
+} from '../lib/pixelIds';
+import { shouldTrackGoogle, initGoogleAds, trackGoogleLead } from '../lib/googleAds';
 import { trackFunnelEvent } from '../lib/pixelCustom';
 
 export default function LeadCapture() {
@@ -143,6 +147,17 @@ export default function LeadCapture() {
         );
         ttViewContentFiredRef.current = true;
         markVcFired(campaign.id, 'tiktok');
+      }
+    }
+
+    // Google: gtag('config') emits its own page_view, so configuring the id here
+    // IS this network's view event. No local fired-ref — initGoogleAds is
+    // idempotent per id on its own, unlike initPixel + a separate trackEvent.
+    const googleId = resolveGoogleAdsConversionId(campaign);
+    if (!vc.firedGoogle && shouldTrackGoogle({ ...trackCtx, conversionId: googleId })) {
+      if (googleId) {
+        initGoogleAds(googleId);
+        markVcFired(campaign.id, 'google');
       }
     }
   }, [campaign, location.pathname, location.search]);
@@ -404,6 +419,15 @@ export default function LeadCapture() {
               leadEventIdRef.current
             );
           }
+        }
+        // Same no-value rule as Meta above: Google would otherwise record every
+        // lead at a fixed price and skew Smart Bidding the same way.
+        const googleId = resolveGoogleAdsConversionId(campaign);
+        if (shouldTrackGoogle({ ...trackCtx, conversionId: googleId })) {
+          initGoogleAds(googleId);
+          trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
+            transactionId: leadEventIdRef.current,
+          });
         }
         setSubmitted(true);
         setShareOpen(true);

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -16,7 +16,11 @@ import {
   shouldTrack, generateEventId, captureFbcFromUrl, captureUtmsFromUrl,
   readFbc, readFbp, readUtms, ensureFbp, initPixel, trackEvent, trackLead,
 } from '@/lib/metaPixel';
-import { resolveMetaPixelId, resolveTikTokPixelId } from '@/lib/pixelIds';
+import {
+  resolveMetaPixelId, resolveTikTokPixelId,
+  resolveGoogleAdsConversionId, resolveGoogleAdsLeadLabel,
+} from '@/lib/pixelIds';
+import { shouldTrackGoogle, initGoogleAds, trackGoogleLead } from '@/lib/googleAds';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 import {
   shouldTrackTikTok, captureTtclidFromUrl, readTtclid, readTtp,
@@ -174,6 +178,16 @@ export default function MarketplaceFlow() {
         initTikTokPixel(ttPixelId);
         trackTikTokViewContent({ content_name: listingTitleOf(campaign), content_type: 'marketplace' }, vc.eventId);
         markVcFired(campaign.id, 'tiktok');
+      }
+    }
+    // Google has no explicit ViewContent — gtag('config') emits its own
+    // page_view — so configuring the id here IS this network's view event, and
+    // it takes the same once-per-session guard as the other two.
+    const googleId = resolveGoogleAdsConversionId(campaign);
+    if (!vc.firedGoogle && shouldTrackGoogle({ ...trackCtx, conversionId: googleId })) {
+      if (googleId) {
+        initGoogleAds(googleId);
+        markVcFired(campaign.id, 'google');
       }
     }
   }, [campaign]);
@@ -390,6 +404,18 @@ export default function MarketplaceFlow() {
         }
         if (shouldTrackTikTok({ ...trackCtx, pixelId: resolveTikTokPixelId(campaign) })) {
           trackTikTokLead({ content_name: listingTitleOf(campaign) }, leadEventIdRef.current);
+        }
+        const googleId = resolveGoogleAdsConversionId(campaign);
+        if (shouldTrackGoogle({ ...trackCtx, conversionId: googleId })) {
+          // init before firing, not just in the view effect: a full document load
+          // straight onto /flow with firedGoogle already set (offer page earlier in
+          // the same tab) skips that effect, and a conversion sent to an
+          // unconfigured id is dropped. initGoogleAds is idempotent, so this is
+          // free when the view effect already ran.
+          initGoogleAds(googleId);
+          trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
+            transactionId: leadEventIdRef.current,
+          });
         }
         if (isDraw) trackCustom('draw_entry_confirmed');
         setResult({

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -9,7 +9,8 @@ import { composeValueLine, ageLabelOf, fmtDateLong, categoryLabel, isDrawCampaig
 import { shouldTrack, initPixel, ensureFbp, trackEvent, captureFbcFromUrl, captureUtmsFromUrl } from '@/lib/metaPixel';
 import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtclidFromUrl } from '@/lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
-import { resolveMetaPixelId, resolveTikTokPixelId } from '@/lib/pixelIds';
+import { resolveMetaPixelId, resolveTikTokPixelId, resolveGoogleAdsConversionId } from '@/lib/pixelIds';
+import { shouldTrackGoogle, initGoogleAds } from '@/lib/googleAds';
 
 /**
  * Offer detail (/offers/:slug) — the FIRST public content surface for
@@ -77,6 +78,15 @@ export default function MarketplaceOffer() {
           vc.eventId
         );
         markVcFired(campaign.id, 'tiktok');
+      }
+    }
+    // Google: gtag('config') emits its own page_view, so configuring here is the
+    // view event — no separate ViewContent call, same once-per-session guard.
+    const googleId = resolveGoogleAdsConversionId(campaign);
+    if (!vc.firedGoogle && shouldTrackGoogle({ ...trackCtx, conversionId: googleId })) {
+      if (googleId) {
+        initGoogleAds(googleId);
+        markVcFired(campaign.id, 'google');
       }
     }
   }, [campaign]);


### PR DESCRIPTION
## Why

Google Ads is being added as a third paid channel (SG new-advertiser promo: spend S$600 in 60 days → S$600 credit), pointed at the Tokyo Getaway draw via Demand Gen. This PR is the browser conversion tag only — the "just enough" tier to start spending with conversion-based bidding.

## What

- **`src/lib/googleAds.js`** (new) — mirrors `metaPixel.js`/`tiktokPixel.js`. Google quirks encoded: conversions addressed as `send_to: "{AW-id}/{label}"` (both halves required; the lib refuses to emit a half-configured conversion instead of shipping Google's silent-discard), `gtag('config')` doubles as the view event, dedup via `transaction_id` fed the same stable event id Meta/TikTok already use.
- **`index.html`** — dataLayer/gtag queue stub gated on `VITE_GOOGLE_ADS_CONVERSION_ID`, same `charAt(0)==='%'` unset-guard as the other two stubs. The SDK itself is injected lazily from React only after `shouldTrackGoogle` passes — never on admin/preview surfaces.
- **Wiring** — `MarketplaceOffer` (config = view), `MarketplaceFlow` + `LeadCapture` (config + Lead at successful `/prospects` submit). No value/currency, same desync rationale as the existing Meta note in `LeadCapture.jsx`.
- **`pixelIds.js`** — `resolveGoogleAdsConversionId` / `resolveGoogleAdsLeadLabel` (campaign override first, env fallback; no DB column yet so env-only today). `pixelSession.js` — `firedGoogle` joins the `vc:{campaignId}` guard.
- **Docs** — `ads-and-tracking.md` Google section, CLAUDE.md one-line summary, `.env.example` var docs.

## Deliberately NOT built

No gclid/gbraid/wbraid capture (gtag's `_gcl_aw` first-party cookie covers browser attribution; Google rejects offline conversions for clicks >90 days old, so there's no history worth banking before the upload exists), no Enhanced Conversions, no server-side events. Upgrade path documented — hangs off `POST /api/integrations/lyfe/lead-outcome` like Meta's down-funnel events.

## Safe to merge now

**Ships dark.** The Google Ads account doesn't exist yet, so both env vars are unset on every build — the stub no-ops, `shouldTrackGoogle` returns false, zero behaviour change. Flipping `VITE_GOOGLE_ADS_CONVERSION_ID` + `VITE_GOOGLE_ADS_LEAD_LABEL` on the static sites lights it up later.

## Tested

- 1918 vitest green on top of latest main, `eslint src/ --quiet` clean
- Prod build verified: unset var leaves the guarded `%VITE_%` placeholder (no broken tag on hosts without the env)
- Backend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HevYE2pAzYJq7yPNfBxk5g