### PR TITLE
feat(redeem): rebuild /winners on the marketplace v2 system

### DIFF
--- a/src/pages/RedeemWinners.jsx
+++ b/src/pages/RedeemWinners.jsx
@@ -1,181 +1,355 @@
-import { useEffect } from 'react';
-import { brand } from '@/lib/brand';
-import { WINNERS } from './redeemWinnersContent';
-import './redeemHome.css';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import MarketplaceLayout from './marketplace/MarketplaceLayout';
+import OfferCard from './marketplace/OfferCard';
+import { fmtDateLong, isDrawCampaign, offerUnavailability } from './marketplace/content';
+import { listMarketplaceCampaigns } from '@/api/marketplace';
+import { listingTitleOf } from '@/lib/listingDerivation';
+import { WINNERS, statusLabel } from './redeemWinnersContent';
 import './redeemWinners.css';
 
 /**
- * redeem.sg/winners — lucky-draw results wall (redeem build only).
- * Winners are posted by editing redeemWinnersContent.js (photos in
- * public/winners/). Empty list → honest "first draw is loading" state.
- * Identities arrive pre-masked in the config (PDPA — see that file's header).
+ * redeem.sg/winners — published lucky-draw results (redeem build only).
+ *
+ * Three data sources, deliberately separate:
+ *  - the results board reads redeemWinnersContent.js (hand-posted, arrives
+ *    pre-masked under PDPA — see that file's header);
+ *  - the countdown and the "still open" grid read the live marketplace list,
+ *    so a closed draw drops off both without anyone editing this page;
+ *  - everything else is static copy.
+ *
+ * The route is cited in draw T&Cs (drawTermsTemplate.js) — it must never 404
+ * on the redeem build, so every section degrades to an honest empty state
+ * rather than hiding the page.
  */
 
-const PANELS = ['rhw-card__ph--lime', 'rhw-card__ph--pink', 'rhw-card__ph--violet'];
+/** Entry cutoff is the SGT day-end of closesAt, exclusive — the same contract
+ *  offerUnavailability() and the backend intake gate enforce. */
+const SGT_DAY_END = 'T23:59:59.999+08:00';
 
