### PR TITLE
feat(ads): Google Customer Match exclusion sync via the Data Manager API (ships dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -736,7 +736,11 @@ GOOGLE_CM_CAMPAIGN_ID=
 GOOGLE_CM_SYNC_INTERVAL_HOURS=24
 # Alert recipient for failed runs; falls back to REDEEMED_AUDIENCE_ALERT_EMAIL.
 GOOGLE_CM_ALERT_EMAIL=
-# Status-poll budget per accepted ingest request (terminal-state settling).
-GOOGLE_CM_STATUS_MAX_POLLS=6
+# Deferred settlement timing: Google recommends the FIRST diagnostics poll
+# ~30 minutes after acceptance (polling up to 24h). The drainer interval runs
+# whenever DM credentials + list id exist (removals settle even if the sync
+# flag is off).
+GOOGLE_CM_FIRST_POLL_MINUTES=30
+GOOGLE_CM_SETTLE_INTERVAL_MINUTES=15
 # Per-request fetch timeout for the Data Manager client.
 GOOGLE_DM_TIMEOUT_MS=30000

--- a/backend/env.example
+++ b/backend/env.example
@@ -736,3 +736,7 @@ GOOGLE_CM_CAMPAIGN_ID=
 GOOGLE_CM_SYNC_INTERVAL_HOURS=24
 # Alert recipient for failed runs; falls back to REDEEMED_AUDIENCE_ALERT_EMAIL.
 GOOGLE_CM_ALERT_EMAIL=
+# Status-poll budget per accepted ingest request (terminal-state settling).
+GOOGLE_CM_STATUS_MAX_POLLS=6
+# Per-request fetch timeout for the Data Manager client.
+GOOGLE_DM_TIMEOUT_MS=30000

--- a/backend/env.example
+++ b/backend/env.example
@@ -708,3 +708,31 @@ SCORING_CONFIG_ADMIN_ENABLED=false
 # App id for the WhatsApp template-submission script's sample upload; falls back
 # to debug_token. See backend/scripts/submit-wa-marketing-templates.mjs.
 # WHATSAPP_APP_ID=
+
+# --- Google Data Manager API (docs/plans/google-ads-signal-levers.md §2) ---
+# OAuth for the datamanager scope. Minted once by
+# scripts/google-dm-oauth-bootstrap.mjs against the INTERNAL OAuth app on the
+# mktr.sg Workspace org (Testing-mode refresh tokens expire in 7 days;
+# Internal ones are durable). No developer token / MCC — the classic Google
+# Ads API upload surfaces are closed to new integrations since Apr/Jun 2026.
+GOOGLE_DM_OAUTH_CLIENT_ID=
+GOOGLE_DM_OAUTH_CLIENT_SECRET=
+GOOGLE_DM_REFRESH_TOKEN=
+# The Ads account that owns the destinations (Customer Match list /
+# conversion actions). Digits only, no dashes.
+GOOGLE_ADS_CUSTOMER_ID=1829163947
+
+# --- Google Customer Match exclusion sync (plan §3 / 2b) ---
+# Master switch. The sync uploads the target campaign's VERIFIED,
+# consent-granted entrants (hashed) into a Customer Match list used as a
+# campaign-level exclusion. Per-campaign by design: funnel dedupe is per
+# (campaignId, phone), so a global list would over-suppress.
+GOOGLE_CM_SYNC_ENABLED=false
+# Customer Match list id (created once in Ads UI → Audience manager; set its
+# membership duration FINITE there — 180d proposed — as the removal backstop).
+GOOGLE_CM_USER_LIST_ID=
+# The campaign whose entrants populate the list.
+GOOGLE_CM_CAMPAIGN_ID=
+GOOGLE_CM_SYNC_INTERVAL_HOURS=24
+# Alert recipient for failed runs; falls back to REDEEMED_AUDIENCE_ALERT_EMAIL.
+GOOGLE_CM_ALERT_EMAIL=

--- a/backend/scripts/google-dm-oauth-bootstrap.mjs
+++ b/backend/scripts/google-dm-oauth-bootstrap.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * One-off local OAuth bootstrap for the Data Manager API (never deployed —
+ * backend/scripts is .dockerignored out of the image).
+ *
+ * Prereqs (docs/plans/google-ads-signal-levers.md §2): a Google Cloud project
+ * on the mktr.sg Workspace org with the Data Manager API enabled, an INTERNAL
+ * OAuth consent screen, and a DESKTOP OAuth client (loopback redirects only
+ * work for Desktop clients).
+ *
+ * Usage:
+ *   GOOGLE_DM_OAUTH_CLIENT_ID=... GOOGLE_DM_OAUTH_CLIENT_SECRET=... \
+ *     node scripts/google-dm-oauth-bootstrap.mjs
+ *
+ * Prints the consent URL, waits for the loopback redirect on 127.0.0.1:8765,
+ * exchanges the code, and prints the REFRESH TOKEN to copy into Render env
+ * (GOOGLE_DM_REFRESH_TOKEN). access_type=offline + prompt=consent force a
+ * refresh token even on re-consent.
+ */
+import http from 'node:http';
+import crypto from 'node:crypto';
+
+const CLIENT_ID = process.env.GOOGLE_DM_OAUTH_CLIENT_ID;
+const CLIENT_SECRET = process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET;
+const PORT = Number(process.env.GOOGLE_DM_OAUTH_PORT || 8765);
+const REDIRECT_URI = `http://127.0.0.1:${PORT}`;
+const SCOPE = 'https://www.googleapis.com/auth/datamanager';
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error('Set GOOGLE_DM_OAUTH_CLIENT_ID and GOOGLE_DM_OAUTH_CLIENT_SECRET first.');
+  process.exit(1);
+}
+
+const state = crypto.randomBytes(16).toString('hex');
+const authUrl =
+  'https://accounts.google.com/o/oauth2/v2/auth?' +
+  new URLSearchParams({
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    response_type: 'code',
+    scope: SCOPE,
+    access_type: 'offline',
+    prompt: 'consent',
+    state,
+  }).toString();
+
+console.log('\nOpen this URL as admin@mktr.sg and approve:\n');
+console.log(authUrl + '\n');
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, REDIRECT_URI);
+  const code = url.searchParams.get('code');
+  const gotState = url.searchParams.get('state');
+  if (!code) {
+    res.writeHead(404).end();
+    return;
+  }
+  if (gotState !== state) {
+    res.writeHead(400).end('state mismatch');
+    console.error('State mismatch — aborting.');
+    process.exit(1);
+  }
+  res.writeHead(200, { 'Content-Type': 'text/plain' }).end('Token minted — you can close this tab.');
+  server.close();
+
+  const form = new URLSearchParams({
+    code,
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+    redirect_uri: REDIRECT_URI,
+    grant_type: 'authorization_code',
+  });
+  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+  const body = await tokenRes.json();
+  if (!tokenRes.ok || !body.refresh_token) {
+    console.error('Token exchange failed:', tokenRes.status, body.error_description || body.error);
+    process.exit(1);
+  }
+  console.log('\nGOOGLE_DM_REFRESH_TOKEN (copy into Render env, never commit):\n');
+  console.log(body.refresh_token + '\n');
+  process.exit(0);
+});
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Listening on ${REDIRECT_URI} for the OAuth redirect…`);
+});

--- a/backend/scripts/google-dm-oauth-bootstrap.mjs
+++ b/backend/scripts/google-dm-oauth-bootstrap.mjs
@@ -84,10 +84,13 @@ const server = http.createServer(async (req, res) => {
     redirect_uri: REDIRECT_URI,
     grant_type: 'authorization_code',
   });
+  // The exchange gets its own bound — a stalled token endpoint must not
+  // hang the script after the redirect deadline was cleared.
   const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: form.toString(),
+    signal: AbortSignal.timeout(30_000),
   });
   const body = await tokenRes.json();
   if (!tokenRes.ok || !body.refresh_token) {

--- a/backend/scripts/google-dm-oauth-bootstrap.mjs
+++ b/backend/scripts/google-dm-oauth-bootstrap.mjs
@@ -47,8 +47,20 @@ const authUrl =
 console.log('\nOpen this URL as admin@mktr.sg and approve:\n');
 console.log(authUrl + '\n');
 
+// A denied consent must not leave the script listening forever.
+const deadline = setTimeout(() => {
+  console.error('Timed out waiting for the OAuth redirect (10 min).');
+  process.exit(1);
+}, 10 * 60 * 1000);
+
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, REDIRECT_URI);
+  const oauthError = url.searchParams.get('error');
+  if (oauthError) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' }).end(`OAuth error: ${oauthError}`);
+    console.error(`OAuth error from Google: ${oauthError}`);
+    process.exit(1);
+  }
   const code = url.searchParams.get('code');
   const gotState = url.searchParams.get('state');
   if (!code) {
@@ -62,7 +74,9 @@ const server = http.createServer(async (req, res) => {
   }
   res.writeHead(200, { 'Content-Type': 'text/plain' }).end('Token minted — you can close this tab.');
   server.close();
+  clearTimeout(deadline);
 
+  try {
   const form = new URLSearchParams({
     code,
     client_id: CLIENT_ID,
@@ -83,6 +97,10 @@ const server = http.createServer(async (req, res) => {
   console.log('\nGOOGLE_DM_REFRESH_TOKEN (copy into Render env, never commit):\n');
   console.log(body.refresh_token + '\n');
   process.exit(0);
+  } catch (err) {
+    console.error('Token exchange threw:', err?.message || err);
+    process.exit(1);
+  }
 });
 server.listen(PORT, '127.0.0.1', () => {
   console.log(`Listening on ${REDIRECT_URI} for the OAuth redirect…`);

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -287,6 +287,25 @@ export async function bootstrapDatabase() {
       logger.info(`[GoogleCM] periodic sync scheduled (${cmIntervalHours}h interval)`);
     }
 
+    // Settlement drainer for accepted Data Manager requests (ingest AND the
+    // erasure/withdrawal removals) — Google's diagnostics window starts ~30min
+    // after acceptance and runs to 24h, so settling is decoupled from the
+    // sync run. Registered whenever the DM credentials exist: removals must
+    // settle even with the sync switched off.
+    if (process.env.GOOGLE_DM_REFRESH_TOKEN && process.env.GOOGLE_CM_USER_LIST_ID) {
+      const settleMinutes = Math.max(1, Number(process.env.GOOGLE_CM_SETTLE_INTERVAL_MINUTES) || 15);
+      const runGoogleCmSettle = async () => {
+        try {
+          const { settlePendingStatuses } = await import('../services/googleCustomerMatchService.js');
+          await settlePendingStatuses();
+        } catch (err) {
+          logger.warn('[GoogleCM] settle pass failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setInterval(runGoogleCmSettle, settleMinutes * 60 * 1000);
+      logger.info(`[GoogleCM] settlement drainer scheduled (${settleMinutes}m interval)`);
+    }
+
     // Redemption CAPI reconciliation sweep — the no-rescan safety net for
     // VoucherRedeemed sends lost between the redemption commit and the
     // fire-and-forget dispatch (process death). Marker-guarded + Meta event_id

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -264,6 +264,29 @@ export async function bootstrapDatabase() {
       logger.info(`[RedeemedAudience] periodic sync scheduled (${intervalHours}h interval)`);
     }
 
+    // Google Customer Match exclusion sync — same in-process pattern as the
+    // Meta block above (single-instance backend, no separate cron service),
+    // uploading the target campaign's verified entrants to the exclusion
+    // list via the Data Manager API. Gated by GOOGLE_CM_SYNC_ENABLED; initial
+    // run 90s after boot (offset from Meta's 60s so the two ledger scans
+    // don't land together), then every GOOGLE_CM_SYNC_INTERVAL_HOURS
+    // (default 24). Additive + in-service single-flight ⇒ extra runs are
+    // harmless.
+    if (String(process.env.GOOGLE_CM_SYNC_ENABLED || 'false').toLowerCase() === 'true') {
+      const cmIntervalHours = Math.max(1, Number(process.env.GOOGLE_CM_SYNC_INTERVAL_HOURS) || 24);
+      const runGoogleCmSync = async () => {
+        try {
+          const { syncGoogleCustomerMatch } = await import('../services/googleCustomerMatchService.js');
+          await syncGoogleCustomerMatch();
+        } catch (err) {
+          logger.warn('[GoogleCM] periodic sync failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setTimeout(runGoogleCmSync, 90_000);
+      setInterval(runGoogleCmSync, cmIntervalHours * 60 * 60 * 1000);
+      logger.info(`[GoogleCM] periodic sync scheduled (${cmIntervalHours}h interval)`);
+    }
+
     // Redemption CAPI reconciliation sweep — the no-rescan safety net for
     // VoucherRedeemed sends lost between the redemption commit and the
     // fire-and-forget dispatch (process death). Marker-guarded + Meta event_id

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -605,7 +605,7 @@ export function makeConsentService(overrides = {}) {
     // Post-commit, fire-and-forget via dynamic import (no static edge — the
     // CM service dynamically imports THIS module for its ledger gates); the
     // list's finite membership duration backstops a lost call.
-    Promise.resolve(d.googleCmRemoveByConsumerId(consumer.id))
+    (async () => d.googleCmRemoveByConsumerId(consumer.id))()
       .catch((err) => {
         d.logger.warn('[consent] google customer match removal failed (membership TTL heals)', {
           consumerId: consumer.id, error: err?.message || String(err),

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -594,6 +594,18 @@ export function makeConsentService(overrides = {}) {
         });
       });
     }
+    // Google Customer Match removal (plan google-ads-signal-levers §3):
+    // a global withdrawal also pulls the person off the ad-exclusion list.
+    // Post-commit, fire-and-forget via dynamic import (no static edge — the
+    // CM service dynamically imports THIS module for its ledger gates); the
+    // list's finite membership duration backstops a lost call.
+    import('./googleCustomerMatchService.js')
+      .then(({ removeByConsumerId }) => removeByConsumerId(consumer.id))
+      .catch((err) => {
+        d.logger.warn('[consent] google customer match removal failed (membership TTL heals)', {
+          consumerId: consumer.id, error: err?.message || String(err),
+        });
+      });
     return result;
   }
 

--- a/backend/src/services/consentService.js
+++ b/backend/src/services/consentService.js
@@ -56,6 +56,12 @@ export function unsubTokenHashOf(token) {
 const defaultDeps = {
   sequelize, Consumer, ConsentEvent, ConsumerSuppression, Prospect, logger,
   reconcileSuppressionPropagation, // tracker "propagate" — post-commit trigger
+  // Injectable seam (tests spy here): lazy import — the CM service imports
+  // THIS module dynamically for its ledger gates, so the edge must not be static.
+  googleCmRemoveByConsumerId: async (consumerId) => {
+    const m = await import('./googleCustomerMatchService.js');
+    return m.removeByConsumerId(consumerId);
+  },
 };
 
 export function makeConsentService(overrides = {}) {
@@ -599,8 +605,7 @@ export function makeConsentService(overrides = {}) {
     // Post-commit, fire-and-forget via dynamic import (no static edge — the
     // CM service dynamically imports THIS module for its ledger gates); the
     // list's finite membership duration backstops a lost call.
-    import('./googleCustomerMatchService.js')
-      .then(({ removeByConsumerId }) => removeByConsumerId(consumer.id))
+    Promise.resolve(d.googleCmRemoveByConsumerId(consumer.id))
       .catch((err) => {
         d.logger.warn('[consent] google customer match removal failed (membership TTL heals)', {
           consumerId: consumer.id, error: err?.message || String(err),

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -68,6 +68,12 @@ const defaultDeps = {
   evictVerifiedPhone, evictDncCheckCache, forgetPhoneVerification,
   inventory: makeInventoryService(),
   audit: makeRedeemOpsAuditService(),
+  // Injectable seam (tests spy here): lazy so this service's import graph is
+  // unchanged and a config-less environment costs nothing.
+  googleCmRemove: async (pairs) => {
+    const m = await import('./googleCustomerMatchService.js');
+    return m.removeAudienceMembers(m.buildRemovalIdentifiers(pairs));
+  },
 };
 
 export function makeErasureService(overrides = {}) {
@@ -785,10 +791,7 @@ export function makeErasureService(overrides = {}) {
     // membership duration backstops a lost call). Dynamic import keeps this
     // service's import graph unchanged.
     if (googleCmRemovalPairs.length) {
-      import('./googleCustomerMatchService.js')
-        .then(({ buildRemovalIdentifiers, removeAudienceMembers }) =>
-          removeAudienceMembers(buildRemovalIdentifiers(googleCmRemovalPairs))
-        )
+      Promise.resolve(d.googleCmRemove(googleCmRemovalPairs))
         .catch((err) => {
           d.logger.warn('[erasure] google customer match removal failed (membership TTL heals)', {
             consumerId, error: err?.message || String(err),

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -791,7 +791,9 @@ export function makeErasureService(overrides = {}) {
     // membership duration backstops a lost call). Dynamic import keeps this
     // service's import graph unchanged.
     if (googleCmRemovalPairs.length) {
-      Promise.resolve(d.googleCmRemove(googleCmRemovalPairs))
+      // async IIFE: a SYNCHRONOUSLY throwing seam becomes a rejection too —
+      // nothing an injected hook does may fail the already-committed erasure.
+      (async () => d.googleCmRemove(googleCmRemovalPairs))()
         .catch((err) => {
           d.logger.warn('[erasure] google customer match removal failed (membership TTL heals)', {
             consumerId, error: err?.message || String(err),

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -134,6 +134,7 @@ export function makeErasureService(overrides = {}) {
     };
     let outboxPairs = [];
     let erasedPhone = null;
+    const googleCmRemovalPairs = []; // pre-scrub {email, phone} for the CM removal hook
 
     await d.sequelize.transaction(async (t) => {
       // 1. THE lock — every capture of this phone serializes behind this row.
@@ -179,6 +180,18 @@ export function makeErasureService(overrides = {}) {
         lock: Transaction.LOCK.UPDATE,
       });
       const pids = prospects.map((p) => p.id);
+      // Google Customer Match removal (plan google-ads-signal-levers §3):
+      // capture the raw pairs BEFORE the scrub destroys them — after commit
+      // no identifier survives to remove the external list membership.
+      // Collection is pure string-copying; the actual removal call runs
+      // post-commit (never inside the row-locked transaction).
+      if (process.env.GOOGLE_CM_CAMPAIGN_ID) {
+        for (const p of prospects) {
+          if (p.campaignId === process.env.GOOGLE_CM_CAMPAIGN_ID && (p.email || p.phone)) {
+            googleCmRemovalPairs.push({ email: p.email, phone: p.phone });
+          }
+        }
+      }
       const prospectEmails = prospects.map((p) => emailNormKey(p.email)).filter(Boolean);
       const sessionIds = [...new Set(prospects.map((p) => p.sessionId).filter(Boolean))];
       const attributionIds = [...new Set(prospects.map((p) => p.attributionId).filter(Boolean))];
@@ -767,6 +780,21 @@ export function makeErasureService(overrides = {}) {
     // (fallback rule, tracker "propagate"). Fire-and-forget: the periodic
     // pass heals a lost trigger.
     d.flushDeliveries(outboxPairs);
+    // Google Customer Match removal — post-commit, fire-and-forget (erasure
+    // success never depends on Google availability; the list's finite
+    // membership duration backstops a lost call). Dynamic import keeps this
+    // service's import graph unchanged.
+    if (googleCmRemovalPairs.length) {
+      import('./googleCustomerMatchService.js')
+        .then(({ buildRemovalIdentifiers, removeAudienceMembers }) =>
+          removeAudienceMembers(buildRemovalIdentifiers(googleCmRemovalPairs))
+        )
+        .catch((err) => {
+          d.logger.warn('[erasure] google customer match removal failed (membership TTL heals)', {
+            consumerId, error: err?.message || String(err),
+          });
+        });
+    }
     Promise.resolve(d.reconcileSuppressionPropagation({ consumerId })).catch((err) => {
       d.logger.warn('[erasure] suppression propagation trigger failed (periodic pass heals)', {
         consumerId, error: err?.message || String(err),

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -278,12 +278,17 @@ export async function settlePendingStatuses(deps = {}) {
   // removePartial tracked separately: a PARTIAL_SUCCESS *removal* left people
   // on the list (alert-worthy); a PARTIAL_SUCCESS ingest self-heals nightly.
   const summary = { polled: 0, succeeded: 0, partialSuccess: 0, removePartial: 0, failed: 0, stuck: 0, pending: 0 };
+  // Partition SYNCHRONOUSLY, due entries ONLY: not-yet-due entries stay in
+  // the shared queue, so a pass stalled on a hung retrieve (Google outage)
+  // can never hide later-due entries from subsequent drainer runs — and
+  // because the take happens before any await, an overlapping pass cannot
+  // double-poll the same entry.
+  const due = [];
+  for (let i = pendingSettles.length - 1; i >= 0; i--) {
+    if (pendingSettles[i].nextPollAt <= now) due.push(...pendingSettles.splice(i, 1));
+  }
   const keep = [];
-  for (const entry of pendingSettles.splice(0)) {
-    if (entry.nextPollAt > now) {
-      keep.push(entry);
-      continue;
-    }
+  for (const entry of due) {
     summary.polled += 1;
     let status = null;
     let retrieveFailed = false;
@@ -363,11 +368,11 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
   if (!shouldSync()) {
     logger.info('google_cm.sync.skipped (disabled or missing config)');
-    return { synced: false, reason: 'guarded' };
+    return { submitted: false, reason: 'guarded' };
   }
   if (syncInFlight) {
     logger.warn('google_cm.sync.overlap_skipped');
-    return { synced: false, reason: 'overlap' };
+    return { submitted: false, reason: 'overlap' };
   }
   syncInFlight = true;
 
@@ -387,7 +392,7 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
     if (rows.length === 0) {
       logger.warn('google_cm.sync.empty (no eligible members)');
-      return { synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null };
+      return { submitted: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null };
     }
 
     const batches = chunk(rows, MAX_BATCH_MEMBERS);
@@ -422,8 +427,10 @@ export async function syncGoogleCustomerMatch(deps = {}) {
     queueSettles(acceptedIds, 'ingest', d.now ? d.now() : Date.now());
 
     const wholesale = acceptedIds.length === 0;
+    // "submitted", not "synced": acceptance-only truth. Whether the accepted
+    // requests actually landed is the settler's story, hours later.
     const summary = {
-      synced: !wholesale,
+      submitted: !wholesale,
       eligible: rows.length,
       batches: batches.length,
       accepted: acceptedIds.length,
@@ -464,7 +471,7 @@ export async function syncGoogleCustomerMatch(deps = {}) {
       d,
       '⚠️ MKTR Google Customer Match sync FAILED (nothing uploaded)',
       [
-        'The Google Customer Match exclusion sync aborted — nothing was uploaded this run.',
+        'The Google Customer Match exclusion sync aborted — nothing was submitted this run.',
         '',
         `Error:     ${err.message}`,
         `List:      ${process.env.GOOGLE_CM_USER_LIST_ID || '(unset)'}`,
@@ -475,7 +482,7 @@ export async function syncGoogleCustomerMatch(deps = {}) {
         'Check Render logs (mktr-backend-jo6r, search "google_cm") + Sentry (source:google_cm_sync).',
       ].join('\n')
     );
-    return { synced: false, error: err.message };
+    return { submitted: false, error: err.message };
   } finally {
     syncInFlight = false;
   }
@@ -493,8 +500,8 @@ export async function removeAudienceMembers(identifierRows, deps = {}) {
   if (rows.length === 0) return { accepted: 0, reason: 'empty' };
   try {
     // Removal is as asynchronous as ingestion: HTTP accept only returns a
-    // requestId. A missing id is a failed batch, and accepted ids are settled
-    // to terminal states before success is claimed.
+    // requestId. A missing id is a failed batch; accepted ids join the
+    // deferred settlement queue — no removal success is ever claimed in-run.
     const batches = chunk(rows, MAX_BATCH_MEMBERS);
     const acceptedIds = [];
     let failedBatches = 0;

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -392,7 +392,9 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
     if (rows.length === 0) {
       logger.warn('google_cm.sync.empty (no eligible members)');
-      return { submitted: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null };
+      // ok distinguishes a healthy no-op from failure; submitted stays
+      // acceptance-only (zero requests were made).
+      return { submitted: false, ok: true, reason: 'empty', eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null };
     }
 
     const batches = chunk(rows, MAX_BATCH_MEMBERS);

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -48,7 +48,7 @@ import { contactGrantAllows } from './contactConsent.js';
  * anything these hooks miss.
  */
 
-const MAX_BATCH_MEMBERS = 5000; // ≤2 identifiers/member keeps us under the 10k identifier cap
+const MAX_BATCH_MEMBERS = 10_000; // Data Manager cap: 10k audience members/request (≤10 identifiers each)
 const SYNTHETIC_EMAIL_SUFFIX = '@calls.mktr.sg';
 const TERMINAL_STATUSES = new Set(['SUCCESS', 'PARTIAL_SUCCESS', 'FAILED']);
 
@@ -61,6 +61,7 @@ const defaultDeps = {
   dmRequest,
   dmRequestGet,
   sleep: realSleep,
+  now: Date.now,
 };
 
 /**
@@ -224,44 +225,123 @@ function extractStatus(body) {
 }
 
 /**
- * Poll each unique accepted requestId through requestStatus:retrieve to a
- * terminal state with bounded backoff (10s → 60s cap, GOOGLE_CM_STATUS_MAX_POLLS
- * attempts each, default 6). Ids still non-terminal after the budget count as
- * STUCK. A retrieve call that itself errors marks the id stuck (never throws).
- * Aggregate counts only — never per-person state.
+ * DEFERRED settlement (Codex P2b round 3): Google's diagnostics guidance is
+ * first poll ~30 MINUTES after acceptance, polling up to 24 hours — an
+ * in-run settle would classify every normal request as stuck. Accepted
+ * requestIds therefore join a module-level pending queue; a lightweight
+ * interval (bootstrap, GOOGLE_CM_SETTLE_INTERVAL_MINUTES, default 15) drains
+ * due entries with ~1.3× backoff capped at 1h + jitter, out to a 24h horizon.
+ *
+ * Consequence: sync/removal results report ACCEPTANCE truth in-run
+ * (settlement: 'queued'); OUTCOME truth lands asynchronously here — terminal
+ * FAILED and horizon-expired entries alert + Sentry. A process restart drops
+ * pending ids (accepted loss: accounting is aggregate-only and the nightly
+ * additive re-ingest self-heals; removal is backstopped by the membership TTL).
  */
-export async function settleRequestStatuses(requestIds, deps = {}) {
+const pendingSettles = []; // { requestId, kind: 'ingest'|'remove', acceptedAt, nextPollAt, delayMs }
+
+/** Test seam — clears the pending-settlement queue. */
+export function __resetPendingSettlesForTests() {
+  pendingSettles.length = 0;
+}
+
+function firstPollDelayMs() {
+  return Math.max(1, Number(process.env.GOOGLE_CM_FIRST_POLL_MINUTES) || 30) * 60_000;
+}
+
+const SETTLE_HORIZON_MS = 24 * 60 * 60 * 1000;
+const SETTLE_BACKOFF_FACTOR = 1.3;
+const SETTLE_MAX_DELAY_MS = 60 * 60 * 1000;
+
+function queueSettles(requestIds, kind, now) {
+  for (const id of new Set((requestIds || []).filter(Boolean))) {
+    const delayMs = firstPollDelayMs();
+    pendingSettles.push({
+      requestId: id,
+      kind,
+      acceptedAt: now,
+      nextPollAt: now + delayMs,
+      delayMs,
+    });
+  }
+}
+
+/**
+ * Drain due pending settlements: one poll each; terminal states are counted
+ * and logged; non-terminal entries reschedule with backoff until the 24h
+ * horizon (then counted stuck). FAILED/stuck raise the alert email + Sentry.
+ * Never throws. Exported for the bootstrap interval and tests.
+ */
+export async function settlePendingStatuses(deps = {}) {
   const d = { ...defaultDeps, ...deps };
-  const maxPolls = Math.max(1, Number(process.env.GOOGLE_CM_STATUS_MAX_POLLS) || 6);
-  const summary = { succeeded: 0, partialSuccess: 0, failed: 0, stuck: 0 };
-  const unique = [...new Set((requestIds || []).filter(Boolean))];
-  for (const id of unique) {
-    let settled = false;
-    for (let attempt = 0; attempt < maxPolls && !settled; attempt++) {
-      if (attempt > 0) await d.sleep(Math.min(10_000 * 2 ** (attempt - 1), 60_000));
-      let status = null;
-      try {
-        const body = await d.dmRequestGet(
-          `requestStatus:retrieve?requestId=${encodeURIComponent(id)}`,
-          d
-        );
-        status = extractStatus(body);
-      } catch (err) {
-        logger.warn({ requestId: id, err: err.message }, 'google_cm.status.retrieve_failed');
-        break; // treated as stuck below
-      }
-      if (status && TERMINAL_STATUSES.has(status)) {
-        settled = true;
-        if (status === 'SUCCESS') summary.succeeded += 1;
-        else if (status === 'PARTIAL_SUCCESS') summary.partialSuccess += 1;
-        else summary.failed += 1;
-        logger.info({ requestId: id, status }, 'google_cm.status.terminal');
-      }
+  const now = d.now ? d.now() : Date.now();
+  // removePartial tracked separately: a PARTIAL_SUCCESS *removal* left people
+  // on the list (alert-worthy); a PARTIAL_SUCCESS ingest self-heals nightly.
+  const summary = { polled: 0, succeeded: 0, partialSuccess: 0, removePartial: 0, failed: 0, stuck: 0, pending: 0 };
+  const keep = [];
+  for (const entry of pendingSettles.splice(0)) {
+    if (entry.nextPollAt > now) {
+      keep.push(entry);
+      continue;
     }
-    if (!settled) {
+    summary.polled += 1;
+    let status = null;
+    let retrieveFailed = false;
+    try {
+      const body = await d.dmRequestGet(
+        `requestStatus:retrieve?requestId=${encodeURIComponent(entry.requestId)}`,
+        d
+      );
+      status = extractStatus(body);
+    } catch (err) {
+      retrieveFailed = true;
+      logger.warn({ requestId: entry.requestId, err: err.message }, 'google_cm.status.retrieve_failed');
+    }
+    if (status && TERMINAL_STATUSES.has(status)) {
+      if (status === 'SUCCESS') summary.succeeded += 1;
+      else if (status === 'PARTIAL_SUCCESS') {
+        summary.partialSuccess += 1;
+        if (entry.kind === 'remove') summary.removePartial += 1;
+      } else summary.failed += 1;
+      logger.info({ requestId: entry.requestId, kind: entry.kind, status }, 'google_cm.status.terminal');
+      continue;
+    }
+    if (now - entry.acceptedAt >= SETTLE_HORIZON_MS) {
       summary.stuck += 1;
-      logger.warn({ requestId: id }, 'google_cm.status.stuck');
+      logger.warn({ requestId: entry.requestId, kind: entry.kind, retrieveFailed }, 'google_cm.status.stuck');
+      continue;
     }
+    const nextDelay = Math.min(Math.round(entry.delayMs * SETTLE_BACKOFF_FACTOR), SETTLE_MAX_DELAY_MS);
+    keep.push({
+      ...entry,
+      delayMs: nextDelay,
+      nextPollAt: now + nextDelay + Math.floor(Math.random() * 30_000),
+    });
+  }
+  pendingSettles.push(...keep);
+  summary.pending = pendingSettles.length;
+  if (summary.failed > 0 || summary.stuck > 0 || summary.removePartial > 0) {
+    Sentry.captureMessage('google_cm.settle.troubled', {
+      level: 'warning',
+      tags: { source: 'google_cm_sync' },
+      extra: summary,
+    });
+    await sendBadRunAlert(
+      d,
+      '⚠️ MKTR Google Customer Match — settlement failures',
+      [
+        'Accepted Data Manager requests ended FAILED, partially-removed, or never settled inside 24h.',
+        '',
+        `Summary: ${JSON.stringify(summary)}`,
+        `Time:    ${new Date().toISOString()}`,
+        '',
+        'Ingest coverage self-heals on the nightly additive re-ingest; removals',
+        'are backstopped by the list membership TTL.',
+        'Check Render logs (mktr-backend-jo6r, search "google_cm") + Sentry.',
+      ].join('\n')
+    );
+  } else if (summary.polled > 0) {
+    logger.info(summary, 'google_cm.settle.done');
   }
   return summary;
 }
@@ -307,7 +387,7 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
     if (rows.length === 0) {
       logger.warn('google_cm.sync.empty (no eligible members)');
-      return { synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, status: null };
+      return { synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null };
     }
 
     const batches = chunk(rows, MAX_BATCH_MEMBERS);
@@ -336,45 +416,37 @@ export async function syncGoogleCustomerMatch(deps = {}) {
       }
     }
 
-    const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
+    // Acceptance truth in-run; OUTCOME truth arrives via the deferred
+    // settlement queue (Google: first diagnostics poll ~30min out). No
+    // in-run claim of confirmed delivery is made.
+    queueSettles(acceptedIds, 'ingest', d.now ? d.now() : Date.now());
 
-    // Classification derives from TERMINAL OUTCOMES, not HTTP acceptance:
-    // Google can accept every batch and later fail every record.
-    const confirmed = status ? status.succeeded + status.partialSuccess : 0;
-    const wholesale = acceptedIds.length === 0 || (status !== null && confirmed === 0 && status.stuck === 0);
-    const unconfirmed = status !== null && confirmed === 0 && status.stuck > 0;
+    const wholesale = acceptedIds.length === 0;
     const summary = {
-      synced: !wholesale && !unconfirmed,
-      ...(unconfirmed ? { reason: 'unconfirmed' } : {}),
+      synced: !wholesale,
       eligible: rows.length,
       batches: batches.length,
       accepted: acceptedIds.length,
       failedBatches,
-      status,
+      settlement: acceptedIds.length ? 'queued' : null,
     };
     logger.info(summary, 'google_cm.sync.done');
 
-    const troubled = failedBatches > 0 || (status && (status.failed > 0 || status.stuck > 0));
-    if (wholesale || unconfirmed || troubled) {
+    if (wholesale || failedBatches > 0) {
       await sendBadRunAlert(
         d,
         wholesale
           ? '⚠️ MKTR Google Customer Match sync FAILED (nothing uploaded)'
-          : unconfirmed
-            ? '⚠️ MKTR Google Customer Match sync — unconfirmed (status stuck)'
-            : '⚠️ MKTR Google Customer Match sync — partial failure',
+          : '⚠️ MKTR Google Customer Match sync — partial failure',
         [
           wholesale
-            ? 'No batch reached a successful terminal state — treat as nothing uploaded.'
-            : unconfirmed
-              ? 'Accepted batches never reached a terminal state — outcome unknown.'
-              : 'Some batches or request statuses failed; confirmed batches stand.',
+            ? 'Every ingest batch failed at the transport layer — nothing was accepted.'
+            : 'Some batches failed at the transport layer; accepted batches settle asynchronously.',
           '',
           `Eligible:        ${rows.length}`,
           `Batches:         ${batches.length}`,
           `Accepted:        ${acceptedIds.length}`,
           `Failed batches:  ${failedBatches}`,
-          `Status summary:  ${JSON.stringify(status)}`,
           `List:            ${process.env.GOOGLE_CM_USER_LIST_ID}`,
           `Campaign:        ${process.env.GOOGLE_CM_CAMPAIGN_ID}`,
           `Time:            ${new Date().toISOString()}`,
@@ -416,9 +488,9 @@ export async function syncGoogleCustomerMatch(deps = {}) {
  */
 export async function removeAudienceMembers(identifierRows, deps = {}) {
   const d = { ...defaultDeps, ...deps };
-  if (!removalConfigured()) return { removed: false, reason: 'unconfigured' };
+  if (!removalConfigured()) return { accepted: 0, reason: 'unconfigured' };
   const rows = (identifierRows || []).filter((r) => r?.userIdentifiers?.length);
-  if (rows.length === 0) return { removed: false, reason: 'empty' };
+  if (rows.length === 0) return { accepted: 0, reason: 'empty' };
   try {
     // Removal is as asynchronous as ingestion: HTTP accept only returns a
     // requestId. A missing id is a failed batch, and accepted ids are settled
@@ -437,29 +509,33 @@ export async function removeAudienceMembers(identifierRows, deps = {}) {
         logger.error({ err: err.message }, 'google_cm.remove.batch_failed');
       }
     }
-    const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
-    // Removal demands FULL success: a PARTIAL_SUCCESS removal left people ON
-    // the list, which must never be reported as removed (ingest tolerates
-    // partials — coverage self-heals additively; removal has no such healer,
-    // only the membership TTL).
-    const confirmed = status ? status.succeeded : 0;
-    const removed = failedBatches === 0 && status !== null && confirmed === acceptedIds.length;
-    const summary = { removed, members: rows.length, accepted: acceptedIds.length, failedBatches, status };
-    if (!removed) {
-      Sentry.captureMessage('google_cm.remove.unconfirmed', {
+    // Removal outcomes settle asynchronously like ingests (first poll ~30min
+    // out). In-run we report ACCEPTANCE only — never removed:true — and the
+    // settler alerts on FAILED/stuck (a PARTIAL_SUCCESS or FAILED removal
+    // left people on the list; the membership TTL is the healer). accepted
+    // means "Google took the removal request", nothing stronger.
+    queueSettles(acceptedIds, 'remove', d.now ? d.now() : Date.now());
+    const summary = {
+      accepted: acceptedIds.length,
+      members: rows.length,
+      failedBatches,
+      settlement: acceptedIds.length ? 'queued' : null,
+    };
+    if (failedBatches > 0 || acceptedIds.length === 0) {
+      Sentry.captureMessage('google_cm.remove.transport_failures', {
         level: 'warning',
         tags: { source: 'google_cm_remove' },
-        extra: { members: rows.length, accepted: acceptedIds.length, failedBatches, status },
+        extra: summary,
       });
-      logger.warn(summary, 'google_cm.remove.unconfirmed (membership TTL backstops)');
+      logger.warn(summary, 'google_cm.remove.transport_failures (membership TTL backstops)');
     } else {
-      logger.info(summary, 'google_cm.remove.done');
+      logger.info(summary, 'google_cm.remove.accepted');
     }
     return summary;
   } catch (err) {
     Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
     logger.error({ err: err.message }, 'google_cm.remove.failed');
-    return { removed: false, error: err.message };
+    return { accepted: 0, error: err.message };
   }
 }
 
@@ -471,7 +547,7 @@ export async function removeAudienceMembers(identifierRows, deps = {}) {
 export async function removeByConsumerId(consumerId, deps = {}) {
   const d = { ...defaultDeps, ...deps };
   if (!removalConfigured() || !process.env.GOOGLE_CM_CAMPAIGN_ID || !consumerId) {
-    return { removed: false, reason: 'unconfigured' };
+    return { accepted: 0, reason: 'unconfigured' };
   }
   try {
     const rows = await d.Prospect.findAll({
@@ -483,6 +559,6 @@ export async function removeByConsumerId(consumerId, deps = {}) {
   } catch (err) {
     Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
     logger.error({ err: err.message }, 'google_cm.remove.lookup_failed');
-    return { removed: false, error: err.message };
+    return { accepted: 0, error: err.message };
   }
 }

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -338,8 +338,14 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
     const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
 
+    // Classification derives from TERMINAL OUTCOMES, not HTTP acceptance:
+    // Google can accept every batch and later fail every record.
+    const confirmed = status ? status.succeeded + status.partialSuccess : 0;
+    const wholesale = acceptedIds.length === 0 || (status !== null && confirmed === 0 && status.stuck === 0);
+    const unconfirmed = status !== null && confirmed === 0 && status.stuck > 0;
     const summary = {
-      synced: acceptedIds.length > 0,
+      synced: !wholesale && !unconfirmed,
+      ...(unconfirmed ? { reason: 'unconfirmed' } : {}),
       eligible: rows.length,
       batches: batches.length,
       accepted: acceptedIds.length,
@@ -348,18 +354,21 @@ export async function syncGoogleCustomerMatch(deps = {}) {
     };
     logger.info(summary, 'google_cm.sync.done');
 
-    const wholesale = acceptedIds.length === 0;
     const troubled = failedBatches > 0 || (status && (status.failed > 0 || status.stuck > 0));
-    if (wholesale || troubled) {
+    if (wholesale || unconfirmed || troubled) {
       await sendBadRunAlert(
         d,
         wholesale
           ? '⚠️ MKTR Google Customer Match sync FAILED (nothing uploaded)'
-          : '⚠️ MKTR Google Customer Match sync — partial failure',
+          : unconfirmed
+            ? '⚠️ MKTR Google Customer Match sync — unconfirmed (status stuck)'
+            : '⚠️ MKTR Google Customer Match sync — partial failure',
         [
           wholesale
-            ? 'Every ingest batch failed — nothing was uploaded this run.'
-            : 'Some batches or request statuses failed; accepted batches stand.',
+            ? 'No batch reached a successful terminal state — treat as nothing uploaded.'
+            : unconfirmed
+              ? 'Accepted batches never reached a terminal state — outcome unknown.'
+              : 'Some batches or request statuses failed; confirmed batches stand.',
           '',
           `Eligible:        ${rows.length}`,
           `Batches:         ${batches.length}`,
@@ -411,14 +420,39 @@ export async function removeAudienceMembers(identifierRows, deps = {}) {
   const rows = (identifierRows || []).filter((r) => r?.userIdentifiers?.length);
   if (rows.length === 0) return { removed: false, reason: 'empty' };
   try {
+    // Removal is as asynchronous as ingestion: HTTP accept only returns a
+    // requestId. A missing id is a failed batch, and accepted ids are settled
+    // to terminal states before success is claimed.
     const batches = chunk(rows, MAX_BATCH_MEMBERS);
-    const requestIds = [];
+    const acceptedIds = [];
+    let failedBatches = 0;
     for (const batch of batches) {
-      const res = await d.dmRequest('audienceMembers:remove', buildRemoveBody(batch), d);
-      requestIds.push(res?.requestId || null);
+      try {
+        const res = await d.dmRequest('audienceMembers:remove', buildRemoveBody(batch), d);
+        if (res?.requestId) acceptedIds.push(res.requestId);
+        else failedBatches += 1;
+      } catch (err) {
+        failedBatches += 1;
+        Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
+        logger.error({ err: err.message }, 'google_cm.remove.batch_failed');
+      }
     }
-    logger.info({ members: rows.length, batches: batches.length }, 'google_cm.remove.done');
-    return { removed: true, members: rows.length, requestIds };
+    const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
+    const confirmed = status ? status.succeeded + status.partialSuccess : 0;
+    const removed =
+      failedBatches === 0 && status !== null && confirmed === acceptedIds.length && status.stuck === 0;
+    const summary = { removed, members: rows.length, accepted: acceptedIds.length, failedBatches, status };
+    if (!removed) {
+      Sentry.captureMessage('google_cm.remove.unconfirmed', {
+        level: 'warning',
+        tags: { source: 'google_cm_remove' },
+        extra: { members: rows.length, accepted: acceptedIds.length, failedBatches, status },
+      });
+      logger.warn(summary, 'google_cm.remove.unconfirmed (membership TTL backstops)');
+    } else {
+      logger.info(summary, 'google_cm.remove.done');
+    }
+    return summary;
   } catch (err) {
     Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
     logger.error({ err: err.message }, 'google_cm.remove.failed');

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -1,0 +1,234 @@
+import * as Sentry from '@sentry/node';
+import { Op } from 'sequelize';
+import { Prospect } from '../models/index.js';
+import { hashEmailGoogle, hashPhoneE164 } from '../utils/piiHashing.js';
+import { dmRequest } from '../utils/googleDataManagerClient.js';
+import { phoneVerificationIsCurrent } from './consumerService.js';
+import { logger } from '../utils/logger.js';
+import { sendEmail } from './mailer.js';
+import { contactGrantAllows } from './contactConsent.js';
+
+/**
+ * Google Customer Match exclusion sync — the Google counterpart of
+ * redeemedAudienceService, uploading hashed email+phone of a campaign's
+ * verified entrants into a Customer Match list used as a CAMPAIGN-LEVEL
+ * EXCLUSION, so people the funnel would dedupe-reject anyway stop costing
+ * paid impressions (docs/plans/google-ads-signal-levers.md §3/2b).
+ *
+ * Deliberate differences from the Meta service, all review-driven (plan §10):
+ *  - PER-CAMPAIGN population (GOOGLE_CM_CAMPAIGN_ID): the funnel dedupe is
+ *    per (campaignId, phone) — a global list would suppress people still
+ *    eligible for other campaigns.
+ *  - Verified-phone predicate uses the shared phoneVerificationIsCurrent
+ *    binding semantic (phoneVerifiedFor is a HASH bound to the number the
+ *    stamp was earned for), never a bare phoneVerifiedAt check.
+ *  - NO consent escape hatch. The Meta service's REQUIRE_CONSENT=false also
+ *    removed its only verified-contact filter; not replicated here.
+ *  - Google-specific hashing: hashEmailGoogle (gmail canonicalization) +
+ *    hashPhoneE164 (E.164 WITH '+', the TikTok util — NOT Meta's digits-only
+ *    hashPhone; wrong normalizer = silent zero-match).
+ *  - Transport is the Data Manager API (audienceMembers:ingest) — the classic
+ *    Google Ads API's Customer Match surface is closed to new integrations
+ *    since 2026-04-01. Requests carry encoding:HEX (mandatory with hashed
+ *    userData), the Customer Match terms acceptance, and CONSENT_GRANTED
+ *    enums — truthful because every row is ledger-gated before upload.
+ *
+ * Erased rows never upload (sourceMetadata.erased skeleton). Erasure-time and
+ * withdrawal-time REMOVAL hooks live with the erasure/consent services (plan
+ * §3); the list's finite membership duration (Ads UI setting, 180d) is the
+ * backstop for anything those hooks miss.
+ */
+
+const MAX_BATCH_MEMBERS = 5000; // ≤2 identifiers/member keeps us under the 10k identifier cap
+const SYNTHETIC_EMAIL_SUFFIX = '@calls.mktr.sg';
+
+const defaultDeps = { Prospect, fetch: globalThis.fetch, sendEmail, dmRequest };
+
+/**
+ * Guard: no-op cleanly when the master switch is off or config is missing —
+ * a misconfigured scheduler exits instead of erroring. Mirrors
+ * redeemedAudienceService.shouldSync.
+ */
+export function shouldSync() {
+  if (process.env.GOOGLE_CM_SYNC_ENABLED !== 'true') return false;
+  if (!process.env.GOOGLE_DM_OAUTH_CLIENT_ID) return false;
+  if (!process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET) return false;
+  if (!process.env.GOOGLE_DM_REFRESH_TOKEN) return false;
+  if (!process.env.GOOGLE_ADS_CUSTOMER_ID) return false;
+  if (!process.env.GOOGLE_CM_USER_LIST_ID) return false;
+  if (!process.env.GOOGLE_CM_CAMPAIGN_ID) return false;
+  return true;
+}
+
+/** Split an array into chunks of `size`. Exported for testing. */
+export function chunk(arr, size) {
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Select the target campaign's non-bot prospects. sourceMetadata rides along
+ * for the erased flag + the verified-phone binding check in buildMemberRows.
+ */
+export async function selectCampaignProspects(deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  return d.Prospect.findAll({
+    attributes: ['email', 'phone', 'campaignId', 'sourceMetadata'],
+    where: {
+      campaignId: process.env.GOOGLE_CM_CAMPAIGN_ID,
+      leadSource: { [Op.ne]: 'call_bot' },
+    },
+    raw: true,
+  });
+}
+
+/**
+ * Prospect rows → Data Manager audience members. Every filter fails CLOSED:
+ *  - erased skeletons out
+ *  - unverified / stale-binding phones out (phoneVerificationIsCurrent)
+ *  - no ledger contact grant in scope {row campaign, global} → out (no hatch;
+ *    grantMap keyed BY PHONE like the Meta service so spine-unlinked rows
+ *    still enforce; missing map/phone/entry → excluded)
+ *  - suppressed phones out
+ *  - synthetic Retell emails dropped from the email key
+ *  - neither usable identifier → out
+ * Returns [{ userIdentifiers: [{emailAddress}|{phoneNumber}...] }, ...] with
+ * HEX SHA-256 values (request-level `encoding: "HEX"` declares this).
+ */
+export function buildMemberRows(prospects, { suppressedPhones = null, grantMap = null } = {}) {
+  const rows = [];
+  for (const p of prospects || []) {
+    if (p?.sourceMetadata?.erased === true) continue;
+    if (!phoneVerificationIsCurrent(p)) continue;
+    if (!contactGrantAllows(grantMap?.get(p?.phone), p?.campaignId || null)) continue;
+    if (suppressedPhones && p?.phone && suppressedPhones.has(p.phone)) continue;
+    const email =
+      p?.email && !String(p.email).toLowerCase().endsWith(SYNTHETIC_EMAIL_SUFFIX)
+        ? p.email
+        : null;
+    const emHash = hashEmailGoogle(email);
+    const phHash = hashPhoneE164(p?.phone);
+    if (!emHash && !phHash) continue;
+    const userIdentifiers = [];
+    if (emHash) userIdentifiers.push({ emailAddress: emHash });
+    if (phHash) userIdentifiers.push({ phoneNumber: phHash });
+    rows.push({ userIdentifiers });
+  }
+  return rows;
+}
+
+/**
+ * The ingest envelope for one batch. Exported for golden-envelope tests —
+ * field names are pinned from the plan's round-2/3 doc checks and re-verified
+ * by the opt-in validateOnly smoke script before the first live flip.
+ */
+export function buildIngestBody(members, { validateOnly = false } = {}) {
+  return {
+    destinations: [
+      {
+        operatingAccount: {
+          product: 'GOOGLE_ADS',
+          accountId: process.env.GOOGLE_ADS_CUSTOMER_ID,
+        },
+        productDestinationId: process.env.GOOGLE_CM_USER_LIST_ID,
+      },
+    ],
+    audienceMembers: members.map((m) => ({ userData: { userIdentifiers: m.userIdentifiers } })),
+    consent: { adUserData: 'CONSENT_GRANTED', adPersonalization: 'CONSENT_GRANTED' },
+    encoding: 'HEX',
+    termsOfService: { customerMatchTermsOfServiceStatus: 'ACCEPTED' },
+    ...(validateOnly ? { validateOnly: true } : {}),
+  };
+}
+
+async function sendBadRunAlert(d, subject, body) {
+  const to = process.env.GOOGLE_CM_ALERT_EMAIL || process.env.REDEEMED_AUDIENCE_ALERT_EMAIL;
+  if (!to) return;
+  try {
+    await d.sendEmail({ to, subject, text: body });
+    logger.info({ to }, 'google_cm.sync.alert_sent');
+  } catch (err) {
+    logger.warn({ err: err.message }, 'google_cm.sync.alert_failed');
+  }
+}
+
+// In-process single-flight: the scheduler's interval and a deploy's initial
+// run must never overlap (single-instance backend — this is the whole lock).
+let syncInFlight = false;
+
+/**
+ * Orchestrate a full sync. Never throws — errors land in Sentry + structured
+ * logs (counts only, never PII) + an optional alert email. Aggregate-only
+ * accounting is deliberate: membership isn't tracked per-row locally and the
+ * next additive run self-heals partial failures (plan §3 job lifecycle).
+ */
+export async function syncGoogleCustomerMatch(deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+
+  if (!shouldSync()) {
+    logger.info('google_cm.sync.skipped (disabled or missing config)');
+    return { synced: false, reason: 'guarded' };
+  }
+  if (syncInFlight) {
+    logger.warn('google_cm.sync.overlap_skipped');
+    return { synced: false, reason: 'overlap' };
+  }
+  syncInFlight = true;
+
+  try {
+    // Fail-closed by construction: if either ledger lookup throws, the run
+    // aborts — never upload while blind to withdrawals/suppressions.
+    const { getSuppressedPhoneSet, getMarketableGrantMap } = await import('./consentService.js');
+    const suppressedPhones = await getSuppressedPhoneSet();
+    const grantMap = await getMarketableGrantMap();
+
+    const prospects = await selectCampaignProspects(d);
+    const rows = buildMemberRows(prospects, { suppressedPhones, grantMap });
+    logger.info(
+      { selected: prospects.length, eligible: rows.length, campaignId: process.env.GOOGLE_CM_CAMPAIGN_ID },
+      'google_cm.sync.start'
+    );
+
+    if (rows.length === 0) {
+      logger.warn('google_cm.sync.empty (no eligible members)');
+      return { synced: true, eligible: 0, batches: 0, requestIds: [] };
+    }
+
+    const batches = chunk(rows, MAX_BATCH_MEMBERS);
+    const requestIds = [];
+    for (let i = 0; i < batches.length; i++) {
+      const body = buildIngestBody(batches[i]);
+      const res = await d.dmRequest('audienceMembers:ingest', body, d);
+      requestIds.push(res?.requestId || null);
+      logger.info(
+        { batch: i + 1, members: batches[i].length, requestId: res?.requestId },
+        'google_cm.sync.batch'
+      );
+    }
+
+    logger.info({ eligible: rows.length, batches: batches.length, requestIds }, 'google_cm.sync.done');
+    return { synced: true, eligible: rows.length, batches: batches.length, requestIds };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { source: 'google_cm_sync' } });
+    logger.error({ err: err.message }, 'google_cm.sync.failed');
+    await sendBadRunAlert(
+      d,
+      '⚠️ MKTR Google Customer Match sync FAILED',
+      [
+        'The Google Customer Match exclusion sync failed — nothing was uploaded this run.',
+        '',
+        `Error:     ${err.message}`,
+        `List:      ${process.env.GOOGLE_CM_USER_LIST_ID || '(unset)'}`,
+        `Campaign:  ${process.env.GOOGLE_CM_CAMPAIGN_ID || '(unset)'}`,
+        `Time:      ${new Date().toISOString()}`,
+        '',
+        'It will retry on the next scheduled run (~24h) or next deploy.',
+        'Check Render logs (mktr-backend-jo6r, search "google_cm") + Sentry (source:google_cm_sync).',
+      ].join('\n')
+    );
+    return { synced: false, error: err.message };
+  } finally {
+    syncInFlight = false;
+  }
+}

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import { Op } from 'sequelize';
 import { Prospect } from '../models/index.js';
 import { hashEmailGoogle, hashPhoneE164 } from '../utils/piiHashing.js';
-import { dmRequest } from '../utils/googleDataManagerClient.js';
+import { dmRequest, dmRequestGet } from '../utils/googleDataManagerClient.js';
 import { phoneVerificationIsCurrent } from './consumerService.js';
 import { logger } from '../utils/logger.js';
 import { sendEmail } from './mailer.js';
@@ -32,31 +32,60 @@ import { contactGrantAllows } from './contactConsent.js';
  *    since 2026-04-01. Requests carry encoding:HEX (mandatory with hashed
  *    userData), the Customer Match terms acceptance, and CONSENT_GRANTED
  *    enums — truthful because every row is ledger-gated before upload.
+ *  - Ingestion is ASYNCHRONOUS: HTTP accept returns a requestId whose
+ *    processing settles later. Every accepted id is polled through
+ *    requestStatus:retrieve to a terminal state (bounded backoff); stuck or
+ *    FAILED requests alert. Accounting stays aggregate-only — membership is
+ *    not tracked per-row locally and the next additive run self-heals.
  *
- * Erased rows never upload (sourceMetadata.erased skeleton). Erasure-time and
- * withdrawal-time REMOVAL hooks live with the erasure/consent services (plan
- * §3); the list's finite membership duration (Ads UI setting, 180d) is the
- * backstop for anything those hooks miss.
+ * REMOVAL surface (plan §3 removal path): removeAudienceMembers /
+ * removeByConsumerId serve the erasure post-commit hook and the
+ * applyUnsubscribe post-commit hook (both call in via dynamic import,
+ * fire-and-forget). Removal is gated only on removalConfigured() — NOT the
+ * sync ENABLED flag: once anything was ever uploaded, honoring erasure/
+ * withdrawal must not depend on the sync still being switched on. The list's
+ * finite membership duration (Ads UI setting, 180d) is the backstop for
+ * anything these hooks miss.
  */
 
 const MAX_BATCH_MEMBERS = 5000; // ≤2 identifiers/member keeps us under the 10k identifier cap
 const SYNTHETIC_EMAIL_SUFFIX = '@calls.mktr.sg';
+const TERMINAL_STATUSES = new Set(['SUCCESS', 'PARTIAL_SUCCESS', 'FAILED']);
 
-const defaultDeps = { Prospect, fetch: globalThis.fetch, sendEmail, dmRequest };
+const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const defaultDeps = {
+  Prospect,
+  fetch: globalThis.fetch,
+  sendEmail,
+  dmRequest,
+  dmRequestGet,
+  sleep: realSleep,
+};
 
 /**
- * Guard: no-op cleanly when the master switch is off or config is missing —
- * a misconfigured scheduler exits instead of erroring. Mirrors
+ * Guard for the SYNC: no-op cleanly when the master switch is off or config
+ * is missing — a misconfigured scheduler exits instead of erroring. Mirrors
  * redeemedAudienceService.shouldSync.
  */
 export function shouldSync() {
   if (process.env.GOOGLE_CM_SYNC_ENABLED !== 'true') return false;
+  if (!removalConfigured()) return false;
+  if (!process.env.GOOGLE_CM_CAMPAIGN_ID) return false;
+  return true;
+}
+
+/**
+ * Guard for the REMOVAL surface: creds + destination only. Deliberately
+ * ignores GOOGLE_CM_SYNC_ENABLED — erasure/withdrawal removal must keep
+ * working after the sync is switched off.
+ */
+export function removalConfigured() {
   if (!process.env.GOOGLE_DM_OAUTH_CLIENT_ID) return false;
   if (!process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET) return false;
   if (!process.env.GOOGLE_DM_REFRESH_TOKEN) return false;
   if (!process.env.GOOGLE_ADS_CUSTOMER_ID) return false;
   if (!process.env.GOOGLE_CM_USER_LIST_ID) return false;
-  if (!process.env.GOOGLE_CM_CAMPAIGN_ID) return false;
   return true;
 }
 
@@ -83,6 +112,18 @@ export async function selectCampaignProspects(deps = {}) {
   });
 }
 
+/** email/phone → HEX-hash identifier array (shared by ingest + removal). */
+function identifiersFor(email, phone) {
+  const usableEmail =
+    email && !String(email).toLowerCase().endsWith(SYNTHETIC_EMAIL_SUFFIX) ? email : null;
+  const emHash = hashEmailGoogle(usableEmail);
+  const phHash = hashPhoneE164(phone);
+  const userIdentifiers = [];
+  if (emHash) userIdentifiers.push({ emailAddress: emHash });
+  if (phHash) userIdentifiers.push({ phoneNumber: phHash });
+  return userIdentifiers;
+}
+
 /**
  * Prospect rows → Data Manager audience members. Every filter fails CLOSED:
  *  - erased skeletons out
@@ -93,8 +134,6 @@ export async function selectCampaignProspects(deps = {}) {
  *  - suppressed phones out
  *  - synthetic Retell emails dropped from the email key
  *  - neither usable identifier → out
- * Returns [{ userIdentifiers: [{emailAddress}|{phoneNumber}...] }, ...] with
- * HEX SHA-256 values (request-level `encoding: "HEX"` declares this).
  */
 export function buildMemberRows(prospects, { suppressedPhones = null, grantMap = null } = {}) {
   const rows = [];
@@ -103,19 +142,39 @@ export function buildMemberRows(prospects, { suppressedPhones = null, grantMap =
     if (!phoneVerificationIsCurrent(p)) continue;
     if (!contactGrantAllows(grantMap?.get(p?.phone), p?.campaignId || null)) continue;
     if (suppressedPhones && p?.phone && suppressedPhones.has(p.phone)) continue;
-    const email =
-      p?.email && !String(p.email).toLowerCase().endsWith(SYNTHETIC_EMAIL_SUFFIX)
-        ? p.email
-        : null;
-    const emHash = hashEmailGoogle(email);
-    const phHash = hashPhoneE164(p?.phone);
-    if (!emHash && !phHash) continue;
-    const userIdentifiers = [];
-    if (emHash) userIdentifiers.push({ emailAddress: emHash });
-    if (phHash) userIdentifiers.push({ phoneNumber: phHash });
+    const userIdentifiers = identifiersFor(p?.email, p?.phone);
+    if (userIdentifiers.length === 0) continue;
     rows.push({ userIdentifiers });
   }
   return rows;
+}
+
+/**
+ * Raw {email, phone} pairs → identifier rows for REMOVAL. No consent /
+ * verification gates: removing someone from an ad audience is always
+ * permitted and erasure-time callers hold pre-scrub values that are about to
+ * be destroyed. Synthetic emails still dropped (they never matched anyway).
+ */
+export function buildRemovalIdentifiers(pairs) {
+  const rows = [];
+  for (const p of pairs || []) {
+    const userIdentifiers = identifiersFor(p?.email, p?.phone);
+    if (userIdentifiers.length === 0) continue;
+    rows.push({ userIdentifiers });
+  }
+  return rows;
+}
+
+function destinations() {
+  return [
+    {
+      operatingAccount: {
+        product: 'GOOGLE_ADS',
+        accountId: process.env.GOOGLE_ADS_CUSTOMER_ID,
+      },
+      productDestinationId: process.env.GOOGLE_CM_USER_LIST_ID,
+    },
+  ];
 }
 
 /**
@@ -125,20 +184,22 @@ export function buildMemberRows(prospects, { suppressedPhones = null, grantMap =
  */
 export function buildIngestBody(members, { validateOnly = false } = {}) {
   return {
-    destinations: [
-      {
-        operatingAccount: {
-          product: 'GOOGLE_ADS',
-          accountId: process.env.GOOGLE_ADS_CUSTOMER_ID,
-        },
-        productDestinationId: process.env.GOOGLE_CM_USER_LIST_ID,
-      },
-    ],
+    destinations: destinations(),
     audienceMembers: members.map((m) => ({ userData: { userIdentifiers: m.userIdentifiers } })),
     consent: { adUserData: 'CONSENT_GRANTED', adPersonalization: 'CONSENT_GRANTED' },
     encoding: 'HEX',
     termsOfService: { customerMatchTermsOfServiceStatus: 'ACCEPTED' },
     ...(validateOnly ? { validateOnly: true } : {}),
+  };
+}
+
+/** The removal envelope. encoding:HEX is required with hashed userData; the
+ * Customer Match terms block is an INGEST requirement and is omitted here. */
+export function buildRemoveBody(members) {
+  return {
+    destinations: destinations(),
+    audienceMembers: members.map((m) => ({ userData: { userIdentifiers: m.userIdentifiers } })),
+    encoding: 'HEX',
   };
 }
 
@@ -153,15 +214,69 @@ async function sendBadRunAlert(d, subject, body) {
   }
 }
 
+function extractStatus(body) {
+  const raw =
+    body?.requestStatusPerDestination?.[0]?.requestStatus ??
+    body?.requestStatus ??
+    body?.status ??
+    null;
+  return raw ? String(raw).toUpperCase() : null;
+}
+
+/**
+ * Poll each unique accepted requestId through requestStatus:retrieve to a
+ * terminal state with bounded backoff (10s → 60s cap, GOOGLE_CM_STATUS_MAX_POLLS
+ * attempts each, default 6). Ids still non-terminal after the budget count as
+ * STUCK. A retrieve call that itself errors marks the id stuck (never throws).
+ * Aggregate counts only — never per-person state.
+ */
+export async function settleRequestStatuses(requestIds, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  const maxPolls = Math.max(1, Number(process.env.GOOGLE_CM_STATUS_MAX_POLLS) || 6);
+  const summary = { succeeded: 0, partialSuccess: 0, failed: 0, stuck: 0 };
+  const unique = [...new Set((requestIds || []).filter(Boolean))];
+  for (const id of unique) {
+    let settled = false;
+    for (let attempt = 0; attempt < maxPolls && !settled; attempt++) {
+      if (attempt > 0) await d.sleep(Math.min(10_000 * 2 ** (attempt - 1), 60_000));
+      let status = null;
+      try {
+        const body = await d.dmRequestGet(
+          `requestStatus:retrieve?requestId=${encodeURIComponent(id)}`,
+          d
+        );
+        status = extractStatus(body);
+      } catch (err) {
+        logger.warn({ requestId: id, err: err.message }, 'google_cm.status.retrieve_failed');
+        break; // treated as stuck below
+      }
+      if (status && TERMINAL_STATUSES.has(status)) {
+        settled = true;
+        if (status === 'SUCCESS') summary.succeeded += 1;
+        else if (status === 'PARTIAL_SUCCESS') summary.partialSuccess += 1;
+        else summary.failed += 1;
+        logger.info({ requestId: id, status }, 'google_cm.status.terminal');
+      }
+    }
+    if (!settled) {
+      summary.stuck += 1;
+      logger.warn({ requestId: id }, 'google_cm.status.stuck');
+    }
+  }
+  return summary;
+}
+
 // In-process single-flight: the scheduler's interval and a deploy's initial
 // run must never overlap (single-instance backend — this is the whole lock).
+// Held through status settling, not just the uploads.
 let syncInFlight = false;
 
 /**
  * Orchestrate a full sync. Never throws — errors land in Sentry + structured
- * logs (counts only, never PII) + an optional alert email. Aggregate-only
- * accounting is deliberate: membership isn't tracked per-row locally and the
- * next additive run self-heals partial failures (plan §3 job lifecycle).
+ * logs (counts only, never PII) + an optional alert email. Per-batch
+ * accounting: an accepted batch is never un-reported because a later batch
+ * failed, and alerts distinguish partial transport failure from wholesale
+ * failure.
  */
 export async function syncGoogleCustomerMatch(deps = {}) {
   const d = { ...defaultDeps, ...deps };
@@ -192,31 +307,83 @@ export async function syncGoogleCustomerMatch(deps = {}) {
 
     if (rows.length === 0) {
       logger.warn('google_cm.sync.empty (no eligible members)');
-      return { synced: true, eligible: 0, batches: 0, requestIds: [] };
+      return { synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, status: null };
     }
 
     const batches = chunk(rows, MAX_BATCH_MEMBERS);
-    const requestIds = [];
+    const acceptedIds = [];
+    let failedBatches = 0;
     for (let i = 0; i < batches.length; i++) {
-      const body = buildIngestBody(batches[i]);
-      const res = await d.dmRequest('audienceMembers:ingest', body, d);
-      requestIds.push(res?.requestId || null);
-      logger.info(
-        { batch: i + 1, members: batches[i].length, requestId: res?.requestId },
-        'google_cm.sync.batch'
-      );
+      try {
+        const body = buildIngestBody(batches[i]);
+        const res = await d.dmRequest('audienceMembers:ingest', body, d);
+        if (!res?.requestId) {
+          // An accept without a requestId cannot be settled — count it failed
+          // rather than assuming success (the next additive run re-covers it).
+          failedBatches += 1;
+          logger.warn({ batch: i + 1 }, 'google_cm.sync.batch_missing_request_id');
+          continue;
+        }
+        acceptedIds.push(res.requestId);
+        logger.info(
+          { batch: i + 1, members: batches[i].length, requestId: res.requestId },
+          'google_cm.sync.batch'
+        );
+      } catch (err) {
+        failedBatches += 1;
+        logger.error({ batch: i + 1, err: err.message }, 'google_cm.sync.batch_failed');
+        Sentry.captureException(err, { tags: { source: 'google_cm_sync' } });
+      }
     }
 
-    logger.info({ eligible: rows.length, batches: batches.length, requestIds }, 'google_cm.sync.done');
-    return { synced: true, eligible: rows.length, batches: batches.length, requestIds };
+    const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
+
+    const summary = {
+      synced: acceptedIds.length > 0,
+      eligible: rows.length,
+      batches: batches.length,
+      accepted: acceptedIds.length,
+      failedBatches,
+      status,
+    };
+    logger.info(summary, 'google_cm.sync.done');
+
+    const wholesale = acceptedIds.length === 0;
+    const troubled = failedBatches > 0 || (status && (status.failed > 0 || status.stuck > 0));
+    if (wholesale || troubled) {
+      await sendBadRunAlert(
+        d,
+        wholesale
+          ? '⚠️ MKTR Google Customer Match sync FAILED (nothing uploaded)'
+          : '⚠️ MKTR Google Customer Match sync — partial failure',
+        [
+          wholesale
+            ? 'Every ingest batch failed — nothing was uploaded this run.'
+            : 'Some batches or request statuses failed; accepted batches stand.',
+          '',
+          `Eligible:        ${rows.length}`,
+          `Batches:         ${batches.length}`,
+          `Accepted:        ${acceptedIds.length}`,
+          `Failed batches:  ${failedBatches}`,
+          `Status summary:  ${JSON.stringify(status)}`,
+          `List:            ${process.env.GOOGLE_CM_USER_LIST_ID}`,
+          `Campaign:        ${process.env.GOOGLE_CM_CAMPAIGN_ID}`,
+          `Time:            ${new Date().toISOString()}`,
+          '',
+          'The nightly additive re-ingest self-heals partial coverage.',
+          'Check Render logs (mktr-backend-jo6r, search "google_cm") + Sentry (source:google_cm_sync).',
+        ].join('\n')
+      );
+    }
+    return summary;
   } catch (err) {
     Sentry.captureException(err, { tags: { source: 'google_cm_sync' } });
     logger.error({ err: err.message }, 'google_cm.sync.failed');
     await sendBadRunAlert(
       d,
-      '⚠️ MKTR Google Customer Match sync FAILED',
+      '⚠️ MKTR Google Customer Match sync FAILED (nothing uploaded)',
       [
-        'The Google Customer Match exclusion sync failed — nothing was uploaded this run.',
+        'The Google Customer Match exclusion sync aborted — nothing was uploaded this run.',
         '',
         `Error:     ${err.message}`,
         `List:      ${process.env.GOOGLE_CM_USER_LIST_ID || '(unset)'}`,
@@ -230,5 +397,55 @@ export async function syncGoogleCustomerMatch(deps = {}) {
     return { synced: false, error: err.message };
   } finally {
     syncInFlight = false;
+  }
+}
+
+/**
+ * Remove identifier rows from the list. Never throws — erasure/withdrawal
+ * must never fail on Google availability; failures land in Sentry/logs and
+ * the finite membership duration mops up. Gated on removalConfigured() only.
+ */
+export async function removeAudienceMembers(identifierRows, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (!removalConfigured()) return { removed: false, reason: 'unconfigured' };
+  const rows = (identifierRows || []).filter((r) => r?.userIdentifiers?.length);
+  if (rows.length === 0) return { removed: false, reason: 'empty' };
+  try {
+    const batches = chunk(rows, MAX_BATCH_MEMBERS);
+    const requestIds = [];
+    for (const batch of batches) {
+      const res = await d.dmRequest('audienceMembers:remove', buildRemoveBody(batch), d);
+      requestIds.push(res?.requestId || null);
+    }
+    logger.info({ members: rows.length, batches: batches.length }, 'google_cm.remove.done');
+    return { removed: true, members: rows.length, requestIds };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
+    logger.error({ err: err.message }, 'google_cm.remove.failed');
+    return { removed: false, error: err.message };
+  }
+}
+
+/**
+ * Withdrawal-time removal: look up the person's rows in the target campaign
+ * and remove their identifiers. Called post-commit from
+ * consentService.applyUnsubscribe (dynamic import, fire-and-forget).
+ */
+export async function removeByConsumerId(consumerId, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (!removalConfigured() || !process.env.GOOGLE_CM_CAMPAIGN_ID || !consumerId) {
+    return { removed: false, reason: 'unconfigured' };
+  }
+  try {
+    const rows = await d.Prospect.findAll({
+      attributes: ['email', 'phone'],
+      where: { consumerId, campaignId: process.env.GOOGLE_CM_CAMPAIGN_ID },
+      raw: true,
+    });
+    return removeAudienceMembers(buildRemovalIdentifiers(rows), d);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { source: 'google_cm_remove' } });
+    logger.error({ err: err.message }, 'google_cm.remove.lookup_failed');
+    return { removed: false, error: err.message };
   }
 }

--- a/backend/src/services/googleCustomerMatchService.js
+++ b/backend/src/services/googleCustomerMatchService.js
@@ -438,9 +438,12 @@ export async function removeAudienceMembers(identifierRows, deps = {}) {
       }
     }
     const status = acceptedIds.length ? await settleRequestStatuses(acceptedIds, d) : null;
-    const confirmed = status ? status.succeeded + status.partialSuccess : 0;
-    const removed =
-      failedBatches === 0 && status !== null && confirmed === acceptedIds.length && status.stuck === 0;
+    // Removal demands FULL success: a PARTIAL_SUCCESS removal left people ON
+    // the list, which must never be reported as removed (ingest tolerates
+    // partials — coverage self-heals additively; removal has no such healer,
+    // only the membership TTL).
+    const confirmed = status ? status.succeeded : 0;
+    const removed = failedBatches === 0 && status !== null && confirmed === acceptedIds.length;
     const summary = { removed, members: rows.length, accepted: acceptedIds.length, failedBatches, status };
     if (!removed) {
       Sentry.captureMessage('google_cm.remove.unconfirmed', {

--- a/backend/src/utils/googleDataManagerClient.js
+++ b/backend/src/utils/googleDataManagerClient.js
@@ -146,11 +146,10 @@ async function authedRequest(method, path, payload, deps) {
   );
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
-    const err = new Error(
-      `google dm ${path} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()
+    throw Object.assign(
+      new Error(`google dm ${path} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()),
+      { status: res.status }
     );
-    err.status = res.status;
-    throw err;
   }
   logger.debug({ path, requestId: body?.requestId }, 'google_dm.request.ok');
   return body;

--- a/backend/src/utils/googleDataManagerClient.js
+++ b/backend/src/utils/googleDataManagerClient.js
@@ -14,14 +14,16 @@ import { logger } from './logger.js';
  * tokens die after 7 days, Internal ones are durable). Access tokens are
  * cached until shortly before expiry.
  *
- * Every call runs through a timeout + bounded-retry wrapper: a hanging fetch
- * must never wedge the scheduler's single-flight lock, and a transient
- * 429/5xx/network blip must not postpone recovery to the next daily run.
+ * Every call runs through a timeout + bounded-retry wrapper whose abort
+ * window covers HEADERS AND BODY (a server that returns headers then stalls
+ * the body must never wedge the scheduler's single-flight lock), with
+ * bounded backoff+jitter on network/429/5xx/body-stream failures only.
  * Terminal 4xx never retries.
  *
- * Error hygiene mirrors the Meta services: messages carry HTTP status +
- * Google's error message only — never request bodies (they contain hashed
- * PII, and hashes are still personal data).
+ * Error hygiene: provider error text is REDACTED before it reaches
+ * exceptions/logs/Sentry — Google can echo rejected identifier values (hex
+ * hashes are still personal data), so free-text messages are stripped of
+ * long hex/token runs and truncated. Request bodies are never attached.
  */
 
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
@@ -51,12 +53,28 @@ export function __resetTokenCacheForTests() {
 }
 
 /**
- * fetch with an AbortController timeout and bounded exponential backoff +
- * jitter on transient failures (network error, 429, 5xx). Non-2xx responses
- * are RETURNED (callers classify); only transport-level transients retry.
+ * Redact provider free-text before it can reach any observable surface:
+ * long hex runs (hashed identifiers) and long opaque tokens become
+ * placeholders, and the result is truncated. Exported for testing.
+ */
+export function redactProviderText(text) {
+  if (!text || typeof text !== 'string') return '';
+  return text
+    .replace(/[a-f0-9]{32,}/gi, '[hash]')
+    .replace(/[A-Za-z0-9_-]{40,}/g, '[token]')
+    .replace(/[^\s@"']+@[^\s@"']+\.[^\s@"']+/g, '[email]')
+    .replace(/\+?\d[\d\s-]{6,}\d/g, '[phone]')
+    .slice(0, 200);
+}
+
+/**
+ * fetch + JSON-parse under ONE abort window, with bounded exponential
+ * backoff + jitter on transient failures (network error, body-stream error,
+ * 429, 5xx). Returns { status, ok, body } — non-2xx responses are RETURNED
+ * for the caller to classify; only transport-level transients retry.
  * Exported for testing.
  */
-export async function fetchWithRetry(url, init, deps = {}) {
+export async function fetchJsonWithRetry(url, init, deps = {}) {
   const fetchFn = deps.fetch || globalThis.fetch;
   const sleep = deps.sleep || realSleep;
   const attempts = deps.attempts || DEFAULT_ATTEMPTS;
@@ -70,7 +88,13 @@ export async function fetchWithRetry(url, init, deps = {}) {
         await sleep(500 * 2 ** attempt + Math.floor(Math.random() * 250));
         continue;
       }
-      return res;
+      // Body consumption stays INSIDE the abort window — a stalled body is a
+      // timeout, not a hang. A malformed/failed body on a 2xx is transient.
+      const body = await res.json().catch((err) => {
+        if (res.ok) throw err;
+        return {};
+      });
+      return { status: res.status, ok: res.ok, body };
     } catch (err) {
       lastErr = err;
       if (attempt < attempts - 1) {
@@ -81,7 +105,9 @@ export async function fetchWithRetry(url, init, deps = {}) {
       clearTimeout(timer);
     }
   }
-  throw new Error(`google dm fetch failed after ${attempts} attempts: ${lastErr?.message || 'network error'}`);
+  throw new Error(
+    `google dm fetch failed after ${attempts} attempts: ${redactProviderText(lastErr?.message) || 'network error'}`
+  );
 }
 
 /**
@@ -108,7 +134,7 @@ export async function getAccessToken(deps = {}) {
     client_secret: clientSecret,
     refresh_token: refreshToken,
   });
-  const res = await fetchWithRetry(
+  const { status, ok, body } = await fetchJsonWithRetry(
     TOKEN_URL,
     {
       method: 'POST',
@@ -117,10 +143,9 @@ export async function getAccessToken(deps = {}) {
     },
     deps
   );
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok || !body.access_token) {
+  if (!ok || !body.access_token) {
     throw new Error(
-      `google dm token refresh failed: HTTP ${res.status} ${body?.error_description || body?.error || ''}`.trim()
+      `google dm token refresh failed: HTTP ${status} ${redactProviderText(body?.error_description || body?.error)}`.trim()
     );
   }
   cachedToken = {
@@ -132,7 +157,7 @@ export async function getAccessToken(deps = {}) {
 
 async function authedRequest(method, path, payload, deps) {
   const accessToken = await getAccessToken(deps);
-  const res = await fetchWithRetry(
+  const { status, ok, body } = await fetchJsonWithRetry(
     `${baseUrl()}/${path}`,
     {
       method,
@@ -144,12 +169,16 @@ async function authedRequest(method, path, payload, deps) {
     },
     deps
   );
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    throw Object.assign(
-      new Error(`google dm ${path} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()),
-      { status: res.status }
-    );
+  if (!ok) {
+    // error.status/code are structured enums (safe); error.message is
+    // free-text Google can stuff identifier echoes into — redacted.
+    const parts = [
+      `google dm ${path} failed:`,
+      `HTTP ${status}`,
+      body?.error?.status || body?.error?.code || '',
+      redactProviderText(body?.error?.message),
+    ].filter(Boolean);
+    throw Object.assign(new Error(parts.join(' ')), { status });
   }
   logger.debug({ path, requestId: body?.requestId }, 'google_dm.request.ok');
   return body;

