### PR TITLE
fix(lead-capture): outcome screens land at the top, killing the post-submit empty band

### DIFF
--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -461,6 +461,18 @@ export default function LeadCapture() {
     }
   };
 
+  // Outcome screens land the visitor at the TOP (#460 follow-up). Submitting
+  // means having scrolled down a tall capture page, and React keeps that offset
+  // when the outcome screen replaces it — then ShareCampaignDialog locks body
+  // scroll (`body.style.overflow = 'hidden'`) the instant it opens. A stale
+  // offset past the shorter outcome page's content therefore FREEZES the
+  // visitor on a band of empty page background under the content, with no way
+  // to scroll back. Resetting on the transition is what keeps the band away;
+  // the dvh sizing fix alone never covered this path.
+  useEffect(() => {
+    if (submitted || error || duplicateDetected) window.scrollTo(0, 0);
+  }, [submitted, error, duplicateDetected]);
+
   // Duplicate countdown
   useEffect(() => {
     if (!duplicateDetected) return;

--- a/src/pages/__tests__/LeadCapture.test.jsx
+++ b/src/pages/__tests__/LeadCapture.test.jsx
@@ -176,6 +176,28 @@ describe('LeadCapture', () => {
  });
  });
 
+ // The share sheet locks body scroll the moment it opens, so an offset carried
+ // over from the taller capture page would strand the visitor on a band of
+ // empty background under the outcome content, unable to scroll back up.
+ it('resets scroll to the top when the outcome screen replaces the form', async () => {
+ apiClient.post.mockResolvedValue({ success: true });
+ const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+ renderPage();
+ await waitFor(() => {
+ expect(screen.getByTestId('signup-form')).toBeInTheDocument();
+ });
+
+ const user = userEvent.setup();
+ await user.click(screen.getByText('Submit'));
+
+ await waitFor(() => {
+ expect(screen.getByTestId('share-dialog')).toBeInTheDocument();
+ });
+ expect(scrollTo).toHaveBeenCalledWith(0, 0);
+ scrollTo.mockRestore();
+ });
+
  it('shows error when submission fails', async () => {
  // First post is analytics (landing), subsequent post for prospect will fail
  let postCount = 0;


### PR DESCRIPTION
## The bug

After submitting the lead-capture form, visitors see a band of empty page background at the bottom of the outcome screen, and cannot scroll away from it.

## Root cause

Not the `100dvh` sizing issue — #460 fixed that correctly and it is live. This is a **scroll-position** bug:

1. Submitting means having scrolled down a tall capture page.
2. React swaps in the outcome screen; the browser **keeps the old scroll offset**.
3. `ShareCampaignDialog` sets `body.style.overflow = 'hidden'` the instant it opens (`ShareCampaignDialog.jsx:64`).
4. The stale offset now points past the end of the shorter outcome page — and scroll is locked, so the visitor is frozen on empty background with no way back up.

Measured live in the Studio "Success + share sheet" state:

```
bodyOverflow: "hidden"
docH:          822px
viewportH:     612px
```

A stale offset of ~400 yields a ~190px band.

## The fix

Reset scroll on the transition into any outcome screen. All three (success, error, duplicate) replace the form and all three can open the share sheet.

## Testing

- `LeadCapture.test.jsx` — 25/25 pass, including a new regression test asserting `scrollTo(0, 0)` on the outcome transition
- `campaignPage` + `PublicPreview` — 173/173 pass
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcFxTJ4vuWC5XJ8mavUTk