-function Photo({ w, tall }) {
-  if (w.photo) {
-    return <img src={w.photo} alt={`${w.name} — ${w.prize}`} loading={tall ? undefined : 'lazy'} />;
+function drawClosesMs(campaign) {
+  const closesAt = campaign?.design_config?.luckyDraw?.closesAt;
+  if (!closesAt) return null;
+  const ms = new Date(`${closesAt}${SGT_DAY_END}`).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/** Headline prize for the countdown card — the top prize row, else the listing title. */
+function prizeLabelOf(campaign) {
+  const rows = campaign?.design_config?.prize_breakdown;
+  const top = Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+  if (top?.name) return top.qty > 1 ? `${top.qty}× ${top.name}` : top.name;
+  return listingTitleOf(campaign);
+}
+
+const pad2 = (n) => String(Math.max(0, n)).padStart(2, '0');
+
+/**
+ * Live marketplace list, narrowed to draws that can still be entered.
+ * Kept local rather than importing MarketplaceBrowse's hook so this lazy chunk
+ * doesn't drag the browse surfaces in with it. null = still loading.
+ */
+function useOpenDraws() {
+  const [campaigns, setCampaigns] = useState(null);
+  useEffect(() => {
+    let alive = true;
+    listMarketplaceCampaigns()
+      .then((cs) => alive && setCampaigns(cs))
+      .catch(() => alive && setCampaigns([]));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return useMemo(() => {
+    if (campaigns === null) return null;
+    return campaigns
+      .filter((c) => isDrawCampaign(c) && offerUnavailability(c) === null && drawClosesMs(c) !== null)
+      .sort((a, b) => drawClosesMs(a) - drawClosesMs(b));
+  }, [campaigns]);
+}
+
+/** dd/hh/mm/ss remaining until `closesMs`, re-rendered once a second. */
+function useCountdown(closesMs) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!closesMs) return undefined;
+    setNow(Date.now());
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [closesMs]);
+
+  const left = closesMs ? Math.max(0, closesMs - now) : 0;
+  return {
+    dd: pad2(Math.floor(left / 86400000)),
+    hh: pad2(Math.floor((left % 86400000) / 3600000)),
+    mm: pad2(Math.floor((left % 3600000) / 60000)),
+    ss: pad2(Math.floor((left % 60000) / 1000)),
+  };
+}
+
+function NextDrawCard({ draws }) {
+  const next = draws && draws.length > 0 ? draws[0] : null;
+  const { dd, hh, mm, ss } = useCountdown(next ? drawClosesMs(next) : null);
+
+  if (draws === null) {
+    return <div className="rm-shimmer" style={{ height: 300 }} />;
   }
-  const pending = w.status === 'pending';
+
+  if (!next) {
+    return (
+      <div className="rw-next">
+        <div className="rw-next-head">
+          <span className="rm-mono-label" style={{ fontSize: 10.5 }}>Next draw</span>
+          <span className="rw-next-pill" style={{ color: 'var(--rm-mut)', background: 'var(--rm-tint)', borderColor: 'var(--rm-line2)' }}>
+            None open
+          </span>
+        </div>
+        <p className="rw-next-body">
+          No draw is taking entries at the moment. New ones open most weeks — every result still
+          lands on this page when it closes.
+        </p>
+        <Link className="rm-btn rw-next-cta" to="/explore">Explore offers</Link>
+        <div className="rw-next-foot">Free · one entry per verified person</div>
+      </div>
+    );
+  }
+
+  const cells = [[dd, 'Days'], [hh, 'Hrs'], [mm, 'Min'], [ss, 'Sec']];
+
   return (
-    <>
-      <span className="rhw-avatar">{pending ? '?' : (w.name || '?').charAt(0)}</span>
-      <span className="rhw-flag">{pending ? 'Winner contacted' : 'No photo — winner’s choice'}</span>
-    </>
+    <div className="rw-next">
+      <div className="rw-next-head">
+        <span className="rm-mono-label" style={{ fontSize: 10.5 }}>Next draw closes in</span>
+        <span className="rw-next-pill">Open</span>
+      </div>
+      <div className="rw-clock" role="timer" aria-label={`Entries close in ${dd} days, ${hh} hours, ${mm} minutes`}>
+        {cells.map(([value, unit]) => (
+          <div className="rw-clock-cell" key={unit}>
+            <div className="rw-clock-num">{value}</div>
+            <div className="rw-clock-unit">{unit}</div>
+          </div>
+        ))}
+      </div>
+      <div className="rw-next-prize">{prizeLabelOf(next)}</div>
+      <div className="rw-next-when">
+        Entries close {fmtDateLong(next.design_config.luckyDraw.closesAt)} · 23:59 SGT
+      </div>
+      <Link className="rm-btn rm-btn--apricot rw-next-cta" to={`/offers/${next.slug}`}>Enter this draw</Link>
+      <div className="rw-next-foot">Free · one entry per verified person</div>
+    </div>
+  );
+}
+
+/** Photo when the winner gave written permission, else the striped arch panel. */
+function ResultPanel({ winner }) {
+  const caption = winner.photo
+    ? winner.photoCaption || 'Photo shared with permission'
+    : winner.archTag || 'result posted';
+  return (
+    <div className="rw-arch">
+      {winner.photo && <img src={winner.photo} alt={`${winner.name || 'Winner'} — ${winner.prize}`} />}
+      <span className="rm-arch-tag">{caption}</span>
+    </div>
   );
 }
 
 export default function RedeemWinners() {
   useEffect(() => {
-    document.title = 'Redeem — Winners’ wall';
+    document.title = 'Redeem — Lucky-draw winners';
     const meta = document.querySelector('meta[name="description"]');
     if (meta) {
       meta.setAttribute(
         'content',
-        'Every Redeem lucky draw ends here — the prize, the draw date, and the winner. A service of MKTR PTE. LTD.'
+        'Every Redeem lucky draw ends here — the prize, the date it was drawn, and the winner’s masked details. A service of MKTR PTE. LTD.'
       );
     }
   }, []);
 
+  const openDraws = useOpenDraws();
   const [latest, ...past] = WINNERS;
 
   return (
-    <div className="rh-page">
-      <nav className="rh-nav" aria-label="Main">
-        <div className="rh-wrap rh-nav__inner">
-          <a className="rh-logo" href="/"><span className="rh-logo__spark">✷</span>REDEEM</a>
-          <div className="rh-nav__links">
-            <a href="/#how">How it works</a>
-            <a href="/#drops">Drops</a>
-            <a href="/winners" style={{ opacity: 1, borderBottom: '3px solid var(--rh-lime-deep)', paddingBottom: 4 }}>Winners</a>
-            <a href="/#faq">FAQ</a>
+    <MarketplaceLayout>
+      <section className="rw-cover">
+        <div className="rm-shell" style={{ paddingTop: 'clamp(44px,5.5vw,78px)', paddingBottom: 'clamp(40px,5vw,66px)' }}>
+          <div className="rw-cover-kicker">
+            <span className="rm-ticket rm-ticket--apr" style={{ flexShrink: 0, marginTop: 2 }} />
+            Lucky draws · published results
           </div>
-          <div className="rh-nav__right">
-            <a className="rh-btn rh-btn--lime rh-btn--sm" href="/#drops">What’s dropping</a>
-          </div>
-        </div>
-      </nav>
-
-      <header className="rhw-head">
-        <div className="rh-wrap">
-          <span className="rh-kicker">Lucky draws · results</span>
-          <h1 className="rh-h1" style={{ fontSize: 84 }}>
-            Winners’<br />
-            <span className="rh-h1__hollow">wall</span> <span className="rh-h1__tilt">of fame.</span>
-          </h1>
-          <p className="rh-hero__sub">
-            Every lucky draw we run ends here — the prize, the draw date, and the person who took
-            it home. If your number was drawn, this is where you’ll see it.
-          </p>
-          <div className="rh-rule">🔒 Winners are contacted directly.</div>
-        </div>
-      </header>
-
-      {latest ? (
-        <div className="rh-wrap">
-          <section className="rhw-feature">
+          <div className="rw-cover-grid">
             <div>
-              <span className="rh-kicker">Latest draw · {latest.draw}</span>
-              <h2>{latest.prize}</h2>
-              {latest.prizeMeta && <p className="rhw-feature__meta">{latest.prizeMeta}</p>}
-              <div className="rhw-wtag">
-                🎉{' '}
-                <div>
-                  {latest.status === 'pending' ? 'Drawn — awaiting claim' : latest.name}
-                  <small>
-                    entry {latest.entry}
-                    {latest.area ? ` · ${latest.area}` : ''}
-                  </small>
-                </div>
-              </div>
-              <div className="rhw-chips">
-                {latest.drawnOn && <span className="rhw-chip">Drawn {latest.drawnOn}</span>}
-                <span className="rhw-chip">Witnessed draw</span>
-                {latest.status === 'pending'
-                  ? <span className="rhw-chip">14 days to claim</span>
-                  : <span className="rhw-chip rhw-chip--lime">Claimed ✓</span>}
-              </div>
+              <h1 className="rw-h1">Every draw <em>ends</em> on this page.</h1>
+              <p className="rw-lede">
+                When a Redeem lucky draw closes, the result is posted here — the prize, the date it
+                was drawn, and the winner’s partially masked details.{' '}
+                <strong>Winners are contacted directly by phone or SMS.</strong> There is never a fee
+                to claim.
+              </p>
             </div>
-            <div className="rhw-pol">
-              <div className="rhw-tape" />
-              <div className="rhw-stamp">Winner</div>
-              <div className="rhw-pol__ph"><Photo w={latest} tall /></div>
-              <div className="rhw-pol__cap">
-                {latest.photo ? (latest.photoCaption || `${latest.name} takes it home`) : latest.name || 'Awaiting claim'}
-                {latest.photo && <small>Photo shared with permission</small>}
-              </div>
-            </div>
-          </section>
-        </div>
-      ) : (
-        <div className="rh-wrap">
-          <div className="rhw-empty">
-            <h3>The first draw is loading.</h3>
-            <p>
-              No draws have concluded yet. When one does, the result lands here — the prize, the
-              draw date, and the winner. Claiming an eligible drop is your entry.
-            </p>
+            <NextDrawCard draws={openDraws} />
           </div>
-        </div>
-      )}
-
-      {past.length > 0 && (
-        <section className="rh-section" style={{ paddingTop: 0 }}>
-          <div className="rh-wrap">
-            <span className="rh-kicker">Past draws</span>
-            <h3 className="rh-h2" style={{ fontSize: 34 }}>Every draw. Every winner.</h3>
-            <div className="rhw-grid">
-              {past.map((w, i) => (
-                <article className="rhw-card" key={`${w.draw}-${w.entry}`}>
-                  <div className="rhw-card__top"><span>{w.draw}</span><span className="rhw-bar" /></div>
-                  <div className={`rhw-card__ph ${w.status === 'pending' ? 'rhw-card__ph--stone' : PANELS[i % PANELS.length]}`}>
-                    <Photo w={w} />
-                  </div>
-                  <div className="rhw-card__bd">
-                    <div className="rhw-who">
-                      {w.status === 'pending' ? 'Drawn — awaiting claim' : w.name}
-                      <small>
-                        entry {w.entry}
-                        {w.status === 'pending' ? ' · 14 days to claim' : w.area ? ` · ${w.area}` : ''}
-                      </small>
-                    </div>
-                    <div className="rhw-prz">
-                      <span>{w.prize}</span>
-                      {w.status === 'pending'
-                        ? <span className="rhw-pend">Pending…</span>
-                        : <span className="rhw-ok">Claimed ✓</span>}
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      <section className="rhw-how">
-        <div className="rh-wrap">
-          <span className="rh-kicker">How draws work</span>
-          <h3>Fair, drawn, posted.</h3>
-          <div className="rhw-steps">
-            <div className="rhw-st"><b>01 — ENTER</b><p>Claiming an eligible drop is your entry. One entry per verified person.</p></div>
-            <div className="rhw-st"><b>02 — DRAWN</b><p>Winner picked at random after the end date, witnessed by MKTR staff.</p></div>
-            <div className="rhw-st"><b>03 — CONTACTED</b><p>We call or SMS the winner directly. 14 days to claim, or we redraw.</p></div>
-            <div className="rhw-st"><b>04 — POSTED</b><p>The result lands on this wall — masked entry number, and a photo if the winner’s happy to share.</p></div>
-          </div>
-          <div className="rhw-scam">🔒 Anyone asking you for a “release fee” is a scammer. Report them to us.</div>
         </div>
       </section>
 
-      <footer className="rh-footer" style={{ marginTop: 0 }}>
-        <div className="rh-wrap">
-          <div className="rh-footer__legal" style={{ marginTop: 0, paddingTop: 0, borderTop: 'none' }}>
-            <span>{brand.consumerLine} · UEN {brand.uen} · Singapore</span>
-            <span>© {new Date().getFullYear()} {brand.legalName}</span>
+      <section className="rm-shell" style={{ paddingTop: 'clamp(40px,5vw,72px)', paddingBottom: 'clamp(20px,3vw,32px)' }}>
+        <div className="rw-boardhead">
+          <div>
+            <div className="rm-mono-label">The results board</div>
+            <h2 className="rw-h2">Every draw, posted in full.</h2>
+          </div>
+          <div className="rw-boardnote">
+            Names and numbers are partially masked under PDPA — enough to recognise your own, not
+            enough to identify anyone else.
           </div>
         </div>
-      </footer>
-    </div>
+
+        {!latest ? (
+          <div className="rw-empty">
+            <span className="rm-ticket rw-door-sage" style={{ flexShrink: 0, marginTop: 3 }} />
+            <div>
+              <div className="rm-mono-label">No results yet</div>
+              <p style={{ margin: '8px 0 0', fontSize: 14.5, lineHeight: 1.65, color: 'var(--rm-sub)', maxWidth: '52ch' }}>
+                No draw has closed yet. The first result will be posted here the week it is drawn.
+                Entering an open draw is how you get on this board.
+              </p>
+              <a href="#open" className="rm-underline" style={{ display: 'inline-flex', alignItems: 'center', gap: 7, marginTop: 14, fontSize: 13.5, fontWeight: 600 }}>
+                See what’s open now →
+              </a>
+            </div>
+          </div>
+        ) : (
+          <>
+            <article className="rw-feature">
+              <div>
+                <div className="rm-mono-label" style={{ color: 'var(--rm-pine)' }}>Latest result · {latest.draw}</div>
+                <h3 className="rw-feature-title">{latest.prize}</h3>
+                {latest.prizeMeta && (
+                  <p style={{ margin: '8px 0 0', fontSize: 13.5, lineHeight: 1.6, color: 'var(--rm-sub)', maxWidth: '50ch' }}>
+                    {latest.prizeMeta}
+                  </p>
+                )}
+
+                <div className="rw-winner">
+                  <div>
+                    <div className="rw-winner-key">Winner</div>
+                    <div className="rw-winner-name">{latest.name || 'Awaiting claim'}</div>
+                  </div>
+                  {latest.entry && (
+                    <>
+                      <div className="rw-winner-sep" />
+                      <div>
+                        <div className="rw-winner-key">Entry</div>
+                        <div className="rw-winner-entry">{latest.entry}</div>
+                      </div>
+                    </>
+                  )}
+                  {latest.area && (
+                    <>
+                      <div className="rw-winner-sep" />
+                      <div>
+                        <div className="rw-winner-key">Area</div>
+                        <div className="rw-winner-area">{latest.area}</div>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="rw-tags">
+                  {latest.drawnOn && <span className="rw-tag">Drawn {latest.drawnOn}</span>}
+                  <span className="rw-tag">Witnessed by MKTR staff</span>
+                  <span className="rw-tag rw-tag--status">{statusLabel(latest.status)}</span>
+                </div>
+              </div>
+
+              <ResultPanel winner={latest} />
+            </article>
+
+            {past.length > 0 && (
+              <div style={{ marginTop: 'clamp(28px,3.5vw,44px)' }}>
+                <div className="rm-mono-label" style={{ marginBottom: 6 }}>Earlier draws</div>
+                <div className="rw-ledger">
+                  <div className="rw-lhead" aria-hidden="true">
+                    <span>Draw</span><span>Prize</span><span>Winner</span><span>Drawn</span><span>Status</span>
+                  </div>
+                  {past.map((w) => (
+                    <div className="rw-lrow" key={`${w.draw}-${w.entry}`}>
+                      <span className="rw-l-draw">{w.draw}</span>
+                      <span className="rw-l-prize">{w.prize}</span>
+                      <span className="rw-l-who">{[w.name, w.entry].filter(Boolean).join(' · ')}</span>
+                      <span className="rw-l-drawn">{w.drawnOn}</span>
+                      <span className="rw-l-status">{statusLabel(w.status)}</span>
+                    </div>
+                  ))}
+                  <div className="rw-lfoot">
+                    Unclaimed after 14 days, a replacement winner is drawn for that prize.
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      <section id="open" className="rm-shell" style={{ paddingTop: 'clamp(30px,4vw,56px)', paddingBottom: 'clamp(28px,4vw,52px)', scrollMarginTop: 80 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 16, flexWrap: 'wrap', marginBottom: 22 }}>
+          <div>
+            <div className="rm-mono-label">Still open</div>
+            <h2 className="rw-h2" style={{ fontSize: 'clamp(24px,3vw,34px)' }}>Draws you can still enter.</h2>
+          </div>
+          <Link to="/explore" className="rm-underline" style={{ fontSize: 14, fontWeight: 600 }}>View all offers →</Link>
+        </div>
+
+        {openDraws === null ? (
+          <div className="rm-grid-cards">
+            {[0, 1, 2].map((i) => <div key={i} className="rm-shimmer" style={{ height: 440 }} />)}
+          </div>
+        ) : openDraws.length === 0 ? (
+          <div className="rm-card" style={{ padding: '32px 28px' }}>
+            <div className="rm-serif" style={{ fontSize: 20 }}>No draw is open right now.</div>
+            <div style={{ fontSize: 14, color: 'var(--rm-sub)', marginTop: 8, maxWidth: '58ch' }}>
+              New draws open most weeks. Every offer on Redeem is worth a look in the meantime.
+            </div>
+            <Link className="rm-btn" to="/explore" style={{ marginTop: 18 }}>Explore offers</Link>
+          </div>
+        ) : (
+          <div className="rm-grid-cards">
+            {openDraws.map((c) => <OfferCard key={c.slug} campaign={c} />)}
+          </div>
+        )}
+      </section>
+
+      <section className="rm-shell" style={{ paddingTop: 'clamp(24px,3vw,40px)', paddingBottom: 'clamp(44px,6vw,80px)' }}>
+        <div className="rw-how">
+          <h2 className="rm-serif" style={{ margin: '0 0 26px', fontSize: 'clamp(22px,2.6vw,30px)' }}>How a Redeem draw is run</h2>
+          <div className="rw-how-grid">
+            {[
+              ['Drawn at random, after close', 'Entries are locked at 23:59 SGT on the closing date. Nothing is drawn early.'],
+              ['Witnessed by MKTR staff', 'The draw is run in a witnessed process and recorded against the campaign’s terms.'],
+              ['Contacted directly, 14 days to claim', 'By phone or SMS on the number you verified. Unclaimed prizes are redrawn.'],
+              ['Published with masked details', 'First name and initial, last digits of the entry number. Photos only with written permission.'],
+            ].map(([title, body]) => (
+              <div className="rw-how-item" key={title}>
+                <span className="rm-ticket rm-ticket--sm" style={{ width: 11, height: 14 }} />
+                <div>
+                  <div className="rw-how-t">{title}</div>
+                  <div className="rw-how-d">{body}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="rw-scam">
+            <span className="rw-scam-door" />
+            <div className="rw-scam-body">
+              <strong>Redeem never asks a winner for money.</strong> No release fee, no admin charge,
+              no bank details, no NRIC. Anyone who does is not us — report it to support@redeem.sg.
+            </div>
+          </div>
+
+          <div className="rw-uen">Redeem is operated by MKTR PTE. LTD. · UEN 202507548M · Singapore</div>
+        </div>
+      </section>
+    </MarketplaceLayout>
   );
 }

--- a/src/pages/__tests__/RedeemWinners.test.jsx
+++ b/src/pages/__tests__/RedeemWinners.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * /winners — the results board reads the hand-posted WINNERS list, while the
+ * countdown and the "still open" grid read the live marketplace list. Each has
+ * to degrade to an honest empty state (the route is cited in draw T&Cs).
+ */
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockWinners = vi.hoisted(() => ({ list: [] }));
+const mockCampaigns = vi.hoisted(() => ({ list: [] }));
+
+vi.mock('../redeemWinnersContent', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, get WINNERS() { return mockWinners.list; } };
+});
+
+vi.mock('@/api/marketplace', () => ({
+  listMarketplaceCampaigns: () => Promise.resolve(mockCampaigns.list),
+}));
+
+const { default: RedeemWinners } = await import('../RedeemWinners');
+
+const drawCampaign = (over = {}) => ({
+  slug: over.slug || 'pottery-draw',
+  name: 'Pottery draw',
+  design_config: {
+    name: over.title || 'Weekend pottery for two — plus the draw',
+    luckyDraw: { enabled: true, closesAt: over.closesAt || '2099-08-28' },
+    prize_breakdown: over.prizes ?? [{ qty: 1, name: 'Family staycation for four' }],
+    category: 'family_lifestyle',
+    mode: 'in_person',
+  },
+  ops: { partner: { name: 'Claypool Studio', verified: true }, capacity: { total: 100, remaining: 40 } },
+});
+
+const winner = (over = {}) => ({
+  draw: 'Draw 04',
+  prize: 'Family staycation for four',
+  prizeMeta: 'Two nights, weekend stay',
+  name: 'Sarah T.',
+  entry: '9••• •312',
+  area: 'Bedok',
+  drawnOn: '20 Jul 2026',
+  status: 'claimed',
+  ...over,
+});
+
+const renderPage = async () => {
+  const view = render(
+    <MemoryRouter>
+      <RedeemWinners />
+    </MemoryRouter>
+  );
+  // let the marketplace list promise settle
+  await screen.findByText('Every draw, posted in full.');
+  return view;
+};
+
+afterEach(() => {
+  mockWinners.list = [];
+  mockCampaigns.list = [];
+  vi.useRealTimers();
+});
+
+describe('RedeemWinners — results board', () => {
+  it('shows the empty state, and no ledger, until a draw has closed', async () => {
+    await renderPage();
+    expect(await screen.findByText('No results yet')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier draws')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Latest result/)).not.toBeInTheDocument();
+  });
+
+  it('features the newest winner and lists the rest in the ledger', async () => {
+    mockWinners.list = [
+      winner(),
+      winner({ draw: 'Draw 03', prize: 'Robotics term programme', name: 'Marcus L.', entry: '8••• •907', drawnOn: '28 Jun 2026' }),
+    ];
+    await renderPage();
+
+    expect(screen.getByText('Latest result · Draw 04')).toBeInTheDocument();
+    expect(screen.getByText('Sarah T.')).toBeInTheDocument();
+    expect(screen.getByText('9••• •312')).toBeInTheDocument();
+    expect(screen.getByText('Drawn 20 Jul 2026')).toBeInTheDocument();
+
+    expect(screen.getByText('Earlier draws')).toBeInTheDocument();
+    expect(screen.getByText('Robotics term programme')).toBeInTheDocument();
+    // ledger composes the masked identity from name + entry
+    expect(screen.getByText('Marcus L. · 8••• •907')).toBeInTheDocument();
+    // the featured winner is not repeated in the ledger
+    expect(screen.queryByText('Sarah T. · 9••• •312')).not.toBeInTheDocument();
+  });
+
+  it('hides the ledger when only one draw has ever closed', async () => {
+    mockWinners.list = [winner()];
+    await renderPage();
+    expect(screen.getByText('Latest result · Draw 04')).toBeInTheDocument();
+    expect(screen.queryByText('Earlier draws')).not.toBeInTheDocument();
+  });
+
+  it('labels a contacted-but-unclaimed winner without claiming it is claimed', async () => {
+    mockWinners.list = [winner({ status: 'pending' })];
+    await renderPage();
+    expect(screen.getByText('Contacted')).toBeInTheDocument();
+    expect(screen.queryByText('Claimed')).not.toBeInTheDocument();
+  });
+
+  it('renders the winner photo only when one was supplied', async () => {
+    mockWinners.list = [winner({ photo: '/winners/draw04.jpg', photoCaption: 'Sarah collects her stay' })];
+    const { container } = await renderPage();
+    expect(container.querySelector('.rw-arch img')).toHaveAttribute('src', '/winners/draw04.jpg');
+    expect(screen.getByText('Sarah collects her stay')).toBeInTheDocument();
+  });
+});
+
+describe('RedeemWinners — next-draw countdown', () => {
+  it('counts down to the soonest-closing open draw and links to it', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2099-08-25T12:00:00+08:00'));
+    mockCampaigns.list = [
+      drawCampaign({ slug: 'later', closesAt: '2099-09-12' }),
+      drawCampaign({ slug: 'sooner', closesAt: '2099-08-28', prizes: [{ qty: 2, name: 'Robotics term' }] }),
+    ];
+    await renderPage();
+
+    const timer = await screen.findByRole('timer');
+    // 25 Aug 12:00 SGT → 28 Aug 23:59:59.999 SGT = 3 days, 11 hours
+    expect(within(timer).getByText('03')).toBeInTheDocument();
+    expect(within(timer).getByText('11')).toBeInTheDocument();
+
+    expect(screen.getByText('2× Robotics term')).toBeInTheDocument();
+    expect(screen.getByText('Entries close 28 August 2099 · 23:59 SGT')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Enter this draw' })).toHaveAttribute('href', '/offers/sooner');
+  });
+
+  it('falls back to the listing title when a draw has no prize rows', async () => {
+    mockCampaigns.list = [drawCampaign({ prizes: [] })];
+    const { container } = await renderPage();
+    expect(container.querySelector('.rw-next-prize')).toHaveTextContent('Weekend pottery for two — plus the draw');
+  });
+
+  it('says no draw is open rather than showing a dead countdown', async () => {
+    mockCampaigns.list = [drawCampaign({ closesAt: '2020-01-01' })];
+    await renderPage();
+    expect(await screen.findByText('None open')).toBeInTheDocument();
+    expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+    expect(screen.getByText('No draw is open right now.')).toBeInTheDocument();
+  });
+});
+
+describe('RedeemWinners — still-open grid', () => {
+  it('lists only draws that can still be entered, soonest first', async () => {
+    mockCampaigns.list = [
+      drawCampaign({ slug: 'later', title: 'Later draw', closesAt: '2099-09-12' }),
+      drawCampaign({ slug: 'sooner', title: 'Sooner draw', closesAt: '2099-08-28' }),
+      drawCampaign({ slug: 'closed', title: 'Closed draw', closesAt: '2020-01-01' }),
+    ];
+    await renderPage();
+
+    const cards = document.querySelectorAll('.rm-offercard');
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveTextContent('Sooner draw');
+    expect(cards[1]).toHaveTextContent('Later draw');
+    expect(screen.queryByText('Closed draw')).not.toBeInTheDocument();
+  });
+
+  it('excludes non-draw offers and sold-out draws', async () => {
+    const soldOut = drawCampaign({ slug: 'sold-out', title: 'Sold out draw' });
+    soldOut.ops.capacity = { total: 100, remaining: 0 };
+    const plainOffer = drawCampaign({ slug: 'plain', title: 'Plain offer' });
+    plainOffer.design_config.luckyDraw = { enabled: false };
+
+    mockCampaigns.list = [soldOut, plainOffer];
+    await renderPage();
+
+    expect(document.querySelectorAll('.rm-offercard')).toHaveLength(0);
+    expect(screen.getByText('No draw is open right now.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/redeemWinners.css
+++ b/src/pages/redeemWinners.css
@@ -1,78 +1,95 @@
-/* Winners' wall (/winners) — rhw-* additions on top of the rh-* base
-   (redeemHome.css is imported by the page for tokens, nav, buttons, footer). */
+/* Winners (/winners) — rw-* on the marketplace v2 pine/cream system.
+   MarketplaceLayout supplies .rm-page (tokens, fonts, nav, footer), so this
+   file only carries what the results board adds on top. Cards in the "still
+   open" grid are plain OfferCards — nothing here restyles them. */
 
-.rhw-head { padding: 64px 0 20px; }
+/* ---------- Cover ---------- */
+.rw-cover { background: #132720; color: #f6f2e6; overflow: hidden; }
+.rw-cover-kicker { font-family: var(--rm-mono); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: #a8c3b4; display: flex; align-items: flex-start; gap: 10px; line-height: 1.7; }
+.rw-cover-grid { display: grid; grid-template-columns: 1.45fr 1fr; gap: clamp(28px, 4.5vw, 72px); align-items: end; margin-top: 26px; }
+.rw-h1 { font-family: var(--rm-serif); font-weight: 700; font-size: clamp(40px, 6vw, 82px); line-height: 0.99; letter-spacing: -0.02em; margin: 0; max-width: 13ch; }
+.rw-h1 em { font-style: italic; color: var(--rm-apr); }
+.rw-lede { margin: 26px 0 0; font-size: clamp(15px, 1.35vw, 17.5px); line-height: 1.68; color: #cfe0d4; max-width: 54ch; border-top: 1px solid rgba(246, 242, 230, 0.22); padding-top: 24px; }
+.rw-lede strong { color: #f6f2e6; font-weight: 600; }
 
-/* Featured latest draw */
-.rhw-feature {
-  margin: 44px 0 90px; background: var(--rh-ink); border: var(--rh-bd); border-radius: 20px;
-  box-shadow: 10px 10px 0 rgba(19, 19, 19, 0.25); padding: 40px 44px; color: var(--rh-paper);
-  display: grid; grid-template-columns: 1fr 340px; gap: 44px; align-items: center;
-}
-.rhw-feature .rh-kicker { color: var(--rh-lime); }
-.rhw-feature h2 { font-family: var(--rh-display); font-size: 44px; text-transform: uppercase; line-height: 1; margin: 12px 0 8px; font-weight: 400; }
-.rhw-feature__meta { font-size: 15px; font-weight: 600; color: rgba(244, 242, 234, 0.75); }
-.rhw-wtag {
-  display: inline-flex; align-items: center; gap: 10px; margin-top: 22px; background: var(--rh-white);
-  color: var(--rh-ink); border: var(--rh-bd); border-radius: 12px; box-shadow: 5px 5px 0 var(--rh-lime);
-  padding: 12px 18px; font-weight: 700; font-size: 16px;
-}
-.rhw-wtag small { display: block; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; color: var(--rh-muted); text-transform: uppercase; }
-.rhw-chips { display: flex; gap: 12px; margin-top: 18px; flex-wrap: wrap; }
-.rhw-chip { border: 2.5px solid var(--rh-paper); border-radius: 9px; padding: 6px 11px; font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--rh-paper); }
-.rhw-chip--lime { background: var(--rh-lime); color: var(--rh-ink); border-color: var(--rh-ink); }
+/* ---------- Next-draw countdown ---------- */
+/* Deeper drop than --rm-sh: this card sits on the dark cover, not on cream. */
+.rw-next { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 18px; padding: 22px 24px 20px; color: var(--rm-ink); box-shadow: 0 1px 2px rgba(23, 37, 31, 0.04), 0 10px 30px rgba(23, 37, 31, 0.14); }
+.rw-next-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.rw-next-pill { font-family: var(--rm-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--rm-apr2); background: #fdf3ea; border: 1px solid #f0cdb2; border-radius: 999px; padding: 4px 10px; }
+.rw-clock { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-top: 16px; }
+.rw-clock-cell { background: var(--rm-tint); border-radius: 12px; padding: 12px 0 9px; text-align: center; }
+.rw-clock-num { font-family: var(--rm-serif); font-weight: 700; font-size: 30px; line-height: 1; letter-spacing: -0.01em; font-variant-numeric: tabular-nums; }
+.rw-clock-unit { font-family: var(--rm-mono); font-size: 9px; letter-spacing: 0.11em; text-transform: uppercase; color: var(--rm-mut); margin-top: 6px; }
+.rw-next-prize { font-family: var(--rm-serif); font-weight: 600; font-size: 19px; line-height: 1.25; letter-spacing: -0.01em; margin-top: 18px; }
+.rw-next-when { font-family: var(--rm-mono); font-size: 10.5px; color: var(--rm-mut); margin-top: 6px; line-height: 1.6; }
+.rw-next-cta { margin-top: 16px; width: 100%; }
+.rw-next-foot { font-family: var(--rm-mono); font-size: 10px; color: var(--rm-mut); text-align: center; margin-top: 10px; }
+.rw-next-body { font-size: 14px; line-height: 1.6; color: var(--rm-sub); margin-top: 14px; }
 
-/* Polaroid */
-.rhw-pol { background: var(--rh-white); border: var(--rh-bd); padding: 12px 12px 0; box-shadow: 8px 8px 0 var(--rh-lime); transform: rotate(2.5deg); position: relative; }
-.rhw-pol__ph { height: 250px; display: flex; align-items: center; justify-content: center; border: var(--rh-bd); overflow: hidden; background: var(--rh-stone); }
-.rhw-pol__ph img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.rhw-pol__cap { text-align: center; padding: 12px 6px; color: var(--rh-ink); font-weight: 700; font-size: 14px; letter-spacing: 0.04em; }
-.rhw-pol__cap small { display: block; font-weight: 600; font-size: 11px; color: var(--rh-muted); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 2px; }
-.rhw-tape { position: absolute; top: -14px; left: 50%; transform: translateX(-50%) rotate(-3deg); width: 110px; height: 28px; background: rgba(205, 246, 59, 0.85); border: 2px solid rgba(19, 19, 19, 0.25); }
-.rhw-stamp {
-  position: absolute; right: -16px; top: -16px; width: 88px; height: 88px; border-radius: 50%;
-  background: var(--rh-lime); border: 3px solid var(--rh-ink); display: flex; align-items: center;
-  justify-content: center; font-size: 11px; font-weight: 800; letter-spacing: 0.1em;
-  text-transform: uppercase; transform: rotate(10deg); box-shadow: 4px 4px 0 var(--rh-ink); color: var(--rh-ink);
-}
+/* ---------- Results board ---------- */
+.rw-boardhead { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.rw-boardnote { font-family: var(--rm-mono); font-size: 10.5px; color: var(--rm-mut); line-height: 1.7; max-width: 34ch; text-align: right; }
+.rw-h2 { font-family: var(--rm-serif); font-weight: 700; letter-spacing: -0.015em; margin: 10px 0 0; font-size: clamp(26px, 3.2vw, 38px); line-height: 1.1; }
 
-/* Past draws grid */
-.rhw-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 26px; }
-.rhw-card { background: var(--rh-white); border: var(--rh-bd); border-radius: 16px; box-shadow: 6px 6px 0 var(--rh-ink); overflow: hidden; }
-.rhw-card__top { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; border-bottom: var(--rh-bd); font-family: var(--rh-display); font-size: 13px; text-transform: uppercase; }
-.rhw-bar { width: 64px; height: 18px; background: repeating-linear-gradient(90deg, var(--rh-ink) 0 2px, transparent 2px 5px); }
-.rhw-card__ph { height: 190px; display: flex; align-items: center; justify-content: center; border-bottom: var(--rh-bd); position: relative; overflow: hidden; }
-.rhw-card__ph img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.rhw-card__ph--lime { background: var(--rh-lime); } .rhw-card__ph--pink { background: var(--rh-pink); }
-.rhw-card__ph--violet { background: var(--rh-violet); } .rhw-card__ph--stone { background: var(--rh-stone); }
-.rhw-avatar { width: 110px; height: 110px; border-radius: 50%; border: var(--rh-bd); background: var(--rh-white); display: flex; align-items: center; justify-content: center; font-family: var(--rh-display); font-size: 44px; }
-.rhw-flag { position: absolute; top: 10px; left: 12px; border: var(--rh-bd); border-radius: 8px; background: var(--rh-white); font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; padding: 4px 8px; }
-.rhw-card__bd { padding: 16px 18px 18px; }
-.rhw-who { font-weight: 700; font-size: 17px; }
-.rhw-who small { display: block; font-size: 11.5px; font-weight: 600; color: var(--rh-muted); letter-spacing: 0.06em; text-transform: uppercase; margin-top: 2px; }
-.rhw-prz { margin-top: 12px; display: flex; justify-content: space-between; align-items: center; gap: 10px; font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
-.rhw-ok { color: #3e7a1f; } .rhw-pend { color: var(--rh-muted); }
+.rw-empty { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 18px; padding: 26px 28px; margin-top: 26px; max-width: 640px; display: flex; gap: 14px; align-items: flex-start; }
+/* Sage door with an ink knob (the base .rm-ticket knob is cream — invisible on
+   sage). Two classes so this wins over .rm-ticket regardless of import order. */
+.rm-ticket.rw-door-sage { background: var(--rm-sage2); }
+.rm-ticket.rw-door-sage::after { background: var(--rm-ink); }
 
-/* How draws work */
-.rhw-how { background: var(--rh-ink); color: var(--rh-paper); border-top: var(--rh-bd); padding: 56px 0 64px; }
-.rhw-how .rh-kicker { color: var(--rh-lime); }
-.rhw-how h3 { font-family: var(--rh-display); font-size: 34px; text-transform: uppercase; margin: 10px 0 30px; font-weight: 400; color: var(--rh-paper); }
-.rhw-steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
-.rhw-st { border: 2.5px dashed rgba(244, 242, 234, 0.35); border-radius: 14px; padding: 18px; }
-.rhw-st b { font-family: var(--rh-display); color: var(--rh-lime); font-size: 13px; display: block; margin-bottom: 8px; }
-.rhw-st p { font-size: 13.5px; font-weight: 500; color: rgba(244, 242, 234, 0.8); margin: 0; }
-.rhw-scam { margin-top: 26px; display: inline-flex; align-items: center; gap: 10px; background: var(--rh-lime); color: var(--rh-ink); border: var(--rh-bd); border-radius: 12px; box-shadow: 5px 5px 0 rgba(244, 242, 234, 0.3); padding: 12px 18px; font-size: 13px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+/* Featured latest result */
+.rw-feature { background: var(--rm-sage); border: 1px solid var(--rm-sage2); border-radius: 22px; padding: clamp(24px, 3.2vw, 40px); margin-top: 26px; display: grid; grid-template-columns: 1fr 232px; gap: clamp(24px, 3.5vw, 48px); align-items: center; }
+.rw-feature-title { font-family: var(--rm-serif); font-weight: 700; letter-spacing: -0.015em; margin: 12px 0 0; font-size: clamp(24px, 2.9vw, 34px); line-height: 1.15; max-width: 20ch; }
+.rw-winner { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 14px; padding: 16px 18px; margin-top: 22px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+.rw-winner-sep { width: 1px; align-self: stretch; background: var(--rm-line); }
+.rw-winner-key { font-family: var(--rm-mono); font-size: 9.5px; letter-spacing: 0.11em; text-transform: uppercase; color: var(--rm-mut); }
+.rw-winner-name { font-family: var(--rm-serif); font-weight: 700; font-size: 22px; line-height: 1.2; letter-spacing: -0.01em; margin-top: 4px; }
+.rw-winner-entry { font-family: var(--rm-mono); font-size: 16px; line-height: 1.2; margin-top: 6px; font-variant-numeric: tabular-nums; }
+.rw-winner-area { font-size: 15px; font-weight: 600; line-height: 1.2; margin-top: 6px; }
+.rw-tags { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 16px; }
+.rw-tag { font-family: var(--rm-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--rm-pine); background: var(--rm-card); border: 1px solid var(--rm-sage2); border-radius: 999px; padding: 6px 13px; }
+.rw-tag--status { color: #2a1608; background: var(--rm-apr); border-color: var(--rm-apr2); }
 
-/* Empty state */
-.rhw-empty { margin: 44px 0 90px; border: var(--rh-bd); border-radius: 16px; background: var(--rh-white); box-shadow: 6px 6px 0 var(--rh-ink); padding: 40px 32px; max-width: 640px; }
-.rhw-empty h3 { font-family: var(--rh-display); font-size: 24px; text-transform: uppercase; margin: 0 0 10px; font-weight: 400; }
-.rhw-empty p { font-size: 15px; font-weight: 500; line-height: 1.6; margin: 0; }
+.rw-arch { position: relative; border-radius: 150px 150px 12px 12px; background: repeating-linear-gradient(45deg, #d5e2d2 0 12px, #e0eadc 12px 24px); height: 280px; display: flex; align-items: flex-end; justify-content: center; padding-bottom: 12px; overflow: hidden; }
+.rw-arch img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; }
+.rw-arch .rm-arch-tag { position: relative; }
 
-@media (max-width: 1020px) {
-  .rhw-feature { grid-template-columns: 1fr; padding: 32px 26px; }
-  .rhw-steps { grid-template-columns: 1fr 1fr; }
-}
-@media (max-width: 640px) {
-  .rhw-feature h2 { font-size: 32px; }
-  .rhw-steps { grid-template-columns: 1fr; }
+/* Earlier draws ledger */
+.rw-ledger { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 18px; overflow: hidden; }
+.rw-lhead { display: grid; grid-template-columns: 118px 1fr 168px 122px 116px; gap: 18px; padding: 14px 24px; border-bottom: 1px solid var(--rm-line); background: var(--rm-tint); }
+.rw-lhead span { font-family: var(--rm-mono); font-size: 9.5px; letter-spacing: 0.11em; text-transform: uppercase; color: var(--rm-mut); }
+.rw-lhead span:last-child { text-align: right; }
+.rw-lrow { display: grid; grid-template-columns: 118px 1fr 168px 122px 116px; gap: 18px; padding: 16px 24px; border-bottom: 1px dotted var(--rm-line2); align-items: center; }
+.rw-l-draw { font-family: var(--rm-mono); font-size: 11.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--rm-pine); }
+.rw-l-prize { font-size: 14.5px; font-weight: 600; line-height: 1.35; }
+.rw-l-who { font-size: 13.5px; line-height: 1.4; color: var(--rm-sub); }
+.rw-l-drawn { font-family: var(--rm-mono); font-size: 11px; color: var(--rm-mut); }
+.rw-l-status { font-family: var(--rm-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; text-align: right; color: var(--rm-sub); }
+.rw-lfoot { padding: 14px 24px; font-family: var(--rm-mono); font-size: 10px; color: var(--rm-mut); line-height: 1.7; }
+
+/* ---------- How a draw is run ---------- */
+.rw-how { background: var(--rm-card); border: 1px solid var(--rm-line); border-radius: 22px; padding: clamp(22px, 4vw, 44px); }
+.rw-how-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 22px 32px; }
+.rw-how-item { display: flex; gap: 12px; align-items: flex-start; }
+.rw-how-item .rm-ticket { margin-top: 3px; flex-shrink: 0; }
+.rw-how-t { font-size: 14.5px; font-weight: 700; }
+.rw-how-d { font-size: 12.5px; line-height: 1.55; color: var(--rm-sub); margin-top: 3px; }
+.rw-scam { background: #fbf3e0; border: 1px solid #e8d9ae; border-radius: 16px; padding: 18px 22px; display: flex; gap: 12px; align-items: flex-start; margin-top: 26px; }
+.rw-scam-door { display: inline-block; width: 11px; height: 14px; border-radius: 6px 6px 1px 1px; background: var(--rm-warn); margin-top: 3px; flex-shrink: 0; }
+.rw-scam-body { font-size: 13.5px; line-height: 1.6; color: #5d4715; max-width: 78ch; }
+.rw-scam-body strong { font-weight: 700; color: var(--rm-ink); }
+.rw-uen { border-top: 1px solid var(--rm-line); margin-top: 26px; padding-top: 16px; font-family: var(--rm-mono); font-size: 10.5px; color: var(--rm-mut); letter-spacing: 0.06em; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 719px) {
+  .rw-cover-grid { grid-template-columns: 1fr; align-items: start; }
+  .rw-feature { grid-template-columns: 1fr; }
+  .rw-arch { height: 210px; border-radius: 120px 120px 12px 12px; }
+  .rw-boardhead { flex-direction: column; }
+  .rw-boardnote { text-align: left; max-width: none; }
+  .rw-lhead { display: none; }
+  .rw-lrow { grid-template-columns: 1fr auto; gap: 5px 12px; padding: 15px 18px; }
+  .rw-l-prize, .rw-l-who, .rw-l-drawn { grid-column: 1 / -1; }
+  .rw-l-status { grid-row: 1; }
 }

--- a/src/pages/redeemWinnersContent.js
+++ b/src/pages/redeemWinnersContent.js
@@ -6,19 +6,26 @@
 // written permission (photoCaption should say so). Photos live in
 // public/winners/ (JPG/PNG, roughly square, ≥600px).
 //
-// Newest draw first — the top entry renders as the featured card. Example:
+// Newest draw first — the top entry renders as the featured result and the
+// rest fill the "Earlier draws" ledger. Example:
 //
 //   {
-//     draw: 'Drop 08',                    // which drop/campaign the draw belonged to
-//     prize: 'Cabin luggage',
-//     prizeMeta: 'Hardshell spinner · 1 of 300 entries drawn',
+//     draw: 'Draw 04',                    // which drop/campaign the draw belonged to
+//     prize: 'Family staycation for four',
+//     prizeMeta: 'Two nights, weekend stay · drawn from 1,240 verified entries',
 //     name: 'Sarah T.',                   // masked
 //     entry: '9••• •312',                 // masked mobile/entry number
 //     area: 'Bedok',                      // optional
 //     drawnOn: '20 Jul 2026',
 //     status: 'claimed',                  // 'claimed' | 'pending' (contacted, not yet collected)
-//     photo: '/winners/drop08-sarah.jpg', // optional — omit for initials avatar
-//     photoCaption: 'Sarah collects her luggage',
+//     archTag: 'prize: staycation',       // optional caption for the placeholder panel
+//     photo: '/winners/draw04-sarah.jpg', // optional — omit for the placeholder panel
+//     photoCaption: 'Sarah collects her staycation',
 //   },
 
 export const WINNERS = [];
+
+/** Board label for a winner's claim state. Unknown/missing → treated as drawn. */
+export function statusLabel(status) {
+  return status === 'pending' ? 'Contacted' : 'Claimed';
+}


### PR DESCRIPTION
Rebuilds `redeem.sg/winners` from the approved claude.ai/design **Winners page redesign**.

The page still wore the legacy `rh-*` system. Since the marketplace became the redeem.sg apex (14 Jul) its nav pointed at `/#how` and `/#drops` — anchors that only exist on the old `RedeemHome`. Both links have been dead in prod; they're gone.

### What's in it
Pine/cream editorial cover, next-draw countdown, results board (featured latest + earlier-draws ledger), still-open draw grid, and the "how a draw is run" panel. Chrome is `MarketplaceLayout`; the open-draw cards are plain `OfferCard`s, so images, the verified badge and the boost line come from the same source as every other surface.

### Real data, not the design's mocks
| Section | Source | With no data |
|---|---|---|
| Results board | `redeemWinnersContent.js` (hand-posted, pre-masked) | "No results yet" |
| Countdown | soonest-closing open draw (live campaigns API) | "None open" |
| Still-open grid | open draws, soonest first | "No draw is open right now" |

The countdown reads `luckyDraw.closesAt` through the same **SGT day-end exclusive** contract `offerUnavailability()` and the backend intake gate use, so the page can't advertise a draw the backend would reject.

`/winners` is cited in draw T&Cs (`drawTermsTemplate.js`) and must never 404 — so the route stays gated on `IS_REDEEM_BUILD` alone and every section degrades to an honest empty state rather than hiding.

### Verification
- 10 new tests; full frontend suite **1928/1928** across 152 files; `eslint src/ --quiet` clean
- Both brands build; redeem `/winners` renders, mktr `/winners` still 404s
- Winners chunk not fetched on either apex (own 11KB chunk — the list fetch is inlined rather than imported from `MarketplaceBrowse` to keep the browse surfaces out of it)
- Zero horizontal overflow at 390px; mobile ledger reflow matches the design spec
- Driven with Playwright against a mocked campaigns API to exercise the countdown and open-draw paths

**Board is empty until a winner is posted** — that's the state that ships. To post one, edit `WINNERS` in `redeemWinnersContent.js`, newest first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNNaRKure9hR4BNThDRX7P