--- a/backend/src/utils/googleDataManagerClient.js
+++ b/backend/src/utils/googleDataManagerClient.js
@@ -14,6 +14,11 @@ import { logger } from './logger.js';
  * tokens die after 7 days, Internal ones are durable). Access tokens are
  * cached until shortly before expiry.
  *
+ * Every call runs through a timeout + bounded-retry wrapper: a hanging fetch
+ * must never wedge the scheduler's single-flight lock, and a transient
+ * 429/5xx/network blip must not postpone recovery to the next daily run.
+ * Terminal 4xx never retries.
+ *
  * Error hygiene mirrors the Meta services: messages carry HTTP status +
  * Google's error message only — never request bodies (they contain hashed
  * PII, and hashes are still personal data).
@@ -21,6 +26,8 @@ import { logger } from './logger.js';
 
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const EXPIRY_SLACK_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_ATTEMPTS = 3;
 
 function apiVersion() {
   return process.env.GOOGLE_DM_API_VERSION || 'v1';
@@ -30,6 +37,12 @@ function baseUrl() {
   return `https://datamanager.googleapis.com/${apiVersion()}`;
 }
 
+function timeoutMs() {
+  return Number(process.env.GOOGLE_DM_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS;
+}
+
+const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 let cachedToken = null; // { accessToken, expiresAt }
 
 /** Test seam — clears the module-level access-token cache. */
@@ -38,12 +51,45 @@ export function __resetTokenCacheForTests() {
 }
 
 /**
+ * fetch with an AbortController timeout and bounded exponential backoff +
+ * jitter on transient failures (network error, 429, 5xx). Non-2xx responses
+ * are RETURNED (callers classify); only transport-level transients retry.
+ * Exported for testing.
+ */
+export async function fetchWithRetry(url, init, deps = {}) {
+  const fetchFn = deps.fetch || globalThis.fetch;
+  const sleep = deps.sleep || realSleep;
+  const attempts = deps.attempts || DEFAULT_ATTEMPTS;
+  let lastErr;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs());
+    try {
+      const res = await fetchFn(url, { ...init, signal: controller.signal });
+      if ((res.status === 429 || res.status >= 500) && attempt < attempts - 1) {
+        await sleep(500 * 2 ** attempt + Math.floor(Math.random() * 250));
+        continue;
+      }
+      return res;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < attempts - 1) {
+        await sleep(500 * 2 ** attempt + Math.floor(Math.random() * 250));
+        continue;
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error(`google dm fetch failed after ${attempts} attempts: ${lastErr?.message || 'network error'}`);
+}
+
+/**
  * Mint (or reuse) an access token from the stored refresh token. Throws a
  * sanitized Error on failure — callers treat that as "run aborts, retry next
  * schedule" (fail closed, never upload blind).
  */
 export async function getAccessToken(deps = {}) {
-  const fetchFn = deps.fetch || globalThis.fetch;
   const now = deps.now ? deps.now() : Date.now();
   if (cachedToken && cachedToken.expiresAt - EXPIRY_SLACK_MS > now) {
     return cachedToken.accessToken;
@@ -62,11 +108,15 @@ export async function getAccessToken(deps = {}) {
     client_secret: clientSecret,
     refresh_token: refreshToken,
   });
-  const res = await fetchFn(TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: form.toString(),
-  });
+  const res = await fetchWithRetry(
+    TOKEN_URL,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: form.toString(),
+    },
+    deps
+  );
   const body = await res.json().catch(() => ({}));
   if (!res.ok || !body.access_token) {
     throw new Error(
@@ -80,30 +130,45 @@ export async function getAccessToken(deps = {}) {
   return cachedToken.accessToken;
 }
 
+async function authedRequest(method, path, payload, deps) {
+  const accessToken = await getAccessToken(deps);
+  const res = await fetchWithRetry(
+    `${baseUrl()}/${path}`,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...(payload !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+    },
+    deps
+  );
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error(
+      `google dm ${path} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()
+    );
+    err.status = res.status;
+    throw err;
+  }
+  logger.debug({ path, requestId: body?.requestId }, 'google_dm.request.ok');
+  return body;
+}
+
 /**
  * POST a Data Manager method (e.g. 'audienceMembers:ingest'). Returns the
  * parsed JSON body on 2xx; throws a sanitized Error (with .status) otherwise.
  * The request body is NEVER attached to errors or logs.
  */
 export async function dmRequest(method, payload, deps = {}) {
-  const fetchFn = deps.fetch || globalThis.fetch;
-  const accessToken = await getAccessToken(deps);
-  const res = await fetchFn(`${baseUrl()}/${method}`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const err = new Error(
-      `google dm ${method} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()
-    );
-    err.status = res.status;
-    throw err;
-  }
-  logger.debug({ method, requestId: body?.requestId }, 'google_dm.request.ok');
-  return body;
+  return authedRequest('POST', method, payload, deps);
+}
+
+/**
+ * GET a Data Manager path (e.g. 'requestStatus:retrieve?requestId=…') — the
+ * diagnostics retrieval surface. Same auth/retry/sanitization contract.
+ */
+export async function dmRequestGet(pathWithQuery, deps = {}) {
+  return authedRequest('GET', pathWithQuery, undefined, deps);
 }

--- a/backend/src/utils/googleDataManagerClient.js
+++ b/backend/src/utils/googleDataManagerClient.js
@@ -1,0 +1,109 @@
+import { logger } from './logger.js';
+
+/**
+ * Data Manager API client — the Google counterpart of the bare-fetch style in
+ * metaCapiService/redeemedAudienceService. Deliberately NOT the classic Google
+ * Ads API: since April/June 2026 its upload surfaces (OfflineUserDataJob,
+ * UploadClickConversions) REJECT developer tokens that never used them before,
+ * and this account has no token to grandfather. Data Manager needs no
+ * developer token and no MCC — just OAuth on the datamanager scope
+ * (docs/plans/google-ads-signal-levers.md §0/§2).
+ *
+ * Auth: refresh-token grant, minted once by scripts/google-dm-oauth-bootstrap.mjs
+ * (INTERNAL OAuth app on the mktr.sg Workspace org — Testing-mode refresh
+ * tokens die after 7 days, Internal ones are durable). Access tokens are
+ * cached until shortly before expiry.
+ *
+ * Error hygiene mirrors the Meta services: messages carry HTTP status +
+ * Google's error message only — never request bodies (they contain hashed
+ * PII, and hashes are still personal data).
+ */
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const EXPIRY_SLACK_MS = 60_000;
+
+function apiVersion() {
+  return process.env.GOOGLE_DM_API_VERSION || 'v1';
+}
+
+function baseUrl() {
+  return `https://datamanager.googleapis.com/${apiVersion()}`;
+}
+
+let cachedToken = null; // { accessToken, expiresAt }
+
+/** Test seam — clears the module-level access-token cache. */
+export function __resetTokenCacheForTests() {
+  cachedToken = null;
+}
+
+/**
+ * Mint (or reuse) an access token from the stored refresh token. Throws a
+ * sanitized Error on failure — callers treat that as "run aborts, retry next
+ * schedule" (fail closed, never upload blind).
+ */
+export async function getAccessToken(deps = {}) {
+  const fetchFn = deps.fetch || globalThis.fetch;
+  const now = deps.now ? deps.now() : Date.now();
+  if (cachedToken && cachedToken.expiresAt - EXPIRY_SLACK_MS > now) {
+    return cachedToken.accessToken;
+  }
+
+  const clientId = process.env.GOOGLE_DM_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET;
+  const refreshToken = process.env.GOOGLE_DM_REFRESH_TOKEN;
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error('google dm client: OAuth env incomplete');
+  }
+
+  const form = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+  });
+  const res = await fetchFn(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok || !body.access_token) {
+    throw new Error(
+      `google dm token refresh failed: HTTP ${res.status} ${body?.error_description || body?.error || ''}`.trim()
+    );
+  }
+  cachedToken = {
+    accessToken: body.access_token,
+    expiresAt: now + (Number(body.expires_in) || 3600) * 1000,
+  };
+  return cachedToken.accessToken;
+}
+
+/**
+ * POST a Data Manager method (e.g. 'audienceMembers:ingest'). Returns the
+ * parsed JSON body on 2xx; throws a sanitized Error (with .status) otherwise.
+ * The request body is NEVER attached to errors or logs.
+ */
+export async function dmRequest(method, payload, deps = {}) {
+  const fetchFn = deps.fetch || globalThis.fetch;
+  const accessToken = await getAccessToken(deps);
+  const res = await fetchFn(`${baseUrl()}/${method}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const err = new Error(
+      `google dm ${method} failed: HTTP ${res.status} ${body?.error?.message || ''}`.trim()
+    );
+    err.status = res.status;
+    throw err;
+  }
+  logger.debug({ method, requestId: body?.requestId }, 'google_dm.request.ok');
+  return body;
+}

--- a/backend/src/utils/piiHashing.js
+++ b/backend/src/utils/piiHashing.js
@@ -58,3 +58,26 @@ export function hashCountry(code) {
   if (!normalized) return undefined;
   return sha256Hex(normalized);
 }
+
+/**
+ * Hash an email for Google Customer Match / Data Manager userData. Google's
+ * formatting rules go beyond Meta's trim+lowercase (`hashEmail`): remove ALL
+ * whitespace, and canonicalize gmail.com/googlemail.com local parts by
+ * stripping dots and dropping any `+suffix` before hashing. Non-Google
+ * domains keep their local part intact (dots/plus are significant elsewhere).
+ */
+export function hashEmailGoogle(email) {
+  if (!email || typeof email !== 'string') return undefined;
+  const normalized = email.trim().toLowerCase().replace(/\s+/g, '');
+  if (!normalized || !normalized.includes('@')) return undefined;
+  const at = normalized.lastIndexOf('@');
+  let local = normalized.slice(0, at);
+  const domain = normalized.slice(at + 1);
+  if (domain === 'gmail.com' || domain === 'googlemail.com') {
+    const plus = local.indexOf('+');
+    if (plus !== -1) local = local.slice(0, plus);
+    local = local.replace(/\./g, '');
+  }
+  if (!local) return undefined;
+  return sha256Hex(`${local}@${domain}`);
+}

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -22,8 +22,8 @@ import {
 } from '../../src/models/index.js';
 import { markPhoneVerified, isPhoneRecentlyVerified } from '../../src/services/verifiedPhoneStore.js';
 import { phoneHashOf } from '../../src/services/consumerService.js';
-import { eraseConsumer, ERASED_PHONE_HASH } from '../../src/services/erasureService.js';
-import { isSuppressed, canMarketTo, applyUnsubscribe } from '../../src/services/consentService.js';
+import { eraseConsumer, makeErasureService, ERASED_PHONE_HASH } from '../../src/services/erasureService.js';
+import { isSuppressed, canMarketTo, applyUnsubscribe, makeConsentService } from '../../src/services/consentService.js';
 import { makeEntitlementService, flushDeliveries as flushEntDeliveries } from '../../src/services/redeemOps/entitlementService.js';
 import { makeWebhookService } from '../../src/services/webhookService.js';
 import { makeLuckyDrawService } from '../../src/services/luckyDrawService.js';
@@ -755,5 +755,80 @@ describe('erasure — suppression upgrade over a prior unsubscribe', () => {
 describe('erasure — service-level 404', () => {
   test('unknown consumer id rejects with 404 AppError', async () => {
     await expect(eraseConsumer(crypto.randomUUID(), {})).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('erasure/withdrawal — Google Customer Match removal hooks (plan google-ads-signal-levers §3)', () => {
+  let savedCm;
+  beforeEach(() => { savedCm = process.env.GOOGLE_CM_CAMPAIGN_ID; });
+  afterEach(() => {
+    if (savedCm === undefined) delete process.env.GOOGLE_CM_CAMPAIGN_ID;
+    else process.env.GOOGLE_CM_CAMPAIGN_ID = savedCm;
+  });
+
+  test('erasure hands PRE-SCRUB pairs to the seam, target campaign only, strictly post-commit, and a seam failure cannot fail erasure', async () => {
+    const phone8 = p8(2100);
+    const pIn = await captureProspect(phone8, campaign1, { firstName: 'Cm', lastName: 'Hook' });
+    // Same person, second campaign — must NOT be collected (per-campaign scope).
+    const pOut = await captureProspect(phone8, campaign2, { firstName: 'Cm', lastName: 'Hook' });
+    expect(pOut.consumerId).toBe(pIn.consumerId);
+    process.env.GOOGLE_CM_CAMPAIGN_ID = campaign1.id;
+    const rawEmail = pIn.email;
+    const e164 = pIn.phone;
+
+    let observed = null;
+    let resolveCalled;
+    const called = new Promise((r) => { resolveCalled = r; });
+    const googleCmRemove = jest.fn(async (pairs) => {
+      // Post-commit probe: by the time the seam runs, the scrub must already
+      // be visible outside the erasure transaction.
+      const row = await Prospect.findByPk(pIn.id);
+      observed = { pairs, emailAtCall: row.email };
+      resolveCalled();
+      // Failure-independence probe: the seam blowing up must not fail erasure
+      // (it already succeeded — this exercises the fire-and-forget catch).
+      throw new Error('google down');
+    });
+
+    const svcErase = makeErasureService({ googleCmRemove });
+    const report = await svcErase.eraseConsumer(pIn.consumerId, { actorUser: admin.user });
+    expect(report.prospects).toBeGreaterThanOrEqual(2); // erasure succeeded despite the throwing seam
+    await called;
+    expect(googleCmRemove).toHaveBeenCalledTimes(1);
+    expect(observed.pairs).toEqual([{ email: rawEmail, phone: e164 }]); // pre-scrub values, ONE row (campaign2 excluded)
+    expect(observed.emailAtCall).toBeFalsy(); // scrub committed before the seam ran
+  });
+
+  test('erasure collects nothing when no prospect is in the target campaign', async () => {
+    const phone8 = p8(2101);
+    const prospect = await captureProspect(phone8, campaign2, { firstName: 'Cm', lastName: 'Off' });
+    process.env.GOOGLE_CM_CAMPAIGN_ID = campaign1.id;
+    const googleCmRemove = jest.fn(async () => ({ removed: true }));
+    const svcErase = makeErasureService({ googleCmRemove });
+    await svcErase.eraseConsumer(prospect.consumerId, { actorUser: admin.user });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(googleCmRemove).not.toHaveBeenCalled();
+  });
+
+  test('unsubscribe dispatches removeByConsumerId strictly post-commit', async () => {
+    const phone8 = p8(2102);
+    const prospect = await captureProspect(phone8, campaign1, { firstName: 'Cm', lastName: 'Unsub' });
+    const consumer = await Consumer.findByPk(prospect.consumerId);
+
+    let committedAtCall = null;
+    let resolveCalled;
+    const called = new Promise((r) => { resolveCalled = r; });
+    const googleCmRemoveByConsumerId = jest.fn(async (cid) => {
+      const sup = await ConsumerSuppression.findOne({ where: { consumerId: cid, channel: 'all' } });
+      committedAtCall = !!sup; // suppression row visible ⇒ the transaction committed first
+      resolveCalled();
+      return { removed: true };
+    });
+
+    const consent = makeConsentService({ googleCmRemoveByConsumerId });
+    await consent.applyUnsubscribe(consumer, { source: 'unsubscribe_link' });
+    await called;
+    expect(googleCmRemoveByConsumerId).toHaveBeenCalledWith(consumer.id);
+    expect(committedAtCall).toBe(true);
   });
 });

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -799,6 +799,19 @@ describe('erasure/withdrawal — Google Customer Match removal hooks (plan googl
     expect(observed.emailAtCall).toBeFalsy(); // scrub committed before the seam ran
   });
 
+  test('a SYNCHRONOUSLY throwing seam cannot fail erasure either', async () => {
+    const phone8 = p8(2103);
+    const prospect = await captureProspect(phone8, campaign1, { firstName: 'Cm', lastName: 'SyncThrow' });
+    process.env.GOOGLE_CM_CAMPAIGN_ID = campaign1.id;
+    const googleCmRemove = jest.fn(() => {
+      throw new Error('sync throw'); // NOT an async rejection
+    });
+    const svcErase = makeErasureService({ googleCmRemove });
+    const report = await svcErase.eraseConsumer(prospect.consumerId, { actorUser: admin.user });
+    expect(report.prospects).toBeGreaterThanOrEqual(1);
+    expect(googleCmRemove).toHaveBeenCalledTimes(1);
+  });
+
   test('erasure collects nothing when no prospect is in the target campaign', async () => {
     const phone8 = p8(2101);
     const prospect = await captureProspect(phone8, campaign2, { firstName: 'Cm', lastName: 'Off' });

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -557,7 +557,7 @@ describe('syncGoogleCustomerMatch', () => {
     const Prospect = { findAll: jest.fn().mockResolvedValue([]) };
     const dmRequest = jest.fn();
     const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sleep: fastSleep });
-    expect(res).toEqual({ submitted: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null });
+    expect(res).toEqual({ submitted: false, ok: true, reason: 'empty', eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null });
     expect(dmRequest).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -1,0 +1,333 @@
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+// Mocks BEFORE importing the SUT (Jest ESM pattern).
+jest.unstable_mockModule('@sentry/node', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  init: jest.fn(),
+  setTag: jest.fn(),
+}));
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+// consumerService (imported for phoneVerificationIsCurrent) drags a wide
+// transitive graph, so the models mock must satisfy EVERY named export of
+// models/index.js — generated, not hand-picked, so a new model never breaks
+// this suite with a missing-export link error.
+const MODEL_NAMES = `Activation ActivationIssuanceSkip AgentGroup AgentGroupMember AiSettings Attribution
+Campaign CampaignAgentAssignment CampaignPreview Cohort ConsentEvent Consumer ConsumerObservation
+ConsumerProfile ConsumerSuppression DiscoveryCandidate DiscoveryDailyUsage DiscoveryPlaceMemory
+DiscoveryRun Draw DrawAttempt DrawBoostReview DrawEntry DrawTermsVersion EmailBroadcast
+EmailBroadcastRecipient EnrichmentJob EnrichmentScoringConfig EnrichmentSweepRun ExternalAgent
+ExternalCampaignAgent IdempotencyKey LeadPackage LeadPackageAssignment MetaAgentConnection
+MetaFormMapping MetaLeadgenEvent MetaPage OutreachAccount OutreachActivity OutreachCadence
+OutreachCadenceEnrollment OutreachCadenceStep OutreachCadenceTransition OutreachEmail
+OutreachPersona OutreachSuppression OutreachTask PartnerAssignmentEvent PartnerContact
+PartnerLocation PartnerOnboardingItem PartnerOrganisation PartnerStageEvent Payment
+PhoneVerificationMarker Prospect ProspectActivity ProspectingPool ProspectingPoolMember QrScan
+QrTag RedeemOpsAuditEvent RedeemOpsCategory Redemption RedemptionEvent RewardEntitlement
+RewardInventoryEvent RewardOffer RewardOfferLocation RewardTermsVersion RoundRobinCursor
+SessionVisit ShortLink ShortLinkClick SuppressionPropagation TimelineHiddenEntry User Verification
+WaitlistSignup WalletLedger WaMessageSend WaMessageStatus WebhookDelivery WebhookSubscriber`
+  .split(/\s+/)
+  .filter(Boolean);
+jest.unstable_mockModule('../../src/models/index.js', () => {
+  const models = Object.fromEntries(MODEL_NAMES.map((n) => [n, {}]));
+  models.Prospect = { findAll: jest.fn() };
+  const sequelize = { transaction: jest.fn(), query: jest.fn() };
+  return { ...models, sequelize, default: { ...models, sequelize } };
+});
+jest.unstable_mockModule('../../src/services/mailer.js', () => ({
+  sendEmail: jest.fn().mockResolvedValue({}),
+}));
+const consentMocks = {
+  getSuppressedPhoneSet: jest.fn(),
+  getMarketableGrantMap: jest.fn(),
+};
+jest.unstable_mockModule('../../src/services/consentService.js', () => consentMocks);
+
+let svc;
+let piiHashing;
+let phoneHashOf;
+beforeAll(async () => {
+  svc = await import('../../src/services/googleCustomerMatchService.js');
+  piiHashing = await import('../../src/utils/piiHashing.js');
+  ({ phoneHashOf } = await import('../../src/services/consumerService.js'));
+});
+
+const ENV_KEYS = [
+  'GOOGLE_CM_SYNC_ENABLED',
+  'GOOGLE_DM_OAUTH_CLIENT_ID',
+  'GOOGLE_DM_OAUTH_CLIENT_SECRET',
+  'GOOGLE_DM_REFRESH_TOKEN',
+  'GOOGLE_ADS_CUSTOMER_ID',
+  'GOOGLE_CM_USER_LIST_ID',
+  'GOOGLE_CM_CAMPAIGN_ID',
+  'GOOGLE_CM_ALERT_EMAIL',
+  'REDEEMED_AUDIENCE_ALERT_EMAIL',
+];
+const saved = {};
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.GOOGLE_CM_SYNC_ENABLED = 'true';
+  process.env.GOOGLE_DM_OAUTH_CLIENT_ID = 'cid';
+  process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET = 'sec';
+  process.env.GOOGLE_DM_REFRESH_TOKEN = 'rt';
+  process.env.GOOGLE_ADS_CUSTOMER_ID = '1829163947';
+  process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
+  process.env.GOOGLE_CM_CAMPAIGN_ID = 'camp-airpods';
+  delete process.env.GOOGLE_CM_ALERT_EMAIL;
+  delete process.env.REDEEMED_AUDIENCE_ALERT_EMAIL;
+  consentMocks.getSuppressedPhoneSet.mockReset().mockResolvedValue(new Set());
+  consentMocks.getMarketableGrantMap.mockReset().mockResolvedValue(new Map());
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+const sha = (v) => crypto.createHash('sha256').update(v).digest('hex');
+
+/** A fully-eligible prospect row + the grantMap entry that admits it. */
+function eligibleRow(overrides = {}) {
+  return {
+    email: 'jane.doe+promo@gmail.com',
+    phone: '+6591234567',
+    campaignId: 'camp-airpods',
+    sourceMetadata: { phoneVerifiedAt: '2026-08-01T00:00:00Z' },
+    ...overrides,
+  };
+}
+function grantAll(rows) {
+  return new Map(rows.map((r) => [r.phone, new Map([['*', true]])]));
+}
+
+describe('shouldSync', () => {
+  it('is true only with the full config set', () => {
+    expect(svc.shouldSync()).toBe(true);
+  });
+
+  it.each(ENV_KEYS.slice(0, 7))('is false when %s is missing', (key) => {
+    delete process.env[key];
+    expect(svc.shouldSync()).toBe(false);
+  });
+
+  it('is false when the flag is any non-"true" value', () => {
+    process.env.GOOGLE_CM_SYNC_ENABLED = '1';
+    expect(svc.shouldSync()).toBe(false);
+  });
+});
+
+describe('buildMemberRows', () => {
+  it('emits HEX-hashed google-normalized email + E.164 phone identifiers', () => {
+    const rows = [eligibleRow()];
+    const out = svc.buildMemberRows(rows, { grantMap: grantAll(rows) });
+    expect(out).toEqual([
+      {
+        userIdentifiers: [
+          // gmail canonicalization: dots stripped, +suffix dropped
+          { emailAddress: sha('janedoe@gmail.com') },
+          { phoneNumber: sha('+6591234567') },
+        ],
+      },
+    ]);
+  });
+
+  it('skips erased skeleton rows', () => {
+    const rows = [eligibleRow({ sourceMetadata: { erased: true } })];
+    expect(svc.buildMemberRows(rows, { grantMap: grantAll(rows) })).toEqual([]);
+  });
+
+  it('skips rows without a verification stamp', () => {
+    const rows = [eligibleRow({ sourceMetadata: {} })];
+    expect(svc.buildMemberRows(rows, { grantMap: grantAll(rows) })).toEqual([]);
+  });
+
+  it('enforces the phoneVerifiedFor binding: stale hash out, matching hash in, legacy stamp in', () => {
+    const stale = eligibleRow({
+      sourceMetadata: { phoneVerifiedAt: 'x', phoneVerifiedFor: 'not-the-hash' },
+    });
+    const bound = eligibleRow({
+      sourceMetadata: { phoneVerifiedAt: 'x', phoneVerifiedFor: phoneHashOf('+6591234567') },
+    });
+    const legacy = eligibleRow();
+    const rows = [stale, bound, legacy];
+    expect(svc.buildMemberRows(rows, { grantMap: grantAll(rows) })).toHaveLength(2);
+  });
+
+  it('fails closed on consent: no map, no entry, and refused entry are all excluded', () => {
+    const row = eligibleRow();
+    expect(svc.buildMemberRows([row], {})).toEqual([]);
+    expect(svc.buildMemberRows([row], { grantMap: new Map() })).toEqual([]);
+    const refused = new Map([[row.phone, new Map([['*', false]])]]);
+    expect(svc.buildMemberRows([row], { grantMap: refused })).toEqual([]);
+  });
+
+  it('admits a campaign-scoped grant for the row campaign', () => {
+    const row = eligibleRow();
+    const scoped = new Map([[row.phone, new Map([['camp-airpods', true]])]]);
+    expect(svc.buildMemberRows([row], { grantMap: scoped })).toHaveLength(1);
+  });
+
+  it('drops suppressed phones', () => {
+    const rows = [eligibleRow()];
+    const out = svc.buildMemberRows(rows, {
+      grantMap: grantAll(rows),
+      suppressedPhones: new Set(['+6591234567']),
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('drops the synthetic Retell email but keeps the phone identifier', () => {
+    const rows = [eligibleRow({ email: 'retell-abc@calls.mktr.sg' })];
+    const out = svc.buildMemberRows(rows, { grantMap: grantAll(rows) });
+    expect(out).toEqual([{ userIdentifiers: [{ phoneNumber: sha('+6591234567') }] }]);
+  });
+
+  it('drops rows with neither usable identifier', () => {
+    const rows = [eligibleRow({ email: null, phone: '' })];
+    // phone '' → no verification either, but assert the neither-identifier path
+    // with a verified-but-unhashable row too:
+    const weird = eligibleRow({ email: 'not-an-email', phone: null });
+    expect(svc.buildMemberRows([...rows, weird], { grantMap: grantAll([...rows, weird]) })).toEqual(
+      []
+    );
+  });
+});
+
+describe('buildIngestBody', () => {
+  it('pins the golden envelope: destination, consent enums, HEX, CM terms', () => {
+    const members = [{ userIdentifiers: [{ phoneNumber: 'ph' }] }];
+    expect(svc.buildIngestBody(members)).toEqual({
+      destinations: [
+        {
+          operatingAccount: { product: 'GOOGLE_ADS', accountId: '1829163947' },
+          productDestinationId: '999888777',
+        },
+      ],
+      audienceMembers: [{ userData: { userIdentifiers: [{ phoneNumber: 'ph' }] } }],
+      consent: { adUserData: 'CONSENT_GRANTED', adPersonalization: 'CONSENT_GRANTED' },
+      encoding: 'HEX',
+      termsOfService: { customerMatchTermsOfServiceStatus: 'ACCEPTED' },
+    });
+  });
+
+  it('adds validateOnly only when asked', () => {
+    expect(svc.buildIngestBody([], { validateOnly: true }).validateOnly).toBe(true);
+    expect(svc.buildIngestBody([]).validateOnly).toBeUndefined();
+  });
+});
+
+describe('chunk', () => {
+  it('splits at the batch cap', () => {
+    expect(svc.chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+});
+
+describe('syncGoogleCustomerMatch', () => {
+  it('returns guarded without touching the ledger when config is missing', async () => {
+    delete process.env.GOOGLE_CM_USER_LIST_ID;
+    const res = await svc.syncGoogleCustomerMatch({ dmRequest: jest.fn() });
+    expect(res).toEqual({ synced: false, reason: 'guarded' });
+    expect(consentMocks.getMarketableGrantMap).not.toHaveBeenCalled();
+  });
+
+  it('uploads eligible members in batches and reports requestIds', async () => {
+    const rows = [eligibleRow(), eligibleRow({ phone: '+6598765432' })];
+    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
+    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
+    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
+    expect(res).toEqual({ synced: true, eligible: 2, batches: 1, requestIds: ['req-1'] });
+    expect(dmRequest).toHaveBeenCalledTimes(1);
+    const [method, body] = dmRequest.mock.calls[0];
+    expect(method).toBe('audienceMembers:ingest');
+    expect(body.audienceMembers).toHaveLength(2);
+    expect(body.encoding).toBe('HEX');
+  });
+
+  it('aborts fail-closed (no upload, alert sent) when a ledger lookup throws', async () => {
+    consentMocks.getSuppressedPhoneSet.mockRejectedValue(new Error('ledger down'));
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const sendEmail = jest.fn().mockResolvedValue({});
+    const dmRequest = jest.fn();
+    const res = await svc.syncGoogleCustomerMatch({ dmRequest, sendEmail });
+    expect(res.synced).toBe(false);
+    expect(res.error).toMatch(/ledger down/);
+    expect(dmRequest).not.toHaveBeenCalled();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail.mock.calls[0][0].to).toBe('ops@mktr.sg');
+  });
+
+  it('reports a failed upload with an alert and keeps PII out of the summary', async () => {
+    const rows = [eligibleRow()];
+    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
+    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
+    const dmRequest = jest.fn().mockRejectedValue(
+      Object.assign(new Error('google dm audienceMembers:ingest failed: HTTP 403 denied'), {
+        status: 403,
+      })
+    );
+    process.env.REDEEMED_AUDIENCE_ALERT_EMAIL = 'fallback@mktr.sg';
+    const sendEmail = jest.fn().mockResolvedValue({});
+    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sendEmail });
+    expect(res.synced).toBe(false);
+    expect(res.error).not.toMatch(/@gmail/);
+    expect(sendEmail.mock.calls[0][0].to).toBe('fallback@mktr.sg');
+  });
+
+  it('single-flights overlapping runs', async () => {
+    const rows = [eligibleRow()];
+    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
+    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
+    let release;
+    const gate = new Promise((r) => {
+      release = r;
+    });
+    const dmRequest = jest.fn(async () => {
+      await gate;
+      return { requestId: 'slow' };
+    });
+    const first = svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
+    // Let the first run reach the in-flight section before starting the second.
+    await new Promise((r) => setTimeout(r, 10));
+    const second = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
+    expect(second).toEqual({ synced: false, reason: 'overlap' });
+    release();
+    const firstRes = await first;
+    expect(firstRes.synced).toBe(true);
+  });
+
+  it('treats an empty eligible set as a successful no-op', async () => {
+    const Prospect = { findAll: jest.fn().mockResolvedValue([]) };
+    const dmRequest = jest.fn();
+    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
+    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, requestIds: [] });
+    expect(dmRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('hashEmailGoogle', () => {
+  it('canonicalizes gmail and googlemail local parts (dots + plus-suffix)', () => {
+    expect(piiHashing.hashEmailGoogle('Jane.Doe+x@Gmail.com')).toBe(sha('janedoe@gmail.com'));
+    expect(piiHashing.hashEmailGoogle('a.b.c@googlemail.com')).toBe(sha('abc@googlemail.com'));
+  });
+
+  it('leaves non-google domains intact (dots/plus significant elsewhere)', () => {
+    expect(piiHashing.hashEmailGoogle('jane.doe+x@mktr.sg')).toBe(sha('jane.doe+x@mktr.sg'));
+  });
+
+  it('strips all whitespace and lowercases', () => {
+    expect(piiHashing.hashEmailGoogle('  Jane @ Gmail.com ')).toBe(sha('jane@gmail.com'));
+  });
+
+  it('returns undefined for garbage', () => {
+    expect(piiHashing.hashEmailGoogle('')).toBeUndefined();
+    expect(piiHashing.hashEmailGoogle(null)).toBeUndefined();
+    expect(piiHashing.hashEmailGoogle('no-at-sign')).toBeUndefined();
+    expect(piiHashing.hashEmailGoogle('+only@gmail.com')).toBeUndefined();
+  });
+});

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -63,7 +63,8 @@ const ENV_KEYS = [
   'GOOGLE_CM_CAMPAIGN_ID',
   'GOOGLE_CM_ALERT_EMAIL',
   'REDEEMED_AUDIENCE_ALERT_EMAIL',
-  'GOOGLE_CM_STATUS_MAX_POLLS',
+  'GOOGLE_CM_FIRST_POLL_MINUTES',
+  'GOOGLE_CM_SETTLE_INTERVAL_MINUTES',
 ];
 const saved = {};
 beforeEach(() => {
@@ -75,7 +76,8 @@ beforeEach(() => {
   process.env.GOOGLE_ADS_CUSTOMER_ID = '1829163947';
   process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
   process.env.GOOGLE_CM_CAMPAIGN_ID = 'camp-airpods';
-  process.env.GOOGLE_CM_STATUS_MAX_POLLS = '3';
+  process.env.GOOGLE_CM_FIRST_POLL_MINUTES = '30';
+  svc.__resetPendingSettlesForTests();
   delete process.env.GOOGLE_CM_ALERT_EMAIL;
   delete process.env.REDEEMED_AUDIENCE_ALERT_EMAIL;
   consentMocks.getSuppressedPhoneSet.mockReset().mockResolvedValue(new Set());
@@ -286,39 +288,89 @@ describe('buildIngestBody / buildRemoveBody', () => {
   });
 });
 
-describe('settleRequestStatuses', () => {
-  it('classifies terminal states and dedupes request ids', async () => {
-    const dmRequestGet = jest
-      .fn()
-      .mockResolvedValueOnce({ requestStatusPerDestination: [{ requestStatus: 'SUCCESS' }] })
-      .mockResolvedValueOnce({ requestStatus: 'PARTIAL_SUCCESS' })
-      .mockResolvedValueOnce({ status: 'FAILED' });
-    const res = await svc.settleRequestStatuses(['a', 'a', 'b', 'c', null], {
-      dmRequestGet,
-      sleep: fastSleep,
-    });
-    expect(res).toEqual({ succeeded: 1, partialSuccess: 1, failed: 1, stuck: 0 });
-    expect(dmRequestGet).toHaveBeenCalledTimes(3);
-    expect(dmRequestGet.mock.calls[0][0]).toBe('requestStatus:retrieve?requestId=a');
+describe('settlePendingStatuses (deferred, Google-recommended timing)', () => {
+  const T0 = 1_700_000_000_000;
+
+  async function seedIngestRequest(requestId, atMs) {
+    const rows = [eligibleRow()];
+    const d = happyDeps(rows);
+    d.dmRequest = jest.fn().mockResolvedValue({ requestId });
+    d.now = () => atMs;
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.settlement).toBe('queued');
+    return d;
+  }
+
+  it('does NOT poll before the 30-minute first-poll delay, then settles when due', async () => {
+    await seedIngestRequest('req-a', T0);
+    const dmRequestGet = jest.fn().mockResolvedValue(okStatus);
+
+    const early = await svc.settlePendingStatuses({ dmRequestGet, now: () => T0 + 29 * 60_000 });
+    expect(dmRequestGet).not.toHaveBeenCalled();
+    expect(early.pending).toBe(1);
+
+    const due = await svc.settlePendingStatuses({ dmRequestGet, now: () => T0 + 31 * 60_000 });
+    expect(dmRequestGet).toHaveBeenCalledTimes(1);
+    expect(dmRequestGet.mock.calls[0][0]).toBe('requestStatus:retrieve?requestId=req-a');
+    expect(due.succeeded).toBe(1);
+    expect(due.pending).toBe(0);
   });
 
-  it('polls PROCESSING through to a terminal state', async () => {
-    const dmRequestGet = jest
-      .fn()
-      .mockResolvedValueOnce({ requestStatus: 'PROCESSING' })
-      .mockResolvedValueOnce({ requestStatus: 'PROCESSING' })
-      .mockResolvedValueOnce({ requestStatus: 'SUCCESS' });
-    const res = await svc.settleRequestStatuses(['a'], { dmRequestGet, sleep: fastSleep });
-    expect(res).toEqual({ succeeded: 1, partialSuccess: 0, failed: 0, stuck: 0 });
+  it('reschedules non-terminal entries with backoff and marks them stuck past the 24h horizon (alerting)', async () => {
+    await seedIngestRequest('req-b', T0);
+    const processing = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });
+    const sendEmail = jest.fn().mockResolvedValue({});
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+
+    const first = await svc.settlePendingStatuses({ dmRequestGet: processing, sendEmail, now: () => T0 + 31 * 60_000 });
+    expect(first.pending).toBe(1); // rescheduled, not stuck
+    expect(sendEmail).not.toHaveBeenCalled();
+
+    const past = await svc.settlePendingStatuses({ dmRequestGet: processing, sendEmail, now: () => T0 + 25 * 60 * 60_000 });
+    expect(past.stuck).toBe(1);
+    expect(past.pending).toBe(0);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail.mock.calls[0][0].subject).toMatch(/settlement failures/);
   });
 
-  it('marks an id stuck after the poll budget, and on a retrieve error', async () => {
-    const neverDone = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });
-    expect(await svc.settleRequestStatuses(['a'], { dmRequestGet: neverDone, sleep: fastSleep }))
-      .toEqual({ succeeded: 0, partialSuccess: 0, failed: 0, stuck: 1 });
+  it('terminal FAILED alerts + Sentry; a retrieve error only reschedules until the horizon', async () => {
+    await seedIngestRequest('req-c', T0);
+    const failed = jest.fn().mockResolvedValue({ requestStatus: 'FAILED' });
+    const sendEmail = jest.fn().mockResolvedValue({});
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.settlePendingStatuses({ dmRequestGet: failed, sendEmail, now: () => T0 + 31 * 60_000 });
+    expect(res.failed).toBe(1);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sentryMocks.captureMessage).toHaveBeenCalled();
+
+    svc.__resetPendingSettlesForTests();
+    await seedIngestRequest('req-d', T0);
     const broken = jest.fn().mockRejectedValue(new Error('boom'));
-    expect(await svc.settleRequestStatuses(['b'], { dmRequestGet: broken, sleep: fastSleep }))
-      .toEqual({ succeeded: 0, partialSuccess: 0, failed: 0, stuck: 1 });
+    const mid = await svc.settlePendingStatuses({ dmRequestGet: broken, sendEmail: jest.fn(), now: () => T0 + 31 * 60_000 });
+    expect(mid.pending).toBe(1); // rescheduled — a flaky retrieve is not yet stuck
+  });
+
+  it('a PARTIAL_SUCCESS *removal* alerts (people stayed on the list); a partial ingest does not', async () => {
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-partial' });
+    const acceptance = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest, now: () => T0 }
+    );
+    expect(acceptance).toEqual({ accepted: 1, members: 1, failedBatches: 0, settlement: 'queued' });
+    const partial = jest.fn().mockResolvedValue({ requestStatus: 'PARTIAL_SUCCESS' });
+    const sendEmail = jest.fn().mockResolvedValue({});
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.settlePendingStatuses({ dmRequestGet: partial, sendEmail, now: () => T0 + 31 * 60_000 });
+    expect(res.removePartial).toBe(1);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+
+    svc.__resetPendingSettlesForTests();
+    await seedIngestRequest('req-e', T0);
+    const sendEmail2 = jest.fn().mockResolvedValue({});
+    const res2 = await svc.settlePendingStatuses({ dmRequestGet: partial, sendEmail: sendEmail2, now: () => T0 + 31 * 60_000 });
+    expect(res2.partialSuccess).toBe(1);
+    expect(res2.removePartial).toBe(0);
+    expect(sendEmail2).not.toHaveBeenCalled();
   });
 });
 
@@ -340,14 +392,16 @@ describe('syncGoogleCustomerMatch', () => {
       batches: 1,
       accepted: 1,
       failedBatches: 0,
-      status: { succeeded: 1, partialSuccess: 0, failed: 0, stuck: 0 },
+      settlement: 'queued',
     });
     expect(d.dmRequest.mock.calls[0][0]).toBe('audienceMembers:ingest');
+    // Settlement is DEFERRED — no in-run status polling.
+    expect(d.dmRequestGet).not.toHaveBeenCalled();
     expect(d.sendEmail).not.toHaveBeenCalled();
   });
 
-  it('splits 5001 members into envelopes of 5000 and 1 (the production cap)', async () => {
-    const rows = Array.from({ length: 5001 }, (_, i) =>
+  it('splits 10001 members into envelopes of 10000 and 1 (the production cap)', async () => {
+    const rows = Array.from({ length: 10001 }, (_, i) =>
       eligibleRow({ phone: `+659${String(1000000 + i).slice(-7)}` })
     );
     const d = happyDeps(rows);
@@ -358,12 +412,12 @@ describe('syncGoogleCustomerMatch', () => {
     const res = await svc.syncGoogleCustomerMatch(d);
     expect(res.batches).toBe(2);
     expect(res.accepted).toBe(2);
-    expect(d.dmRequest.mock.calls[0][1].audienceMembers).toHaveLength(5000);
+    expect(d.dmRequest.mock.calls[0][1].audienceMembers).toHaveLength(10000);
     expect(d.dmRequest.mock.calls[1][1].audienceMembers).toHaveLength(1);
   });
 
   it('partial batch failure: accepted batches stand, alert says partial (not wholesale)', async () => {
-    const rows = Array.from({ length: 5001 }, (_, i) =>
+    const rows = Array.from({ length: 10001 }, (_, i) =>
       eligibleRow({ phone: `+659${String(1000000 + i).slice(-7)}` })
     );
     const d = happyDeps(rows);
@@ -377,7 +431,7 @@ describe('syncGoogleCustomerMatch', () => {
     expect(res.failedBatches).toBe(1);
     expect(d.sendEmail).toHaveBeenCalledTimes(1);
     expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/partial failure/);
-    expect(d.sendEmail.mock.calls[0][0].text).toMatch(/confirmed batches stand/i);
+    expect(d.sendEmail.mock.calls[0][0].text).toMatch(/settle asynchronously/i);
   });
 
   it('a missing requestId on accept counts as a failed batch, never silent success', async () => {
@@ -389,30 +443,8 @@ describe('syncGoogleCustomerMatch', () => {
     expect(res.synced).toBe(false);
     expect(res.failedBatches).toBe(1);
     expect(res.accepted).toBe(0);
+    expect(res.settlement).toBeNull();
     expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
-  });
-
-  it('every accepted job terminally FAILED = wholesale, never "synced" (outcome-derived)', async () => {
-    const rows = [eligibleRow()];
-    const d = happyDeps(rows);
-    d.dmRequestGet.mockResolvedValue({ requestStatus: 'FAILED' });
-    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
-    const res = await svc.syncGoogleCustomerMatch(d);
-    expect(res.synced).toBe(false);
-    expect(res.status.failed).toBe(1);
-    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
-  });
-
-  it('accepted-but-stuck statuses = unconfirmed, never "synced"', async () => {
-    const rows = [eligibleRow()];
-    const d = happyDeps(rows);
-    d.dmRequestGet.mockResolvedValue({ requestStatus: 'PROCESSING' });
-    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
-    const res = await svc.syncGoogleCustomerMatch(d);
-    expect(res.synced).toBe(false);
-    expect(res.reason).toBe('unconfirmed');
-    expect(res.status.stuck).toBe(1);
-    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/unconfirmed/);
   });
 
   it('aborts fail-closed (no upload, wholesale alert) when a ledger lookup throws', async () => {
@@ -475,9 +507,9 @@ describe('syncGoogleCustomerMatch', () => {
     const gate = new Promise((r) => {
       release = r;
     });
-    d.dmRequestGet = jest.fn(async () => {
+    d.dmRequest = jest.fn(async () => {
       await gate;
-      return okStatus;
+      return { requestId: 'slow' };
     });
     const first = svc.syncGoogleCustomerMatch(d);
     await new Promise((r) => setTimeout(r, 10));
@@ -492,7 +524,7 @@ describe('syncGoogleCustomerMatch', () => {
     const Prospect = { findAll: jest.fn().mockResolvedValue([]) };
     const dmRequest = jest.fn();
     const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sleep: fastSleep });
-    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, status: null });
+    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null });
     expect(dmRequest).not.toHaveBeenCalled();
   });
 });
@@ -501,49 +533,31 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
   it('no-ops unconfigured, and works with the sync flag OFF', async () => {
     delete process.env.GOOGLE_CM_USER_LIST_ID;
     expect(await svc.removeAudienceMembers([{ userIdentifiers: [{ phoneNumber: 'x' }] }])).toEqual({
-      removed: false,
+      accepted: 0,
       reason: 'unconfigured',
     });
     process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
     process.env.GOOGLE_CM_SYNC_ENABLED = 'false';
     const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
-    const dmRequestGet = jest.fn().mockResolvedValue(okStatus);
+    const dmRequestGet = jest.fn();
     const res = await svc.removeAudienceMembers(
       [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest, dmRequestGet, sleep: fastSleep }
+      { dmRequest, dmRequestGet, sleep: fastSleep, now: () => 1_700_000_000_000 }
     );
-    expect(res.removed).toBe(true);
+    expect(res).toEqual({ accepted: 1, members: 1, failedBatches: 0, settlement: 'queued' });
     expect(dmRequest.mock.calls[0][0]).toBe('audienceMembers:remove');
     expect(dmRequest.mock.calls[0][1].encoding).toBe('HEX');
-    expect(dmRequestGet).toHaveBeenCalled(); // removal is settled, not assumed
+    expect(dmRequestGet).not.toHaveBeenCalled(); // settlement is deferred, never in-run
   });
 
-  it('removal PARTIAL_SUCCESS is NOT removed:true — people stayed on the list', async () => {
-    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
-    const partialGet = jest.fn().mockResolvedValue({ requestStatus: 'PARTIAL_SUCCESS' });
+  it('a missing requestId on a removal accept is a failed batch (no silent success)', async () => {
     const res = await svc.removeAudienceMembers(
       [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest, dmRequestGet: partialGet, sleep: fastSleep }
+      { dmRequest: jest.fn().mockResolvedValue({}), sleep: fastSleep }
     );
-    expect(res.removed).toBe(false);
-    expect(res.status.partialSuccess).toBe(1);
-  });
-
-  it('removal is UNCONFIRMED (removed:false) when the status never settles or FAILs', async () => {
-    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
-    const stuckGet = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });
-    const stuck = await svc.removeAudienceMembers(
-      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest, dmRequestGet: stuckGet, sleep: fastSleep }
-    );
-    expect(stuck.removed).toBe(false);
-    expect(stuck.status.stuck).toBe(1);
-    const noId = await svc.removeAudienceMembers(
-      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest: jest.fn().mockResolvedValue({}), dmRequestGet: stuckGet, sleep: fastSleep }
-    );
-    expect(noId.removed).toBe(false);
-    expect(noId.failedBatches).toBe(1);
+    expect(res.accepted).toBe(0);
+    expect(res.failedBatches).toBe(1);
+    expect(res.settlement).toBeNull();
   });
 
   it('never throws on a provider failure (erasure must not depend on Google)', async () => {
@@ -552,9 +566,8 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
       [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
       { dmRequest, sleep: fastSleep }
     );
-    expect(res.removed).toBe(false);
-    expect(res.failedBatches).toBe(1);
     expect(res.accepted).toBe(0);
+    expect(res.failedBatches).toBe(1);
     expect(sentryMocks.captureException).toHaveBeenCalled();
   });
 
@@ -574,7 +587,7 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
       where: { consumerId: 'consumer-1', campaignId: 'camp-airpods' },
       raw: true,
     });
-    expect(res.removed).toBe(true);
+    expect(res.accepted).toBe(1);
     expect(res.members).toBe(1);
   });
 });

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -2,15 +2,10 @@ import { jest } from '@jest/globals';
 import crypto from 'crypto';
 
 // Mocks BEFORE importing the SUT (Jest ESM pattern).
-jest.unstable_mockModule('@sentry/node', () => ({
-  captureException: jest.fn(),
-  captureMessage: jest.fn(),
-  init: jest.fn(),
-  setTag: jest.fn(),
-}));
-jest.unstable_mockModule('../../src/utils/logger.js', () => ({
-  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
-}));
+const sentryMocks = { captureException: jest.fn(), captureMessage: jest.fn(), init: jest.fn(), setTag: jest.fn() };
+jest.unstable_mockModule('@sentry/node', () => sentryMocks);
+const loggerMock = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({ logger: loggerMock }));
 // consumerService (imported for phoneVerificationIsCurrent) drags a wide
 // transitive graph, so the models mock must satisfy EVERY named export of
 // models/index.js — generated, not hand-picked, so a new model never breaks
@@ -50,10 +45,12 @@ jest.unstable_mockModule('../../src/services/consentService.js', () => consentMo
 let svc;
 let piiHashing;
 let phoneHashOf;
+let Op;
 beforeAll(async () => {
   svc = await import('../../src/services/googleCustomerMatchService.js');
   piiHashing = await import('../../src/utils/piiHashing.js');
   ({ phoneHashOf } = await import('../../src/services/consumerService.js'));
+  ({ Op } = await import('sequelize'));
 });
 
 const ENV_KEYS = [
@@ -66,6 +63,7 @@ const ENV_KEYS = [
   'GOOGLE_CM_CAMPAIGN_ID',
   'GOOGLE_CM_ALERT_EMAIL',
   'REDEEMED_AUDIENCE_ALERT_EMAIL',
+  'GOOGLE_CM_STATUS_MAX_POLLS',
 ];
 const saved = {};
 beforeEach(() => {
@@ -77,10 +75,15 @@ beforeEach(() => {
   process.env.GOOGLE_ADS_CUSTOMER_ID = '1829163947';
   process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
   process.env.GOOGLE_CM_CAMPAIGN_ID = 'camp-airpods';
+  process.env.GOOGLE_CM_STATUS_MAX_POLLS = '3';
   delete process.env.GOOGLE_CM_ALERT_EMAIL;
   delete process.env.REDEEMED_AUDIENCE_ALERT_EMAIL;
   consentMocks.getSuppressedPhoneSet.mockReset().mockResolvedValue(new Set());
   consentMocks.getMarketableGrantMap.mockReset().mockResolvedValue(new Map());
+  sentryMocks.captureException.mockClear();
+  loggerMock.info.mockClear();
+  loggerMock.warn.mockClear();
+  loggerMock.error.mockClear();
 });
 afterEach(() => {
   for (const k of ENV_KEYS) {
@@ -90,6 +93,8 @@ afterEach(() => {
 });
 
 const sha = (v) => crypto.createHash('sha256').update(v).digest('hex');
+const fastSleep = () => Promise.resolve();
+const okStatus = { requestStatusPerDestination: [{ requestStatus: 'SUCCESS' }] };
 
 /** A fully-eligible prospect row + the grantMap entry that admits it. */
 function eligibleRow(overrides = {}) {
@@ -104,20 +109,53 @@ function eligibleRow(overrides = {}) {
 function grantAll(rows) {
   return new Map(rows.map((r) => [r.phone, new Map([['*', true]])]));
 }
+function happyDeps(rows, dmOverrides = {}) {
+  consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
+  return {
+    Prospect: { findAll: jest.fn().mockResolvedValue(rows) },
+    dmRequest: jest.fn().mockResolvedValue({ requestId: 'req-1' }),
+    dmRequestGet: jest.fn().mockResolvedValue(okStatus),
+    sendEmail: jest.fn().mockResolvedValue({}),
+    sleep: fastSleep,
+    ...dmOverrides,
+  };
+}
 
-describe('shouldSync', () => {
-  it('is true only with the full config set', () => {
+describe('shouldSync / removalConfigured', () => {
+  it('shouldSync is true only with the full config set', () => {
     expect(svc.shouldSync()).toBe(true);
   });
 
-  it.each(ENV_KEYS.slice(0, 7))('is false when %s is missing', (key) => {
+  it.each(ENV_KEYS.slice(0, 7))('shouldSync is false when %s is missing', (key) => {
     delete process.env[key];
     expect(svc.shouldSync()).toBe(false);
   });
 
-  it('is false when the flag is any non-"true" value', () => {
+  it('shouldSync is false when the flag is any non-"true" value', () => {
     process.env.GOOGLE_CM_SYNC_ENABLED = '1';
     expect(svc.shouldSync()).toBe(false);
+  });
+
+  it('removalConfigured ignores the sync flag (erasure honor survives a sync switch-off)', () => {
+    process.env.GOOGLE_CM_SYNC_ENABLED = 'false';
+    expect(svc.removalConfigured()).toBe(true);
+    delete process.env.GOOGLE_CM_USER_LIST_ID;
+    expect(svc.removalConfigured()).toBe(false);
+  });
+});
+
+describe('selectCampaignProspects', () => {
+  it('pins the exact selector: target campaign, non-bot, minimal attributes', async () => {
+    const findAll = jest.fn().mockResolvedValue([]);
+    await svc.selectCampaignProspects({ Prospect: { findAll } });
+    expect(findAll).toHaveBeenCalledWith({
+      attributes: ['email', 'phone', 'campaignId', 'sourceMetadata'],
+      where: {
+        campaignId: 'camp-airpods',
+        leadSource: { [Op.ne]: 'call_bot' },
+      },
+      raw: true,
+    });
   });
 });
 
@@ -128,7 +166,6 @@ describe('buildMemberRows', () => {
     expect(out).toEqual([
       {
         userIdentifiers: [
-          // gmail canonicalization: dots stripped, +suffix dropped
           { emailAddress: sha('janedoe@gmail.com') },
           { phoneNumber: sha('+6591234567') },
         ],
@@ -188,18 +225,32 @@ describe('buildMemberRows', () => {
   });
 
   it('drops rows with neither usable identifier', () => {
-    const rows = [eligibleRow({ email: null, phone: '' })];
-    // phone '' → no verification either, but assert the neither-identifier path
-    // with a verified-but-unhashable row too:
     const weird = eligibleRow({ email: 'not-an-email', phone: null });
-    expect(svc.buildMemberRows([...rows, weird], { grantMap: grantAll([...rows, weird]) })).toEqual(
-      []
-    );
+    expect(svc.buildMemberRows([weird], { grantMap: grantAll([weird]) })).toEqual([]);
   });
 });
 
-describe('buildIngestBody', () => {
-  it('pins the golden envelope: destination, consent enums, HEX, CM terms', () => {
+describe('buildRemovalIdentifiers', () => {
+  it('builds identifiers with NO consent/verification gate (removal is always permitted)', () => {
+    const out = svc.buildRemovalIdentifiers([
+      { email: 'jane.doe@gmail.com', phone: '+6591234567' },
+      { email: 'retell-x@calls.mktr.sg', phone: '+6598765432' },
+      { email: null, phone: null },
+    ]);
+    expect(out).toEqual([
+      {
+        userIdentifiers: [
+          { emailAddress: sha('janedoe@gmail.com') },
+          { phoneNumber: sha('+6591234567') },
+        ],
+      },
+      { userIdentifiers: [{ phoneNumber: sha('+6598765432') }] },
+    ]);
+  });
+});
+
+describe('buildIngestBody / buildRemoveBody', () => {
+  it('pins the golden ingest envelope: destination, consent enums, HEX, CM terms', () => {
     const members = [{ userIdentifiers: [{ phoneNumber: 'ph' }] }];
     expect(svc.buildIngestBody(members)).toEqual({
       destinations: [
@@ -219,11 +270,55 @@ describe('buildIngestBody', () => {
     expect(svc.buildIngestBody([], { validateOnly: true }).validateOnly).toBe(true);
     expect(svc.buildIngestBody([]).validateOnly).toBeUndefined();
   });
+
+  it('pins the removal envelope: HEX, destination, NO consent/terms blocks', () => {
+    const body = svc.buildRemoveBody([{ userIdentifiers: [{ phoneNumber: 'ph' }] }]);
+    expect(body).toEqual({
+      destinations: [
+        {
+          operatingAccount: { product: 'GOOGLE_ADS', accountId: '1829163947' },
+          productDestinationId: '999888777',
+        },
+      ],
+      audienceMembers: [{ userData: { userIdentifiers: [{ phoneNumber: 'ph' }] } }],
+      encoding: 'HEX',
+    });
+  });
 });
 
-describe('chunk', () => {
-  it('splits at the batch cap', () => {
-    expect(svc.chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+describe('settleRequestStatuses', () => {
+  it('classifies terminal states and dedupes request ids', async () => {
+    const dmRequestGet = jest
+      .fn()
+      .mockResolvedValueOnce({ requestStatusPerDestination: [{ requestStatus: 'SUCCESS' }] })
+      .mockResolvedValueOnce({ requestStatus: 'PARTIAL_SUCCESS' })
+      .mockResolvedValueOnce({ status: 'FAILED' });
+    const res = await svc.settleRequestStatuses(['a', 'a', 'b', 'c', null], {
+      dmRequestGet,
+      sleep: fastSleep,
+    });
+    expect(res).toEqual({ succeeded: 1, partialSuccess: 1, failed: 1, stuck: 0 });
+    expect(dmRequestGet).toHaveBeenCalledTimes(3);
+    expect(dmRequestGet.mock.calls[0][0]).toBe('requestStatus:retrieve?requestId=a');
+  });
+
+  it('polls PROCESSING through to a terminal state', async () => {
+    const dmRequestGet = jest
+      .fn()
+      .mockResolvedValueOnce({ requestStatus: 'PROCESSING' })
+      .mockResolvedValueOnce({ requestStatus: 'PROCESSING' })
+      .mockResolvedValueOnce({ requestStatus: 'SUCCESS' });
+    const res = await svc.settleRequestStatuses(['a'], { dmRequestGet, sleep: fastSleep });
+    expect(res).toEqual({ succeeded: 1, partialSuccess: 0, failed: 0, stuck: 0 });
+  });
+
+  it('marks an id stuck after the poll budget, and on a retrieve error', async () => {
+    const neverDone = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });
+    expect(await svc.settleRequestStatuses(['a'], { dmRequestGet: neverDone, sleep: fastSleep }))
+      .toEqual({ succeeded: 0, partialSuccess: 0, failed: 0, stuck: 1 });
+    const broken = jest.fn().mockRejectedValue(new Error('boom'));
+    expect(await svc.settleRequestStatuses(['b'], { dmRequestGet: broken, sleep: fastSleep }))
+      .toEqual({ succeeded: 0, partialSuccess: 0, failed: 0, stuck: 1 });
   });
 });
 
@@ -235,66 +330,132 @@ describe('syncGoogleCustomerMatch', () => {
     expect(consentMocks.getMarketableGrantMap).not.toHaveBeenCalled();
   });
 
-  it('uploads eligible members in batches and reports requestIds', async () => {
+  it('uploads, settles statuses, and reports the full summary', async () => {
     const rows = [eligibleRow(), eligibleRow({ phone: '+6598765432' })];
-    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
-    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
-    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
-    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
-    expect(res).toEqual({ synced: true, eligible: 2, batches: 1, requestIds: ['req-1'] });
-    expect(dmRequest).toHaveBeenCalledTimes(1);
-    const [method, body] = dmRequest.mock.calls[0];
-    expect(method).toBe('audienceMembers:ingest');
-    expect(body.audienceMembers).toHaveLength(2);
-    expect(body.encoding).toBe('HEX');
+    const d = happyDeps(rows);
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res).toEqual({
+      synced: true,
+      eligible: 2,
+      batches: 1,
+      accepted: 1,
+      failedBatches: 0,
+      status: { succeeded: 1, partialSuccess: 0, failed: 0, stuck: 0 },
+    });
+    expect(d.dmRequest.mock.calls[0][0]).toBe('audienceMembers:ingest');
+    expect(d.sendEmail).not.toHaveBeenCalled();
   });
 
-  it('aborts fail-closed (no upload, alert sent) when a ledger lookup throws', async () => {
+  it('splits 5001 members into envelopes of 5000 and 1 (the production cap)', async () => {
+    const rows = Array.from({ length: 5001 }, (_, i) =>
+      eligibleRow({ phone: `+659${String(1000000 + i).slice(-7)}` })
+    );
+    const d = happyDeps(rows);
+    d.dmRequest
+      .mockResolvedValueOnce({ requestId: 'req-1' })
+      .mockResolvedValueOnce({ requestId: 'req-2' });
+    d.dmRequestGet.mockResolvedValue(okStatus);
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.batches).toBe(2);
+    expect(res.accepted).toBe(2);
+    expect(d.dmRequest.mock.calls[0][1].audienceMembers).toHaveLength(5000);
+    expect(d.dmRequest.mock.calls[1][1].audienceMembers).toHaveLength(1);
+  });
+
+  it('partial batch failure: accepted batches stand, alert says partial (not wholesale)', async () => {
+    const rows = Array.from({ length: 5001 }, (_, i) =>
+      eligibleRow({ phone: `+659${String(1000000 + i).slice(-7)}` })
+    );
+    const d = happyDeps(rows);
+    d.dmRequest
+      .mockResolvedValueOnce({ requestId: 'req-1' })
+      .mockRejectedValueOnce(new Error('google dm audienceMembers:ingest failed: HTTP 500'));
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.synced).toBe(true);
+    expect(res.accepted).toBe(1);
+    expect(res.failedBatches).toBe(1);
+    expect(d.sendEmail).toHaveBeenCalledTimes(1);
+    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/partial failure/);
+    expect(d.sendEmail.mock.calls[0][0].text).toMatch(/accepted batches stand/i);
+  });
+
+  it('a missing requestId on accept counts as a failed batch, never silent success', async () => {
+    const rows = [eligibleRow()];
+    const d = happyDeps(rows);
+    d.dmRequest.mockResolvedValue({});
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.synced).toBe(false);
+    expect(res.failedBatches).toBe(1);
+    expect(res.accepted).toBe(0);
+    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
+  });
+
+  it('FAILED/stuck statuses trigger the partial alert even with all batches accepted', async () => {
+    const rows = [eligibleRow()];
+    const d = happyDeps(rows);
+    d.dmRequestGet.mockResolvedValue({ requestStatus: 'FAILED' });
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.status.failed).toBe(1);
+    expect(d.sendEmail).toHaveBeenCalledTimes(1);
+    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/partial failure/);
+  });
+
+  it('aborts fail-closed (no upload, wholesale alert) when a ledger lookup throws', async () => {
     consentMocks.getSuppressedPhoneSet.mockRejectedValue(new Error('ledger down'));
     process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
     const sendEmail = jest.fn().mockResolvedValue({});
     const dmRequest = jest.fn();
-    const res = await svc.syncGoogleCustomerMatch({ dmRequest, sendEmail });
+    const res = await svc.syncGoogleCustomerMatch({ dmRequest, sendEmail, sleep: fastSleep });
     expect(res.synced).toBe(false);
     expect(res.error).toMatch(/ledger down/);
     expect(dmRequest).not.toHaveBeenCalled();
-    expect(sendEmail).toHaveBeenCalledTimes(1);
-    expect(sendEmail.mock.calls[0][0].to).toBe('ops@mktr.sg');
+    expect(sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
   });
 
-  it('reports a failed upload with an alert and keeps PII out of the summary', async () => {
-    const rows = [eligibleRow()];
-    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
-    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
-    const dmRequest = jest.fn().mockRejectedValue(
-      Object.assign(new Error('google dm audienceMembers:ingest failed: HTTP 403 denied'), {
-        status: 403,
+  it('never leaks raw or hashed PII into errors, logs, Sentry, or alert email', async () => {
+    const rawEmail = 'pii.sentinel@gmail.com';
+    const rawPhone = '+6590000001';
+    const emailHash = sha('piisentinel@gmail.com');
+    const phoneHash = sha(rawPhone);
+    const rows = [eligibleRow({ email: rawEmail, phone: rawPhone })];
+    const d = happyDeps(rows);
+    d.dmRequest.mockRejectedValue(
+      Object.assign(new Error('google dm audienceMembers:ingest failed: HTTP 400 bad identifier'), {
+        status: 400,
       })
     );
-    process.env.REDEEMED_AUDIENCE_ALERT_EMAIL = 'fallback@mktr.sg';
-    const sendEmail = jest.fn().mockResolvedValue({});
-    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sendEmail });
-    expect(res.synced).toBe(false);
-    expect(res.error).not.toMatch(/@gmail/);
-    expect(sendEmail.mock.calls[0][0].to).toBe('fallback@mktr.sg');
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    await svc.syncGoogleCustomerMatch(d);
+    const surfaces = [
+      JSON.stringify(d.sendEmail.mock.calls),
+      JSON.stringify(loggerMock.error.mock.calls),
+      JSON.stringify(loggerMock.warn.mock.calls),
+      JSON.stringify(loggerMock.info.mock.calls),
+      JSON.stringify(sentryMocks.captureException.mock.calls.map((c) => c[0]?.message)),
+    ].join(' ');
+    expect(surfaces).not.toContain(rawEmail);
+    expect(surfaces).not.toContain(rawPhone);
+    expect(surfaces).not.toContain(emailHash);
+    expect(surfaces).not.toContain(phoneHash);
   });
 
-  it('single-flights overlapping runs', async () => {
+  it('single-flights overlapping runs (held through settling)', async () => {
     const rows = [eligibleRow()];
-    consentMocks.getMarketableGrantMap.mockResolvedValue(grantAll(rows));
-    const Prospect = { findAll: jest.fn().mockResolvedValue(rows) };
+    const d = happyDeps(rows);
     let release;
     const gate = new Promise((r) => {
       release = r;
     });
-    const dmRequest = jest.fn(async () => {
+    d.dmRequestGet = jest.fn(async () => {
       await gate;
-      return { requestId: 'slow' };
+      return okStatus;
     });
-    const first = svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
-    // Let the first run reach the in-flight section before starting the second.
+    const first = svc.syncGoogleCustomerMatch(d);
     await new Promise((r) => setTimeout(r, 10));
-    const second = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
+    const second = await svc.syncGoogleCustomerMatch(d);
     expect(second).toEqual({ synced: false, reason: 'overlap' });
     release();
     const firstRes = await first;
@@ -304,9 +465,57 @@ describe('syncGoogleCustomerMatch', () => {
   it('treats an empty eligible set as a successful no-op', async () => {
     const Prospect = { findAll: jest.fn().mockResolvedValue([]) };
     const dmRequest = jest.fn();
-    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest });
-    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, requestIds: [] });
+    const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sleep: fastSleep });
+    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, status: null });
     expect(dmRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeAudienceMembers / removeByConsumerId', () => {
+  it('no-ops unconfigured, and works with the sync flag OFF', async () => {
+    delete process.env.GOOGLE_CM_USER_LIST_ID;
+    expect(await svc.removeAudienceMembers([{ userIdentifiers: [{ phoneNumber: 'x' }] }])).toEqual({
+      removed: false,
+      reason: 'unconfigured',
+    });
+    process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
+    process.env.GOOGLE_CM_SYNC_ENABLED = 'false';
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
+    const res = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest }
+    );
+    expect(res.removed).toBe(true);
+    expect(dmRequest.mock.calls[0][0]).toBe('audienceMembers:remove');
+    expect(dmRequest.mock.calls[0][1].encoding).toBe('HEX');
+  });
+
+  it('never throws on a provider failure (erasure must not depend on Google)', async () => {
+    const dmRequest = jest.fn().mockRejectedValue(new Error('boom'));
+    const res = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest }
+    );
+    expect(res).toEqual({ removed: false, error: 'boom' });
+    expect(sentryMocks.captureException).toHaveBeenCalled();
+  });
+
+  it('removeByConsumerId scopes the lookup to the target campaign and removes', async () => {
+    const findAll = jest
+      .fn()
+      .mockResolvedValue([{ email: 'jane@mktr.sg', phone: '+6591234567' }]);
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
+    const res = await svc.removeByConsumerId('consumer-1', {
+      Prospect: { findAll },
+      dmRequest,
+    });
+    expect(findAll).toHaveBeenCalledWith({
+      attributes: ['email', 'phone'],
+      where: { consumerId: 'consumer-1', campaignId: 'camp-airpods' },
+      raw: true,
+    });
+    expect(res.removed).toBe(true);
+    expect(res.members).toBe(1);
   });
 });
 

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -518,6 +518,17 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
     expect(dmRequestGet).toHaveBeenCalled(); // removal is settled, not assumed
   });
 
+  it('removal PARTIAL_SUCCESS is NOT removed:true — people stayed on the list', async () => {
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
+    const partialGet = jest.fn().mockResolvedValue({ requestStatus: 'PARTIAL_SUCCESS' });
+    const res = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest, dmRequestGet: partialGet, sleep: fastSleep }
+    );
+    expect(res.removed).toBe(false);
+    expect(res.status.partialSuccess).toBe(1);
+  });
+
   it('removal is UNCONFIRMED (removed:false) when the status never settles or FAILs', async () => {
     const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
     const stuckGet = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -377,7 +377,7 @@ describe('syncGoogleCustomerMatch', () => {
     expect(res.failedBatches).toBe(1);
     expect(d.sendEmail).toHaveBeenCalledTimes(1);
     expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/partial failure/);
-    expect(d.sendEmail.mock.calls[0][0].text).toMatch(/accepted batches stand/i);
+    expect(d.sendEmail.mock.calls[0][0].text).toMatch(/confirmed batches stand/i);
   });
 
   it('a missing requestId on accept counts as a failed batch, never silent success', async () => {
@@ -392,15 +392,27 @@ describe('syncGoogleCustomerMatch', () => {
     expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
   });
 
-  it('FAILED/stuck statuses trigger the partial alert even with all batches accepted', async () => {
+  it('every accepted job terminally FAILED = wholesale, never "synced" (outcome-derived)', async () => {
     const rows = [eligibleRow()];
     const d = happyDeps(rows);
     d.dmRequestGet.mockResolvedValue({ requestStatus: 'FAILED' });
     process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
     const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.synced).toBe(false);
     expect(res.status.failed).toBe(1);
-    expect(d.sendEmail).toHaveBeenCalledTimes(1);
-    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/partial failure/);
+    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
+  });
+
+  it('accepted-but-stuck statuses = unconfirmed, never "synced"', async () => {
+    const rows = [eligibleRow()];
+    const d = happyDeps(rows);
+    d.dmRequestGet.mockResolvedValue({ requestStatus: 'PROCESSING' });
+    process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
+    const res = await svc.syncGoogleCustomerMatch(d);
+    expect(res.synced).toBe(false);
+    expect(res.reason).toBe('unconfirmed');
+    expect(res.status.stuck).toBe(1);
+    expect(d.sendEmail.mock.calls[0][0].subject).toMatch(/unconfirmed/);
   });
 
   it('aborts fail-closed (no upload, wholesale alert) when a ledger lookup throws', async () => {
@@ -415,18 +427,32 @@ describe('syncGoogleCustomerMatch', () => {
     expect(sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
   });
 
-  it('never leaks raw or hashed PII into errors, logs, Sentry, or alert email', async () => {
+  it('never leaks raw or hashed PII into errors, logs, Sentry, or alert email — through the REAL client (provider echoes the hash)', async () => {
     const rawEmail = 'pii.sentinel@gmail.com';
     const rawPhone = '+6590000001';
     const emailHash = sha('piisentinel@gmail.com');
     const phoneHash = sha(rawPhone);
     const rows = [eligibleRow({ email: rawEmail, phone: rawPhone })];
     const d = happyDeps(rows);
-    d.dmRequest.mockRejectedValue(
-      Object.assign(new Error('google dm audienceMembers:ingest failed: HTTP 400 bad identifier'), {
+    // Route through the real dmRequest with a mocked fetch whose error body
+    // ECHOES both sentinels — the client's redaction is the surface under test.
+    const client = await import('../../src/utils/googleDataManagerClient.js');
+    client.__resetTokenCacheForTests();
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ access_token: 'at', expires_in: 3600 }) })
+      .mockResolvedValue({
+        ok: false,
         status: 400,
-      })
-    );
+        json: async () => ({
+          error: {
+            code: 400,
+            status: 'INVALID_ARGUMENT',
+            message: `rejected identifiers ${emailHash} ${phoneHash} for ${rawEmail} / ${rawPhone}`,
+          },
+        }),
+      });
+    d.dmRequest = (method, payload) => client.dmRequest(method, payload, { fetch, sleep: fastSleep });
     process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
     await svc.syncGoogleCustomerMatch(d);
     const surfaces = [
@@ -481,22 +507,43 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
     process.env.GOOGLE_CM_USER_LIST_ID = '999888777';
     process.env.GOOGLE_CM_SYNC_ENABLED = 'false';
     const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
+    const dmRequestGet = jest.fn().mockResolvedValue(okStatus);
     const res = await svc.removeAudienceMembers(
       [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest }
+      { dmRequest, dmRequestGet, sleep: fastSleep }
     );
     expect(res.removed).toBe(true);
     expect(dmRequest.mock.calls[0][0]).toBe('audienceMembers:remove');
     expect(dmRequest.mock.calls[0][1].encoding).toBe('HEX');
+    expect(dmRequestGet).toHaveBeenCalled(); // removal is settled, not assumed
+  });
+
+  it('removal is UNCONFIRMED (removed:false) when the status never settles or FAILs', async () => {
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-1' });
+    const stuckGet = jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' });
+    const stuck = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest, dmRequestGet: stuckGet, sleep: fastSleep }
+    );
+    expect(stuck.removed).toBe(false);
+    expect(stuck.status.stuck).toBe(1);
+    const noId = await svc.removeAudienceMembers(
+      [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
+      { dmRequest: jest.fn().mockResolvedValue({}), dmRequestGet: stuckGet, sleep: fastSleep }
+    );
+    expect(noId.removed).toBe(false);
+    expect(noId.failedBatches).toBe(1);
   });
 
   it('never throws on a provider failure (erasure must not depend on Google)', async () => {
     const dmRequest = jest.fn().mockRejectedValue(new Error('boom'));
     const res = await svc.removeAudienceMembers(
       [{ userIdentifiers: [{ phoneNumber: 'x' }] }],
-      { dmRequest }
+      { dmRequest, sleep: fastSleep }
     );
-    expect(res).toEqual({ removed: false, error: 'boom' });
+    expect(res.removed).toBe(false);
+    expect(res.failedBatches).toBe(1);
+    expect(res.accepted).toBe(0);
     expect(sentryMocks.captureException).toHaveBeenCalled();
   });
 
@@ -508,6 +555,8 @@ describe('removeAudienceMembers / removeByConsumerId', () => {
     const res = await svc.removeByConsumerId('consumer-1', {
       Prospect: { findAll },
       dmRequest,
+      dmRequestGet: jest.fn().mockResolvedValue(okStatus),
+      sleep: fastSleep,
     });
     expect(findAll).toHaveBeenCalledWith({
       attributes: ['email', 'phone'],

--- a/backend/test/unit/googleCustomerMatchService.test.js
+++ b/backend/test/unit/googleCustomerMatchService.test.js
@@ -350,6 +350,39 @@ describe('settlePendingStatuses (deferred, Google-recommended timing)', () => {
     expect(mid.pending).toBe(1); // rescheduled — a flaky retrieve is not yet stuck
   });
 
+  it('a blocked pass cannot hide a later-due request from a subsequent pass', async () => {
+    await seedIngestRequest('req-slow', T0);
+    // second request accepted five minutes later — NOT yet due at pass 1
+    const rows = [eligibleRow()];
+    const d2 = happyDeps(rows);
+    d2.dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-later' });
+    d2.now = () => T0 + 5 * 60_000;
+    const second = await svc.syncGoogleCustomerMatch(d2);
+    expect(second).toMatchObject({ submitted: true, accepted: 1, settlement: 'queued' });
+
+    let releaseSlow;
+    const slowGate = new Promise((r) => { releaseSlow = r; });
+    const slowGet = jest.fn(async (path) => {
+      if (path.includes('req-slow')) {
+        await slowGate; // Google outage: this poll hangs
+        return okStatus;
+      }
+      return okStatus;
+    });
+    // Pass 1 at T0+31min: only req-slow is due; it hangs mid-poll.
+    const pass1 = svc.settlePendingStatuses({ dmRequestGet: slowGet, now: () => T0 + 31 * 60_000 });
+    await new Promise((r) => setTimeout(r, 10));
+    // Pass 2 at T0+36min: req-later is due now — it must be visible and settle
+    // even though pass 1 still holds req-slow.
+    const pass2 = await svc.settlePendingStatuses({ dmRequestGet: slowGet, now: () => T0 + 36 * 60_000 });
+    expect(pass2.succeeded).toBe(1);
+    expect(pass2.polled).toBe(1);
+    releaseSlow();
+    const pass1Res = await pass1;
+    expect(pass1Res.succeeded).toBe(1);
+    expect(slowGet.mock.calls.filter((c) => c[0].includes('req-slow'))).toHaveLength(1); // no double-poll
+  });
+
   it('a PARTIAL_SUCCESS *removal* alerts (people stayed on the list); a partial ingest does not', async () => {
     const dmRequest = jest.fn().mockResolvedValue({ requestId: 'rm-partial' });
     const acceptance = await svc.removeAudienceMembers(
@@ -378,7 +411,7 @@ describe('syncGoogleCustomerMatch', () => {
   it('returns guarded without touching the ledger when config is missing', async () => {
     delete process.env.GOOGLE_CM_USER_LIST_ID;
     const res = await svc.syncGoogleCustomerMatch({ dmRequest: jest.fn() });
-    expect(res).toEqual({ synced: false, reason: 'guarded' });
+    expect(res).toEqual({ submitted: false, reason: 'guarded' });
     expect(consentMocks.getMarketableGrantMap).not.toHaveBeenCalled();
   });
 
@@ -387,7 +420,7 @@ describe('syncGoogleCustomerMatch', () => {
     const d = happyDeps(rows);
     const res = await svc.syncGoogleCustomerMatch(d);
     expect(res).toEqual({
-      synced: true,
+      submitted: true,
       eligible: 2,
       batches: 1,
       accepted: 1,
@@ -426,7 +459,7 @@ describe('syncGoogleCustomerMatch', () => {
       .mockRejectedValueOnce(new Error('google dm audienceMembers:ingest failed: HTTP 500'));
     process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
     const res = await svc.syncGoogleCustomerMatch(d);
-    expect(res.synced).toBe(true);
+    expect(res.submitted).toBe(true);
     expect(res.accepted).toBe(1);
     expect(res.failedBatches).toBe(1);
     expect(d.sendEmail).toHaveBeenCalledTimes(1);
@@ -440,7 +473,7 @@ describe('syncGoogleCustomerMatch', () => {
     d.dmRequest.mockResolvedValue({});
     process.env.GOOGLE_CM_ALERT_EMAIL = 'ops@mktr.sg';
     const res = await svc.syncGoogleCustomerMatch(d);
-    expect(res.synced).toBe(false);
+    expect(res.submitted).toBe(false);
     expect(res.failedBatches).toBe(1);
     expect(res.accepted).toBe(0);
     expect(res.settlement).toBeNull();
@@ -453,7 +486,7 @@ describe('syncGoogleCustomerMatch', () => {
     const sendEmail = jest.fn().mockResolvedValue({});
     const dmRequest = jest.fn();
     const res = await svc.syncGoogleCustomerMatch({ dmRequest, sendEmail, sleep: fastSleep });
-    expect(res.synced).toBe(false);
+    expect(res.submitted).toBe(false);
     expect(res.error).toMatch(/ledger down/);
     expect(dmRequest).not.toHaveBeenCalled();
     expect(sendEmail.mock.calls[0][0].subject).toMatch(/nothing uploaded/);
@@ -514,17 +547,17 @@ describe('syncGoogleCustomerMatch', () => {
     const first = svc.syncGoogleCustomerMatch(d);
     await new Promise((r) => setTimeout(r, 10));
     const second = await svc.syncGoogleCustomerMatch(d);
-    expect(second).toEqual({ synced: false, reason: 'overlap' });
+    expect(second).toEqual({ submitted: false, reason: 'overlap' });
     release();
     const firstRes = await first;
-    expect(firstRes.synced).toBe(true);
+    expect(firstRes.submitted).toBe(true);
   });
 
   it('treats an empty eligible set as a successful no-op', async () => {
     const Prospect = { findAll: jest.fn().mockResolvedValue([]) };
     const dmRequest = jest.fn();
     const res = await svc.syncGoogleCustomerMatch({ Prospect, dmRequest, sleep: fastSleep });
-    expect(res).toEqual({ synced: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null });
+    expect(res).toEqual({ submitted: true, eligible: 0, batches: 0, accepted: 0, failedBatches: 0, settlement: null });
     expect(dmRequest).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/unit/googleDataManagerClient.test.js
+++ b/backend/test/unit/googleDataManagerClient.test.js
@@ -1,0 +1,122 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+let client;
+beforeAll(async () => {
+  client = await import('../../src/utils/googleDataManagerClient.js');
+});
+
+const ENV_KEYS = [
+  'GOOGLE_DM_OAUTH_CLIENT_ID',
+  'GOOGLE_DM_OAUTH_CLIENT_SECRET',
+  'GOOGLE_DM_REFRESH_TOKEN',
+  'GOOGLE_DM_API_VERSION',
+];
+const saved = {};
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.GOOGLE_DM_OAUTH_CLIENT_ID = 'cid';
+  process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET = 'sec';
+  process.env.GOOGLE_DM_REFRESH_TOKEN = 'rt';
+  delete process.env.GOOGLE_DM_API_VERSION;
+  client.__resetTokenCacheForTests();
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+const tokenOk = () =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: async () => ({ access_token: 'at-1', expires_in: 3600 }),
+  });
+
+describe('getAccessToken', () => {
+  it('mints via the refresh grant and caches until expiry', async () => {
+    const fetch = jest.fn().mockImplementation(tokenOk);
+    const now = jest.fn().mockReturnValue(1_000_000);
+    expect(await client.getAccessToken({ fetch, now })).toBe('at-1');
+    expect(await client.getAccessToken({ fetch, now })).toBe('at-1');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe('https://oauth2.googleapis.com/token');
+    expect(init.body).toContain('grant_type=refresh_token');
+  });
+
+  it('re-mints once the cached token nears expiry', async () => {
+    const fetch = jest.fn().mockImplementation(tokenOk);
+    let t = 1_000_000;
+    const now = jest.fn(() => t);
+    await client.getAccessToken({ fetch, now });
+    t += 3600_000 - 30_000; // inside the 60s slack window
+    await client.getAccessToken({ fetch, now });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on incomplete OAuth env without calling out', async () => {
+    delete process.env.GOOGLE_DM_REFRESH_TOKEN;
+    const fetch = jest.fn();
+    await expect(client.getAccessToken({ fetch })).rejects.toThrow(/OAuth env incomplete/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a sanitized error on a refresh failure', async () => {
+    const fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'invalid_grant', error_description: 'Token has been revoked.' }),
+    });
+    await expect(client.getAccessToken({ fetch })).rejects.toThrow(
+      /token refresh failed: HTTP 400 Token has been revoked\./
+    );
+  });
+});
+
+describe('dmRequest', () => {
+  it('POSTs the method under the versioned base with a bearer token', async () => {
+    const fetch = jest
+      .fn()
+      .mockImplementationOnce(tokenOk)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ requestId: 'r1' }) });
+    const res = await client.dmRequest('audienceMembers:ingest', { a: 1 }, { fetch });
+    expect(res).toEqual({ requestId: 'r1' });
+    const [url, init] = fetch.mock.calls[1];
+    expect(url).toBe('https://datamanager.googleapis.com/v1/audienceMembers:ingest');
+    expect(init.headers.Authorization).toBe('Bearer at-1');
+    expect(JSON.parse(init.body)).toEqual({ a: 1 });
+  });
+
+  it('honours GOOGLE_DM_API_VERSION', async () => {
+    process.env.GOOGLE_DM_API_VERSION = 'v2beta';
+    const fetch = jest
+      .fn()
+      .mockImplementationOnce(tokenOk)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+    await client.dmRequest('events:ingest', {}, { fetch });
+    expect(fetch.mock.calls[1][0]).toBe('https://datamanager.googleapis.com/v2beta/events:ingest');
+  });
+
+  it('throws a sanitized error carrying status + google message, never the request body', async () => {
+    const fetch = jest
+      .fn()
+      .mockImplementationOnce(tokenOk)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: { message: 'Customer Match not allowed' } }),
+      });
+    const err = await client
+      .dmRequest('audienceMembers:ingest', { secretHash: 'abc123' }, { fetch })
+      .catch((e) => e);
+    expect(err.status).toBe(403);
+    expect(err.message).toMatch(/HTTP 403 Customer Match not allowed/);
+    expect(err.message).not.toMatch(/abc123/);
+  });
+});

--- a/backend/test/unit/googleDataManagerClient.test.js
+++ b/backend/test/unit/googleDataManagerClient.test.js
@@ -121,16 +121,16 @@ describe('dmRequest', () => {
   });
 });
 
-describe('fetchWithRetry', () => {
-  it('retries transient 429/5xx with backoff and returns the eventual response', async () => {
+describe('fetchJsonWithRetry', () => {
+  it('retries transient 429/5xx with backoff and returns the eventual parsed body', async () => {
     const fetch = jest
       .fn()
       .mockResolvedValueOnce({ status: 429, ok: false, json: async () => ({}) })
       .mockResolvedValueOnce({ status: 503, ok: false, json: async () => ({}) })
-      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => ({}) });
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => ({ fine: true }) });
     const sleep = jest.fn().mockResolvedValue();
-    const res = await client.fetchWithRetry('https://x', {}, { fetch, sleep });
-    expect(res.status).toBe(200);
+    const res = await client.fetchJsonWithRetry('https://x', {}, { fetch, sleep });
+    expect(res).toEqual({ status: 200, ok: true, body: { fine: true } });
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(sleep).toHaveBeenCalledTimes(2);
   });
@@ -138,7 +138,7 @@ describe('fetchWithRetry', () => {
   it('does NOT retry a terminal 4xx (returned to the caller to classify)', async () => {
     const fetch = jest.fn().mockResolvedValue({ status: 400, ok: false, json: async () => ({}) });
     const sleep = jest.fn();
-    const res = await client.fetchWithRetry('https://x', {}, { fetch, sleep });
+    const res = await client.fetchJsonWithRetry('https://x', {}, { fetch, sleep });
     expect(res.status).toBe(400);
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(sleep).not.toHaveBeenCalled();
@@ -147,15 +147,32 @@ describe('fetchWithRetry', () => {
   it('retries network errors and surfaces a sanitized failure after the budget', async () => {
     const fetch = jest.fn().mockRejectedValue(new Error('socket hang up'));
     const sleep = jest.fn().mockResolvedValue();
-    await expect(client.fetchWithRetry('https://x', {}, { fetch, sleep })).rejects.toThrow(
+    await expect(client.fetchJsonWithRetry('https://x', {}, { fetch, sleep })).rejects.toThrow(
       /failed after 3 attempts: socket hang up/
     );
     expect(fetch).toHaveBeenCalledTimes(3);
   });
 
+  it('consumes the BODY inside the retry/abort boundary — a failed 2xx body stream retries', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => {
+          throw new Error('body stream stalled/aborted');
+        },
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => ({ fine: true }) });
+    const sleep = jest.fn().mockResolvedValue();
+    const res = await client.fetchJsonWithRetry('https://x', {}, { fetch, sleep });
+    expect(res.body).toEqual({ fine: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it('passes an abort signal so a hung fetch cannot wedge the caller', async () => {
     const fetch = jest.fn().mockResolvedValue({ status: 200, ok: true, json: async () => ({}) });
-    await client.fetchWithRetry('https://x', {}, { fetch });
+    await client.fetchJsonWithRetry('https://x', {}, { fetch });
     expect(fetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/backend/test/unit/googleDataManagerClient.test.js
+++ b/backend/test/unit/googleDataManagerClient.test.js
@@ -120,3 +120,58 @@ describe('dmRequest', () => {
     expect(err.message).not.toMatch(/abc123/);
   });
 });
+
+describe('fetchWithRetry', () => {
+  it('retries transient 429/5xx with backoff and returns the eventual response', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ status: 429, ok: false, json: async () => ({}) })
+      .mockResolvedValueOnce({ status: 503, ok: false, json: async () => ({}) })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => ({}) });
+    const sleep = jest.fn().mockResolvedValue();
+    const res = await client.fetchWithRetry('https://x', {}, { fetch, sleep });
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a terminal 4xx (returned to the caller to classify)', async () => {
+    const fetch = jest.fn().mockResolvedValue({ status: 400, ok: false, json: async () => ({}) });
+    const sleep = jest.fn();
+    const res = await client.fetchWithRetry('https://x', {}, { fetch, sleep });
+    expect(res.status).toBe(400);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries network errors and surfaces a sanitized failure after the budget', async () => {
+    const fetch = jest.fn().mockRejectedValue(new Error('socket hang up'));
+    const sleep = jest.fn().mockResolvedValue();
+    await expect(client.fetchWithRetry('https://x', {}, { fetch, sleep })).rejects.toThrow(
+      /failed after 3 attempts: socket hang up/
+    );
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes an abort signal so a hung fetch cannot wedge the caller', async () => {
+    const fetch = jest.fn().mockResolvedValue({ status: 200, ok: true, json: async () => ({}) });
+    await client.fetchWithRetry('https://x', {}, { fetch });
+    expect(fetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('dmRequestGet', () => {
+  it('GETs the path with auth and no body', async () => {
+    const fetch = jest
+      .fn()
+      .mockImplementationOnce(tokenOk)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ requestStatus: 'SUCCESS' }) });
+    const res = await client.dmRequestGet('requestStatus:retrieve?requestId=r1', { fetch });
+    expect(res).toEqual({ requestStatus: 'SUCCESS' });
+    const [url, init] = fetch.mock.calls[1];
+    expect(url).toBe('https://datamanager.googleapis.com/v1/requestStatus:retrieve?requestId=r1');
+    expect(init.method).toBe('GET');
+    expect(init.body).toBeUndefined();
+    expect(init.headers.Authorization).toBe('Bearer at-1');
+  });
+});

--- a/docs/plans/google-ads-signal-levers.md
+++ b/docs/plans/google-ads-signal-levers.md
@@ -239,7 +239,7 @@ needed; id → env).
     campaigns, remove members / delete the list in the UI, lifespan expiry
     mops up.
 - **Scheduler:** same in-process interval block in `bootstrap.js` beside the
-  Meta one (24h default via `GOOGLE_CM_SYNC_INTERVAL_HOURS`, 60s initial).
+  Meta one (24h default via `GOOGLE_CM_SYNC_INTERVAL_HOURS`; 90s initial — deliberately offset from the Meta block's 60s so the two ledger scans never land together).
 - **Eligibility caveat:** Customer Match exclusions are available without the
   90-day/USD 50k *targeting* threshold, but the account must be policy- and
   payment-compliant — check the account's Customer Match status page as a


### PR DESCRIPTION
## Why

Phase 2b of `docs/plans/google-ads-signal-levers.md` (v8, 8-round Codex-passed plan; this PR's code additionally survived a **6-round Codex code review**, findings 8 → 6 → 2 → 2 → 1 → 0). The funnel's phone dedupe rejects a repeat entrant only **after** the click is paid for; a Customer Match exclusion list attached to the Demand Gen campaign kills the wasted impression upstream.

## What

- **`googleDataManagerClient.js`** — refresh-token OAuth + POST/GET helpers for the **Data Manager API** (the classic Google Ads API's Customer Match surface rejects new developer tokens since 2026-04-01; no token/MCC needed). Timeout + bounded retry with the abort window covering **headers and body**; provider free-text **redacted** (hash/token/email/phone patterns) before any exception/log/Sentry surface — the PII sentinel test routes through the real client with a provider body echoing raw + hashed identifiers.
- **`googleCustomerMatchService.js`** — mirror of `redeemedAudienceService` with the plan's review-driven differences: **per-campaign population** (`GOOGLE_CM_CAMPAIGN_ID`), the `phoneVerifiedFor` **binding semantic**, **no consent escape hatch**, erased-skeleton exclusion, in-process single-flight, 10k-member batches.
- **Acceptance-only truth in-run** (`submitted`/`accepted`/`settlement:'queued'`; empty runs are `ok:true`, never `submitted:true`): ingestion and removal are asynchronous, so accepted requestIds join a **deferred settlement queue** drained on Google's real diagnostics window (first poll 30 min, ~1.3× backoff capped 1h + jitter, 24h horizon). The drainer registers whenever DM creds + list id exist — **removals settle even with the sync flag off**. Settler alerts + Sentry on FAILED, horizon-stuck, and **PARTIAL_SUCCESS removals** (people stayed on the list) while partial ingests self-heal on the nightly additive re-ingest. Due-only synchronous partition: a pass hung on a Google outage can neither hide later-due entries nor be double-polled (controlled-promise test).
- **Erasure/withdrawal removal hooks (IN this PR)**: `erasureService` collects raw pairs **pre-scrub inside the row-locked transaction** and fires `audienceMembers:remove` **post-commit** via an injectable seam; `applyUnsubscribe` dispatches `removeByConsumerId` post-commit. Async-IIFE'd so even a synchronously-throwing seam cannot fail a committed erasure. Proven in `test/integration/erasure.test.js` on real Postgres (pre-scrub values, post-commit ordering, target-campaign-only collection, seam-failure independence). `removalConfigured()` deliberately ignores the sync flag. The list's finite membership duration (Ads UI, 180d proposed) backstops lost calls; restart-dropped pending settles are documented accepted loss.
- **`hashEmailGoogle`** (gmail/googlemail canonicalization — Meta's `hashEmail` would silently zero-match) + **`hashPhoneE164`**; ingest envelope pinned (destinations/HEX/`CONSENT_GRANTED`/CM terms) with a `validateOnly` seam for the pre-flip smoke.
- **`bootstrap.js`** scheduler (90s initial — offset from Meta's 60s — + 24h interval) and the settlement drainer; **`scripts/google-dm-oauth-bootstrap.mjs`** (loopback flow, error/timeout hardened); `env.example` documented.

## Safe to merge now

**Ships dark.** `GOOGLE_CM_SYNC_ENABLED` unset everywhere; `shouldSync()` requires the full config; the drainer registers only when DM creds exist (they don't yet). Zero behavior change until Phase 0's OAuth mint + env flip.

## Tested

- 2407 backend unit green (145 suites; 59 in the two new google suites incl. golden envelopes, fail-closed ledger abort, real-client PII sentinels, deferred-settlement clock tests, due-only partition under a hung pass, 10001→10000/1 batching)
- `test/integration/erasure.test.js` 29/29 on real Postgres (hook ordering matrix)
- Typecheck (checkJs ratchet) + `eslint src/ --quiet` clean; no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcFxTJ4vuWC5XJ8mavUTk