### PR TITLE
fix(campaign-page): full-page surfaces size to the VISIBLE viewport, not 100vh

### DIFF
--- a/src/components/campaignPage/CampaignPageRenderer.jsx
+++ b/src/components/campaignPage/CampaignPageRenderer.jsx
@@ -74,7 +74,7 @@ function BlockedPage({ t, content, reason, luckyDraw }) {
     <div
       data-campaign-page-blocked={reason}
       style={{
-        minHeight: '100vh',
+        minHeight: 'var(--cp-vh, 100vh)',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',

--- a/src/components/campaignPage/drawTemplates.jsx
+++ b/src/components/campaignPage/drawTemplates.jsx
@@ -374,13 +374,13 @@ function Postcard({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile
       </div>
     </div>;
     return (
-      <div style={{ minHeight: '100vh', background: PC.bg, display: 'flex', fontFamily: SANS, color: PC.ink }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: PC.bg, display: 'flex', fontFamily: SANS, color: PC.ink }}>
         {mediaLeft ? <>{heroPane}{formPane}</> : <>{formPane}{heroPane}</>}
       </div>
     );
   }
   return (
-    <div style={{ minHeight: '100vh', background: PC.bg, display: 'flex', flexDirection: 'column', fontFamily: SANS, color: PC.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: PC.bg, display: 'flex', flexDirection: 'column', fontFamily: SANS, color: PC.ink }}>
       {hero}
       {formCard}
       {belowCard}
@@ -460,7 +460,7 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
   );
   if (!mobile) {
     return (
-      <div style={{ minHeight: '100vh', background: GZ.bg, padding: '36px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 26, fontFamily: SANS, color: GZ.ink }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: GZ.bg, padding: '36px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 26, fontFamily: SANS, color: GZ.ink }}>
         <GazetteMasthead content={content} kickerText={`OFFICIAL ENTRY FORM${s.kicker ? ` · ${s.kicker}` : ''}`} inkColor={GZ.ink} mutedColor={GZ.mut} />
         <div style={{ display: 'flex', gap: 56 }}>
           <div style={{ flex: 1.1, display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -479,7 +479,7 @@ function Gazette({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile,
     );
   }
   return (
-    <div style={{ minHeight: '100vh', background: GZ.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 24px', boxSizing: 'border-box', fontFamily: SANS, color: GZ.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: GZ.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 24px', boxSizing: 'border-box', fontFamily: SANS, color: GZ.ink }}>
       <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" inkColor={GZ.ink} mutedColor={GZ.mut} />
       <div style={{ display: 'flex', flexDirection: 'column', gap: 18, paddingTop: 20 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
@@ -518,7 +518,7 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
   );
   if (!mobile) {
     return (
-      <div style={{ minHeight: '100vh', background: NF_HERO, position: 'relative', display: 'flex', flexDirection: 'column', fontFamily: SANS }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: NF_HERO, position: 'relative', display: 'flex', flexDirection: 'column', fontFamily: SANS }}>
         <BackdropMedia t={t} media={content.media} />
         <div data-se="content.media" style={{ position: 'absolute', inset: 0, background: 'linear-gradient(100deg, rgba(20,22,31,.9) 34%, rgba(20,22,31,.35))' }} />
         <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', padding: '26px 40px' }}>
@@ -547,8 +547,8 @@ function Nightfall({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
     );
   }
   return (
-    <div style={{ minHeight: '100vh', background: NF.bg, color: NF.ink, display: 'flex', flexDirection: 'column', position: 'relative', fontFamily: SANS }}>
-      <div style={{ position: 'relative', minHeight: '100vh', background: NF_HERO, display: 'flex', flexDirection: 'column' }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: NF.bg, color: NF.ink, display: 'flex', flexDirection: 'column', position: 'relative', fontFamily: SANS }}>
+      <div style={{ position: 'relative', minHeight: 'var(--cp-vh, 100vh)', background: NF_HERO, display: 'flex', flexDirection: 'column' }}>
         <BackdropMedia t={t} media={content.media} />
         <div data-se="content.media" style={{ position: 'absolute', inset: 0, background: scrim }} />
         <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '18px 20px' }}>
@@ -707,7 +707,7 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
   );
   if (!mobile) {
     return (
-      <div style={{ minHeight: '100vh', background: ST.bg, padding: '34px 0', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, fontFamily: SANS, color: ST.ink }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: ST.bg, padding: '34px 0', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 18, fontFamily: SANS, color: ST.ink }}>
         <div style={{ width: 760, maxWidth: 'calc(100vw - 48px)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <div data-se="content.wordmark" style={{ fontWeight: 800, fontSize: 20 }}>{content.wordmark}</div>
           <div data-se={s.draw ? 'content.drawCopy.freeEntryTag' : undefined} style={mono(11, { letterSpacing: 1.5, color: ST.mut })}>{s.draw ? s.freeEntryTag('FREE ENTRY') : 'FREE ENTRY'}</div>
@@ -752,7 +752,7 @@ function Stub({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, re
     </div>
   );
   return (
-    <div style={{ minHeight: '100vh', background: ST.bg, display: 'flex', flexDirection: 'column', padding: '18px 16px 26px', boxSizing: 'border-box', gap: 14, fontFamily: SANS, color: ST.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: ST.bg, display: 'flex', flexDirection: 'column', padding: '18px 16px 26px', boxSizing: 'border-box', gap: 14, fontFamily: SANS, color: ST.ink }}>
       <StubHeader content={content} mutedColor={ST.mut} draw={s.draw} freeEntry={s.freeEntryTag('FREE ENTRY')} />
       {ticket}
       {s.draw && <div data-se="content.drawCopy.trustRow" style={mono(11, { letterSpacing: 0.8, color: ST.mut, textAlign: 'center' })}>{s.trustRow}</div>}
@@ -856,7 +856,7 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
   );
   if (!mobile) {
     return (
-      <div style={{ minHeight: '100vh', background: CL.bg, padding: '34px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 24, fontFamily: SANS, color: CL.ink }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: CL.bg, padding: '34px 56px', boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 24, fontFamily: SANS, color: CL.ink }}>
         <ChecklistHeader content={content} s={s} mutedColor={CL.mut} />
         {showBand && (
           <div style={{ position: 'relative', height: 190, borderRadius: 14, overflow: 'hidden' }}>
@@ -897,7 +897,7 @@ function Checklist({ t, content, params, luckyDraw, funnel, formAnchorRef, mobil
     );
   }
   return (
-    <div style={{ minHeight: '100vh', background: CL.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 26px', boxSizing: 'border-box', gap: 16, fontFamily: SANS, color: CL.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: CL.bg, display: 'flex', flexDirection: 'column', padding: '18px 20px 26px', boxSizing: 'border-box', gap: 16, fontFamily: SANS, color: CL.ink }}>
       <ChecklistHeader content={content} s={s} mutedColor={CL.mut} />
       {showBand && (
         <div style={{ position: 'relative', height: 150, margin: '0 -20px', overflow: 'hidden' }}>
@@ -1087,7 +1087,7 @@ export function DrawSuccessPage({ campaign, submittedPhone = null, screeningCall
   return (
     <div
       data-draw-success={templateId}
-      style={{ minHeight: '100vh', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
+      style={{ minHeight: 'var(--cp-vh, 100vh)', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
     >
       <div style={{ width: '100%', maxWidth: 560, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, flex: 1 }}>
         {body}
@@ -1145,7 +1145,7 @@ export function DrawClosedPage({ templateId, t, content, luckyDraw, campaignName
     <div
       data-campaign-page-blocked="draw"
       data-draw-closed={templateId}
-      style={{ minHeight: '100vh', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
+      style={{ minHeight: 'var(--cp-vh, 100vh)', background: chrome.pageBg, color: chrome.ink, fontFamily: SANS, display: 'flex', flexDirection: 'column', boxSizing: 'border-box', padding: 20 }}
     >
       <div style={{ width: '100%', maxWidth: 560, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 14, flex: 1 }}>
         {chrome.masthead && <GazetteMasthead content={content} kickerText="OFFICIAL ENTRY FORM" inkColor={pal.ink} mutedColor={pal.mut} />}

--- a/src/components/campaignPage/templates.jsx
+++ b/src/components/campaignPage/templates.jsx
@@ -132,7 +132,7 @@ function Editorial({ t, content, params, luckyDraw, funnel, formAnchorRef, scrol
   return (
     <div
       style={{
-        minHeight: '100vh',
+        minHeight: 'var(--cp-vh, 100vh)',
         background: t.bg,
         backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined,
         padding: 'max(20px, env(safe-area-inset-top)) 16px max(28px, env(safe-area-inset-bottom))',
@@ -206,7 +206,7 @@ function Poster({ t, content, params, luckyDraw, funnel, formAnchorRef, scrollTo
   const heroBackdrop = t.dark ? t.card : '#17191E';
   const showCta = content.media.kind !== 'none' && !!content.heroCtaLabel;
   return (
-    <div style={{ minHeight: '100vh', background: t.bg, fontFamily: SANS, color: t.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: t.bg, fontFamily: SANS, color: t.ink }}>
       <div style={{ position: 'relative', height: mobile ? 430 : 480, background: heroBackdrop, overflow: 'hidden' }}>
         <MediaBlock t={t} media={content.media} radius={0} style={{ position: 'absolute', inset: 0, aspectRatio: 'auto', height: '100%' }} />
         <div data-se="content.media" style={{ position: 'absolute', inset: 0, background: `linear-gradient(to top, ${fade} 4%, rgba(12,10,8,.28) 55%, rgba(12,10,8,.2))` }} />
@@ -283,7 +283,7 @@ function Split({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, r
     </div>
   );
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: mobile ? '1fr' : mediaSide === 'left' ? '1fr 1.05fr' : '1.05fr 1fr', minHeight: '100vh', background: t.bg, fontFamily: SANS, color: t.ink }}>
+    <div style={{ display: 'grid', gridTemplateColumns: mobile ? '1fr' : mediaSide === 'left' ? '1fr 1.05fr' : '1.05fr 1fr', minHeight: 'var(--cp-vh, 100vh)', background: t.bg, fontFamily: SANS, color: t.ink }}>
       {mediaSide === 'left' || mobile ? (
         <>
           {mediaPanel}
@@ -304,8 +304,8 @@ function Split({ t, content, params, luckyDraw, funnel, formAnchorRef, mobile, r
 function Spotlight({ t, content, luckyDraw, funnel, formAnchorRef, stage, referrerName }) {
   const pastQuiz = stage !== 'quiz';
   return (
-    <div style={{ minHeight: '100vh', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink, padding: '16px 16px 0', boxSizing: 'border-box' }}>
-      <div style={{ maxWidth: 460, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, minHeight: '100vh', boxSizing: 'border-box' }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink, padding: '16px 16px 0', boxSizing: 'border-box' }}>
+      <div style={{ maxWidth: 460, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16, minHeight: 'var(--cp-vh, 100vh)', boxSizing: 'border-box' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingTop: 4 }}>
           <span data-se="content.wordmark" style={{ fontFamily: t.fontStack, fontSize: 17, fontWeight: 700 }}>{content.wordmark}</span>
           <DrawBadge t={t} luckyDraw={luckyDraw} inverted={false} />
@@ -343,7 +343,7 @@ function Spotlight({ t, content, luckyDraw, funnel, formAnchorRef, stage, referr
 
 function Express({ t, content, params, luckyDraw, funnel, formAnchorRef, referrerName }) {
   return (
-    <div style={{ minHeight: '100vh', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink, display: 'flex', flexDirection: 'column', justifyContent: 'safe center', padding: 16, boxSizing: 'border-box' }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink, display: 'flex', flexDirection: 'column', justifyContent: 'safe center', padding: 16, boxSizing: 'border-box' }}>
       <div style={{ maxWidth: 430, width: '100%', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 14 }}>
         <div data-se="content.wordmark" style={{ textAlign: 'center', fontFamily: t.fontStack, fontSize: 18, fontWeight: 700 }}>{content.wordmark}</div>
         <DrawBadge t={t} luckyDraw={luckyDraw} />
@@ -364,7 +364,7 @@ function Journey({ t, content, params, luckyDraw, funnel, formAnchorRef, scrollT
   const alternate = params.sectionRhythm !== 'stacked';
   const showSticky = params.stickyCta !== false && stage !== 'outcome';
   return (
-    <div style={{ minHeight: '100vh', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink }}>
+    <div style={{ minHeight: 'var(--cp-vh, 100vh)', background: t.bg, backgroundImage: t.bgCss !== 'none' ? t.bgCss : undefined, fontFamily: SANS, color: t.ink }}>
       <div style={{ maxWidth: 600, margin: '0 auto', padding: mobile ? 16 : 26, boxSizing: 'border-box', display: 'flex', flexDirection: 'column', gap: 18 }}>
         <div data-se="content.wordmark" style={{ textAlign: 'center', fontFamily: t.fontStack, fontSize: 20, fontWeight: 700, paddingTop: 6 }}>{content.wordmark}</div>
         <DrawBadge t={t} luckyDraw={luckyDraw} />

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,17 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+/* ── Visible-viewport height for full-page campaign surfaces ──────────────
+   `100vh` on mobile is the LARGE viewport: it measures the page as if the
+   browser's collapsing toolbar were hidden, so a `min-height:100vh` page is
+   taller than what the user can actually see. Scrolled to the bottom that
+   surplus reads as a band of empty background under the content — the "large
+   space at the bottom" on the post-submit screens.
+
+   `dvh` tracks the visible height instead. The `vh` declaration stays as the
+   fallback for browsers without `dvh` (pre-2022), and @supports upgrades it. */
+:root { --cp-vh: 100vh; }
+@supports (height: 100dvh) {
+  :root { --cp-vh: 100dvh; }
+}

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -508,7 +508,7 @@ export default function LeadCapture() {
   // Loading state
   if (!campaign && !error) {
     return (
-      <div style={{ minHeight: '100vh', backgroundColor: TOKENS.pagebg }}>
+      <div style={{ minHeight: 'var(--cp-vh, 100vh)', backgroundColor: TOKENS.pagebg }}>
         <TypingLoader />
       </div>
     );
@@ -636,7 +636,7 @@ export default function LeadCapture() {
       return (
         <div
           style={{
-            minHeight: '100vh',
+            minHeight: 'var(--cp-vh, 100vh)',
             background: vt.bg,
             display: 'flex',
             flexDirection: 'column',


### PR DESCRIPTION
The post-submit screens leave a band of empty background under the content on mobile — scroll to the bottom of "You're in the draw" and the page keeps going past the last line.

## Cause

`100vh` is the **large** viewport: it measures the page as if the browser's collapsing toolbar were hidden. `min-height: 100vh` therefore makes the page taller than what's actually visible, and that surplus reads as dead space below the content.

It does **not** reproduce in headless Chrome — there's no dynamic toolbar there, so `vh == dvh == svh`. I confirmed that directly, which is why this has survived: the local measurement comes out clean (page height == content height) while the real device shows the gap.

## Fix

Every full-page campaign surface now sizes to `--cp-vh`:

```css
:root { --cp-vh: 100vh; }                                  /* fallback */
@supports (height: 100dvh) { :root { --cp-vh: 100dvh; } }  /* visible viewport */
```

23 sites across the draw templates (13), the standard templates (7), the renderer's blocked page (1) and LeadCapture's own wrappers (2).

A custom property rather than a utility class because these are inline style objects — and `var(--cp-vh, 100vh)` degrades to exactly today's behaviour if the stylesheet ever fails to load.

## Verified

On the built bundle: `--cp-vh` resolves to `100dvh`, `CSS.supports('height','100dvh')` is true, the success page's computed `min-height` resolves correctly, and it still measures content-height on desktop — no change anywhere `vh` already equalled the visible height. 1934 frontend tests pass, eslint clean.

Reproduction harness: drove the real campaign (`airpods-pro-draw`, checklist template) through the PR gate → form → OTP → draw success page against a mocked API, and measured `document.scrollHeight` vs the success element at 376×686.

While in there I also checked the share sheet that auto-opens on success: it locks body scroll on open and **does** release it correctly on close (`dialogStillMounted: false`, overflow restored). Not a contributor — no change made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNNaRKure9hR4BNThDRX7P