### PR TITLE
feat(studio): owner-authored custom questions — display-only answers on the lead

### DIFF
--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -1,6 +1,11 @@
 import Joi from 'joi';
 import { logger } from '../utils/logger.js';
 import { CAMPAIGN_TYPE_IDS } from '../utils/campaignTypes.js';
+import {
+  CUSTOM_ANSWER_TEXT_MAX,
+  MAX_CUSTOM_OPTIONS,
+  MAX_TOTAL_PROFILE_QUESTIONS,
+} from '../utils/designConfigV2.js';
 
 // Validation middleware.
 //
@@ -271,11 +276,15 @@ export const schemas = {
       .pattern(
         Joi.string().pattern(/^[a-z][a-z0-9_]{0,31}$/),
         Joi.alternatives().try(
-          Joi.string().max(32),
-          Joi.array().items(Joi.string().max(32)).max(8).unique()
+          // The string alternative also carries custom free-TEXT answers
+          // (studio-custom-questions §6) — semantic validation still drops any
+          // non-option value for select questions, so the wider bound never
+          // loosens library answers.
+          Joi.string().max(CUSTOM_ANSWER_TEXT_MAX),
+          Joi.array().items(Joi.string().max(32)).max(MAX_CUSTOM_OPTIONS).unique()
         )
       )
-      .max(5)
+      .max(MAX_TOTAL_PROFILE_QUESTIONS)
       .unknown(false)
       .optional(),
     // Ad attribution (IG/TikTok). Captured from the landing URL, stashed in

--- a/backend/src/services/prospectScoring.js
+++ b/backend/src/services/prospectScoring.js
@@ -19,7 +19,13 @@
 import { scoreQuiz } from './quizScoringService.js';
 import { getProfileQuestion, resolveAnswer as resolveProfileAnswer } from '../utils/profileQuestionLibrary.js';
 import { validateFact } from '../utils/factTaxonomy.js';
-import { isV2 as isV2DesignConfig } from '../utils/designConfigV2.js';
+import {
+  isV2 as isV2DesignConfig,
+  CUSTOM_ANSWER_TEXT_MAX,
+  LIMITS,
+  MAX_CUSTOM_OPTIONS,
+  sanitizeQuestionText,
+} from '../utils/designConfigV2.js';
 
 /**
  * @param {object} args
@@ -93,6 +99,13 @@ export function makeScoringStage({ d }) {
         && isV2DesignConfig(dcRaw)
         && pq?.enabled === true
         && dcRaw?.template?.id !== 'guided_review'
+        // The leg the parent plan intended (studio-custom-questions §6, Codex
+        // R1 #7): the UI branches on campaign TYPE while this gate checked only
+        // template.id — a guided-review-type campaign carrying a v2 doc with a
+        // different template id accepted hidden answers via direct POST. Both
+        // checks stay (belt + braces); this also closes the same latent gap
+        // for LIBRARY answers.
+        && sourceCampaign?.type !== 'guided_review'
         && Array.isArray(pq?.questionIds);
       if (eligible) {
         const acceptedIds = {};
@@ -110,6 +123,52 @@ export function makeScoringStage({ d }) {
           acceptedProfileFacts.push({ key: q.factKey, value });
           acceptedIds[qid] = provided;
         }
+        // --- Custom questions (studio-custom-questions §6) — DISPLAY-ONLY ---
+        // Iterate the campaign's questionIds in order (never attacker keys),
+        // taking ids that resolve to a campaign custom def. Accepted answers
+        // freeze the EN prompt + EN labels (or the sanitized literal text)
+        // server-side, so a later Studio edit can never re-caption history.
+        // They deliberately NEVER touch acceptedProfileFacts — zero
+        // consumer-observation facts by construction.
+        const customById = new Map((Array.isArray(pq.custom) ? pq.custom : [])
+          .filter((q) => q && typeof q === 'object' && typeof q.id === 'string')
+          .map((q) => [q.id, q]));
+        const customAnswers = [];
+        for (const qid of pq.questionIds) {
+          const def = customById.get(qid);
+          if (!def) continue;
+          const provided = rawAnswers[qid];
+          if (provided === undefined || provided === null || provided === '') continue;
+          // Belt + braces vs direct-DB-authored defs: freeze SANITIZED copy.
+          const prompt = sanitizeQuestionText(def.prompt, LIMITS.cqPrompt);
+          if (!prompt) continue;
+          const options = Array.isArray(def.options) ? def.options.filter((o) => o && typeof o === 'object') : [];
+          let values = null;
+          if (def.type === 'text') {
+            if (typeof provided === 'string') {
+              const text = sanitizeQuestionText(provided, CUSTOM_ANSWER_TEXT_MAX);
+              if (text) values = [text];
+              else continue; // empty after trim = skipped, not an abuse signal
+            }
+          } else if (def.type === 'single') {
+            const opt = typeof provided === 'string' ? options.find((o) => o.id === provided) : null;
+            if (opt) values = [sanitizeQuestionText(opt.label, LIMITS.cqOption)].filter(Boolean);
+          } else if (def.type === 'multi') {
+            if (Array.isArray(provided) && provided.length && provided.length <= MAX_CUSTOM_OPTIONS
+              && new Set(provided).size === provided.length
+              && provided.every((v) => typeof v === 'string')) {
+              const chosen = options.filter((o) => provided.includes(o.id));
+              if (chosen.length === provided.length) {
+                values = chosen.map((o) => sanitizeQuestionText(o.label, LIMITS.cqOption)).filter(Boolean);
+              }
+            }
+          }
+          if (!values || !values.length) {
+            dropped.push(qid); // ids only — never answer content (log-injection surface)
+            continue;
+          }
+          customAnswers.push({ qid, prompt, values });
+        }
         if (dropped.length) {
           d.logger.warn('[enrichment] profile answers dropped (invalid)', {
             campaignId, dropped,
@@ -117,6 +176,9 @@ export function makeScoringStage({ d }) {
         }
         if (Object.keys(acceptedIds).length) {
           sourceMetadataPatch.profileAnswers = acceptedIds;
+        }
+        if (customAnswers.length) {
+          sourceMetadataPatch.customAnswers = customAnswers;
         }
       } else if (rawAnswers && typeof rawAnswers === 'object' && Object.keys(rawAnswers).length) {
         d.logger.warn('[enrichment] profile answers ignored (campaign not eligible)', {

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -231,19 +231,30 @@ export function makeProspectService(overrides = {}) {
       // consent can never be forged via the body (defence-in-depth beyond route stripUnknown).
       consentMetadata: _cm,
       quizResult: _qr, referralRef: _rref,
+      // profileAnswers is consumed by the scoring stage (scoreSubmission reads
+      // it off safeBody) — stripped here so it can never ride `incoming` into
+      // Prospect.create (studio-custom-questions §6; it was inert only because
+      // Sequelize ignores non-attribute keys).
+      profileAnswers: _pans,
       utm_source: _us, utm_medium: _um, utm_campaign: _ucmp, utm_content: _ucnt, utm_term: _utm,
       // Marketplace flow extras — validated against the campaign config below
       // (never free text into sourceMetadata). NOTE: a caller-supplied
       // sourceMetadata object itself is preserved for internal callers (the
-      // public route strips it via Joi stripUnknown), but its `marketplace`
-      // subkey is server-built ONLY — scrubbed below before the validated
-      // values are written, so it can never be forged through the body.
+      // public route strips it via Joi stripUnknown), but its `marketplace`,
+      // `profileAnswers`, and `customAnswers` subkeys are server-built ONLY —
+      // scrubbed below before the validated values are written, so none can
+      // be forged through the body or an internal caller.
       marketplace: marketplaceRaw,
       ...bodyWithoutMeta
     } = safeBody;
     const incoming = { ...bodyWithoutMeta };
     if (incoming.sourceMetadata && typeof incoming.sourceMetadata === 'object') {
-      const { marketplace: _forgedMk, ...restSm } = incoming.sourceMetadata;
+      const {
+        marketplace: _forgedMk,
+        profileAnswers: _forgedPa,
+        customAnswers: _forgedCa,
+        ...restSm
+      } = incoming.sourceMetadata;
       incoming.sourceMetadata = restSm;
     }
 

--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -57,6 +57,8 @@ export const LIMITS = {
   drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
   // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
   submitFontSizeMin: 12, submitFontSizeMax: 24,
+  // Custom profile questions (profileQuestions.custom — studio-custom-questions §2)
+  cqPrompt: 140, cqOption: 48,
 };
 
 /**
@@ -247,6 +249,35 @@ export const V1_CONSUMED_KEYS = [
 
 /** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
 export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai', 'profileQuestions'];
+
+// ─────────── custom profile questions (studio-custom-questions §2) ───────────
+
+/** Owner-authored questions in the profileQuestions block. The library cap
+ * (MAX_PROFILE_QUESTIONS, profileQuestionLibrary.js) keeps its meaning — these
+ * bound the NEW `custom[]` defs and the combined `questionIds` membership.
+ * Custom answers are DISPLAY-ONLY (frozen onto sourceMetadata.customAnswers);
+ * they never mint consumer-observation facts. */
+export const MAX_CUSTOM_QUESTIONS = 5;
+export const MAX_TOTAL_PROFILE_QUESTIONS = 10;
+export const MAX_CUSTOM_OPTIONS = 8; // aligned with the capture Joi array bound
+export const CUSTOM_QUESTION_ID_RE = /^c_[a-z0-9]{4,12}$/;
+export const CUSTOM_OPTION_ID_RE = /^[a-z0-9_]{1,24}$/;
+export const CUSTOM_ANSWER_TEXT_MAX = 200;
+
+/** Shared sanitizer for owner-authored question copy AND customer free-text
+ * answers: strip C0/C1 controls + bidi overrides, trim, cap. The clamp's
+ * cleanString only slices — question copy renders on redeem.sg and in admin,
+ * so control/bidi stripping is non-negotiable. The Studio's completeness
+ * check MUST use this exact function (a value this sanitizer empties can
+ * never commit, then vanish in the clamp — studio-custom-questions §4). */
+export function sanitizeQuestionText(v, max) {
+  if (typeof v !== 'string') return '';
+  // eslint-disable-next-line no-control-regex
+  const stripped = v.replace(/[\u0000-\u001F\u007F-\u009F\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, '');
+  const trimmed = stripped.trim();
+  if (typeof max === 'number' && max >= 0 && trimmed.length > max) return trimmed.slice(0, max).trimEnd();
+  return trimmed;
+}
 
 // ───────────────────────── helpers (dependency-free) ─────────────────────────
 

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -26,16 +26,22 @@
 
 import {
   classifyDesignConfigVersion,
+  CUSTOM_OPTION_ID_RE,
+  CUSTOM_QUESTION_ID_RE,
   defaultFields,
   FIELD_IDS,
   FONT_IDS,
   LIMITS,
   LOCKED_FIELD_IDS,
   MARKETPLACE_V1_TO_V2,
+  MAX_CUSTOM_OPTIONS,
+  MAX_CUSTOM_QUESTIONS,
+  MAX_TOTAL_PROFILE_QUESTIONS,
   QR_V1_TO_V2,
   marketplaceToV1,
   PRESET_IDS,
   readLegacyView,
+  sanitizeQuestionText,
   TEMPLATE_REGISTRY,
   THEME_BACKGROUNDS,
   THEME_PRESETS,
@@ -58,21 +64,76 @@ import { PROFILE_QUESTION_IDS, MAX_PROFILE_QUESTIONS } from './profileQuestionLi
  * profileQuestions is a V2_TOP_KEY, so the unknown-passthrough below can
  * never overwrite this sanitized value with raw input (Codex PR0 R1 #7).
  */
+/**
+ * §3 step 1 (studio-custom-questions): validity-sanitize custom[] WITHOUT a
+ * count cap — membership caps in the questionIds pass, so an unreferenced
+ * def can never consume the cap ahead of a referenced one (Codex R2 #3).
+ * Returns a Map id → sanitized def.
+ */
+function sanitizeCustomQuestionDefs(raw) {
+  const defs = new Map();
+  for (const row of Array.isArray(raw) ? raw : []) {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) continue;
+    const id = row.id;
+    if (typeof id !== 'string' || !CUSTOM_QUESTION_ID_RE.test(id)) continue;
+    if (defs.has(id) || PROFILE_QUESTION_IDS.includes(id)) continue; // the c_ prefix already precludes library collisions; checked anyway
+    const type = row.type === 'single' || row.type === 'multi' || row.type === 'text' ? row.type : null;
+    if (!type) continue;
+    const prompt = sanitizeQuestionText(row.prompt, LIMITS.cqPrompt);
+    if (!prompt) continue;
+    const promptZh = sanitizeQuestionText(row.promptZh, LIMITS.cqPrompt);
+    const options = [];
+    if (type !== 'text') {
+      const seenOpt = new Set();
+      for (const opt of Array.isArray(row.options) ? row.options : []) {
+        if (!opt || typeof opt !== 'object' || Array.isArray(opt)) continue;
+        if (typeof opt.id !== 'string' || !CUSTOM_OPTION_ID_RE.test(opt.id) || seenOpt.has(opt.id)) continue;
+        const label = sanitizeQuestionText(opt.label, LIMITS.cqOption);
+        if (!label) continue;
+        seenOpt.add(opt.id);
+        const labelZh = sanitizeQuestionText(opt.labelZh, LIMITS.cqOption);
+        options.push({ id: opt.id, label, ...(labelZh ? { labelZh } : {}) });
+        if (options.length >= MAX_CUSTOM_OPTIONS) break;
+      }
+      if (options.length < 2) continue; // a select question needs a real choice
+    }
+    defs.set(id, { id, type, prompt, ...(promptZh ? { promptZh } : {}), options });
+  }
+  return defs;
+}
+
 function clampProfileQuestions(raw) {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     return { enabled: false, questionIds: [], requiredIds: [], showZh: true };
   }
+  const customDefs = sanitizeCustomQuestionDefs(raw.custom);
   const seen = new Set();
   const questionIds = [];
+  let libraryCount = 0;
+  let customCount = 0;
   for (const id of Array.isArray(raw.questionIds) ? raw.questionIds : []) {
-    if (typeof id !== 'string' || seen.has(id) || !PROFILE_QUESTION_IDS.includes(id)) continue;
+    if (typeof id !== 'string' || seen.has(id)) continue;
+    if (PROFILE_QUESTION_IDS.includes(id)) {
+      if (libraryCount >= MAX_PROFILE_QUESTIONS) continue;
+      libraryCount += 1;
+    } else if (customDefs.has(id)) {
+      if (customCount >= MAX_CUSTOM_QUESTIONS) continue;
+      customCount += 1;
+    } else {
+      continue;
+    }
     seen.add(id);
     questionIds.push(id);
-    if (questionIds.length >= MAX_PROFILE_QUESTIONS) break;
+    if (questionIds.length >= MAX_TOTAL_PROFILE_QUESTIONS) break;
   }
+  // §3 step 3: store only defs REFERENCED by the final membership, in their
+  // original array order — no server-side drafts, and `custom` is omitted
+  // entirely when empty so existing docs round-trip byte-identically.
+  const custom = [...customDefs.values()].filter((d) => seen.has(d.id));
   // requiredIds ⊆ questionIds (a question can't be required if it isn't
   // asked); showZh defaults ON (hide the inline Chinese only on explicit
-  // false) — owner controls added 2026-07-26.
+  // false) — owner controls added 2026-07-26. Custom ids participate in both
+  // mechanisms (studio-custom-questions §2).
   const requiredIds = [...new Set(Array.isArray(raw.requiredIds) ? raw.requiredIds : [])]
     .filter((id) => questionIds.includes(id));
   return {
@@ -80,6 +141,7 @@ function clampProfileQuestions(raw) {
     questionIds,
     requiredIds,
     showZh: raw.showZh !== false,
+    ...(custom.length ? { custom } : {}),
   };
 }
 

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -121,6 +121,23 @@ function buildPublicDesignConfigV2(dc) {
       requiredIds: Array.isArray(pq.requiredIds) ? [...pq.requiredIds] : [],
       showZh: pq.showZh !== false,
     };
+    // Custom question defs — leaf-picked to EXACTLY the funnel's render shape
+    // and re-filtered to membership (the clamp already guarantees defs ⊆
+    // questionIds; defensive here, like everything in this builder) —
+    // studio-custom-questions §3.
+    const custom = (Array.isArray(pq.custom) ? pq.custom : [])
+      .filter((q) => q && typeof q === 'object' && typeof q.id === 'string'
+        && pq.questionIds.includes(q.id))
+      .map((q) => ({
+        id: q.id,
+        type: q.type,
+        prompt: q.prompt,
+        ...(q.promptZh ? { promptZh: q.promptZh } : {}),
+        options: (Array.isArray(q.options) ? q.options : [])
+          .filter((o) => o && typeof o === 'object')
+          .map((o) => ({ id: o.id, label: o.label, ...(o.labelZh ? { labelZh: o.labelZh } : {}) })),
+      }));
+    if (custom.length) out.profileQuestions.custom = custom;
   }
   // media WITHOUT the internal legacy shadow (v1-URL bookkeeping for downgrade).
   const media = pick(dc.content?.media, ['kind', 'src', 'alt']);

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -487,3 +487,146 @@ describe('the band reaches the Buy score (score/v3 — PR B seam)', () => {
     expect(profile.consumerScore).toBe(leadResult.score)
   })
 })
+
+describe('custom questions (studio-custom-questions §6–§7) — display-only answers', () => {
+  let cqCampaign
+  const V2_CQ = {
+    version: 2,
+    template: { id: 'express' },
+    profileQuestions: {
+      enabled: true,
+      questionIds: ['language', 'c_showrm', 'c_hobby1', 'c_notes1'],
+      requiredIds: [],
+      custom: [
+        { id: 'c_showrm', type: 'single', prompt: 'Which showroom is closer?', options: [{ id: 'o1', label: 'Jurong' }, { id: 'o2', label: 'Tampines' }] },
+        { id: 'c_hobby1', type: 'multi', prompt: 'What do you enjoy?', options: [{ id: 'o1', label: 'Golf' }, { id: 'o2', label: 'Travel' }, { id: 'o3', label: 'Food' }] },
+        { id: 'c_notes1', type: 'text', prompt: 'Anything else?' },
+      ],
+    },
+  }
+
+  beforeAll(async () => {
+    cqCampaign = await createTestCampaign(admin.id, {
+      name: `CQ IT ${Date.now()}`,
+      design_config: V2_CQ,
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.ENRICHMENT_MAP_ARTIFACT_JOBS
+  })
+
+  it('accepts custom answers → frozen {qid, prompt, values} in questionIds order; library rides beside; ZERO observations minted from custom', async () => {
+    process.env.ENRICHMENT_MAP_ARTIFACT_JOBS = 'true'
+    const prospect = await capture({
+      campaignId: cqCampaign.id,
+      profileAnswers: {
+        language: 'zh',
+        c_showrm: 'o2',
+        c_hobby1: ['o3', 'o1'], // frozen in the DEF's option order, not submission order
+        c_notes1: '  Call after 6pm <b>pls</b>  ',
+      },
+    })
+    expect(prospect.sourceMetadata.profileAnswers).toEqual({ language: 'zh' })
+    expect(prospect.sourceMetadata.customAnswers).toEqual([
+      { qid: 'c_showrm', prompt: 'Which showroom is closer?', values: ['Tampines'] },
+      { qid: 'c_hobby1', prompt: 'What do you enjoy?', values: ['Golf', 'Food'] },
+      // Customer text: trimmed, stored as DATA (markup renders as literal text in admin)
+      { qid: 'c_notes1', prompt: 'Anything else?', values: ['Call after 6pm <b>pls</b>'] },
+    ])
+
+    // The fact ledger sees ONLY the library answer — custom answers mint
+    // zero observations by construction.
+    await drainAndQuiesce(prospect.id)
+    const obs = await ConsumerObservation.findAll({
+      where: { sourceProspectId: prospect.id, sourceArtifactId: `profile:${prospect.id}`, supersededAt: null },
+    })
+    expect(obs.map((o) => o.key)).toEqual(['identity.preferred_language'])
+  })
+
+  it('guided-review-TYPE campaign rejects answers via direct POST even with a non-guided template id (the repaired gate)', async () => {
+    const gr = await createTestCampaign(admin.id, {
+      name: `CQ GR ${Date.now()}`,
+      type: 'guided_review',
+      design_config: V2_CQ, // template.id is 'express' — the old gate missed this
+    })
+    const p = await capture({
+      campaignId: gr.id,
+      profileAnswers: { language: 'zh', c_showrm: 'o1' },
+    })
+    expect(p.sourceMetadata?.profileAnswers).toBeUndefined()
+    expect(p.sourceMetadata?.customAnswers).toBeUndefined()
+  })
+
+  it('drop-not-fail per answer: unknown option + whitespace-only text dropped, sibling survives; STRUCTURAL abuse (dup array) still 400s at Joi', async () => {
+    const p1 = await capture({
+      campaignId: cqCampaign.id,
+      profileAnswers: { c_showrm: 'o9', c_notes1: '   ' },
+    })
+    expect(p1.sourceMetadata?.customAnswers).toBeUndefined()
+
+    const p2 = await capture({
+      campaignId: cqCampaign.id,
+      profileAnswers: { c_showrm: 'o9', c_notes1: 'second attempt' },
+    })
+    expect(p2.sourceMetadata.customAnswers).toEqual([
+      { qid: 'c_notes1', prompt: 'Anything else?', values: ['second attempt'] },
+    ])
+
+    // Duplicate ids in a multi array are STRUCTURAL abuse — Joi's .unique()
+    // rejects before semantics (parent §5.4 step 1: 400, never a silent drop).
+    phoneSeq += 1
+    const res = await request(app)
+      .post('/api/prospects')
+      .send({
+        firstName: 'Enrich', lastName: 'Case',
+        email: `enrich-${phoneSeq}@example.com`, phone: phoneFor(phoneSeq),
+        leadSource: 'website', campaignId: cqCampaign.id,
+        profileAnswers: { c_hobby1: ['o1', 'o1'] },
+      })
+    expect(res.status).toBe(400)
+  })
+
+  it('customAnswers cannot be forged — public route strips body sourceMetadata; internal callers get the scrub', async () => {
+    // Public route: Joi stripUnknown drops sourceMetadata wholesale.
+    const p1 = await capture({
+      campaignId: cqCampaign.id,
+      sourceMetadata: { customAnswers: [{ qid: 'x', prompt: 'Forged', values: ['x'] }] },
+    })
+    expect(p1.sourceMetadata?.customAnswers).toBeUndefined()
+
+    // Internal caller: sourceMetadata is preserved — but the customAnswers /
+    // profileAnswers subkeys are server-built ONLY and get scrubbed.
+    phoneSeq += 1
+    const service = makeProspectService()
+    const { prospect } = await service.createProspect({
+      firstName: 'Forge', lastName: 'Case',
+      email: `forge-${phoneSeq}@example.com`, phone: phoneFor(phoneSeq),
+      leadSource: 'website', campaignId: cqCampaign.id,
+      sourceMetadata: {
+        customAnswers: [{ qid: 'x', prompt: 'Forged', values: ['x'] }],
+        profileAnswers: { language: 'zh' },
+        keepMe: 'yes',
+      },
+    }, admin)
+    const p2 = await Prospect.findByPk(prospect.id)
+    expect(p2.sourceMetadata.customAnswers).toBeUndefined()
+    expect(p2.sourceMetadata.profileAnswers).toBeUndefined()
+    expect(p2.sourceMetadata.keepMe).toBe('yes')
+  })
+
+  it('erasure sheds customAnswers via the allowlist rebuild', async () => {
+    const prospect = await capture({
+      campaignId: cqCampaign.id,
+      profileAnswers: { c_notes1: 'my private note' },
+      utm_source: 'ig',
+    })
+    expect(prospect.sourceMetadata.customAnswers).toHaveLength(1)
+    const erasure = makeErasureService()
+    await erasure.eraseConsumer(prospect.consumerId, { reason: 'test' })
+    const scrubbed = await Prospect.findByPk(prospect.id)
+    expect(scrubbed.sourceMetadata.customAnswers).toBeUndefined()
+    expect(scrubbed.sourceMetadata.erased).toBe(true)
+    expect(scrubbed.sourceMetadata.utm).toEqual({ utm_source: 'ig' })
+  })
+})

--- a/backend/test/designConfigV2StudioClamp.test.js
+++ b/backend/test/designConfigV2StudioClamp.test.js
@@ -257,3 +257,91 @@ describe('featuredDrop.endsAt inherits luckyDraw.closesAt (PR-2, F9)', () => {
     expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
   });
 });
+
+describe('clampProfileQuestions — custom questions (studio-custom-questions §3)', () => {
+  const v2 = (pq) => ({
+    version: 2,
+    template: { id: 'express', params: {} },
+    theme: { preset: 'warm-cream' },
+    content: {},
+    form: {},
+    distribution: { host: 'redeem' },
+    profileQuestions: pq,
+  });
+  const clampPq = (pq) => clampDesignConfigV2(v2(pq), undefined, 'admin').profileQuestions;
+
+  it('sanitizes the full matrix: bad shapes/types/ids dropped, dup option ids dropped, labels/prompts trimmed, text rows lose options', () => {
+    const out = clampPq({
+      enabled: true,
+      questionIds: ['language', 'c_ok0001', 'c_txt001', 'c_badid', 'not_real'],
+      requiredIds: ['c_ok0001', 'c_ghost1'],
+      custom: [
+        { id: 'c_ok0001', type: 'single', prompt: '  Which?  ', options: [{ id: 'o1', label: ' A ' }, { id: 'o1', label: 'dup' }, { id: 'o2', label: 'B' }, { id: 'BAD ID', label: 'x' }] },
+        { id: 'c_txt001', type: 'text', prompt: 'Notes', options: [{ id: 'o1', label: 'stripped' }] },
+        { id: 'c_badid', type: 'single', prompt: 'x' }, // id fails the pattern? (c_badid matches — but no options → dropped)
+        { id: 'not-valid', type: 'single', prompt: 'x', options: [] },
+        { id: 'c_notype', type: 'wat', prompt: 'x', options: [] },
+        'garbage',
+      ],
+    });
+    expect(out.questionIds).toEqual(['language', 'c_ok0001', 'c_txt001']);
+    expect(out.requiredIds).toEqual(['c_ok0001']);
+    expect(out.custom).toEqual([
+      { id: 'c_ok0001', type: 'single', prompt: 'Which?', options: [{ id: 'o1', label: 'A' }, { id: 'o2', label: 'B' }] },
+      { id: 'c_txt001', type: 'text', prompt: 'Notes', options: [] },
+    ]);
+  });
+
+  it('cap ordering: 5 unreferenced defs never cost a referenced one; a 9th option is dropped; caps hold (5 custom / 10 total)', () => {
+    const unref = [1, 2, 3, 4, 5].map((n) => ({ id: `c_unref${n}`, type: 'text', prompt: `U${n}`, options: [] }));
+    const out = clampPq({
+      enabled: true,
+      questionIds: ['c_real01'],
+      requiredIds: [],
+      custom: [...unref, { id: 'c_real01', type: 'text', prompt: 'The real one', options: [] }],
+    });
+    expect(out.questionIds).toEqual(['c_real01']);
+    expect(out.custom.map((d) => d.id)).toEqual(['c_real01']);
+
+    const nineOptions = Array.from({ length: 9 }, (_, i) => ({ id: `o${i + 1}`, label: `L${i + 1}` }));
+    const capped = clampPq({
+      enabled: true,
+      questionIds: ['c_opts01'],
+      custom: [{ id: 'c_opts01', type: 'multi', prompt: 'Many?', options: nineOptions }],
+    });
+    expect(capped.custom[0].options).toHaveLength(8);
+
+    const six = [1, 2, 3, 4, 5, 6].map((n) => ({ id: `c_q${n}0000`, type: 'text', prompt: `Q${n}`, options: [] }));
+    const sixOut = clampPq({ enabled: true, questionIds: six.map((d) => d.id), custom: six });
+    expect(sixOut.questionIds).toHaveLength(5);
+    expect(sixOut.custom).toHaveLength(5);
+  });
+
+  it('a campaign with ONLY custom questions is fully valid; zero-valid disables; existing docs keep their exact key set', () => {
+    const onlyCustom = clampPq({
+      enabled: true,
+      questionIds: ['c_solo01'],
+      custom: [{ id: 'c_solo01', type: 'text', prompt: 'Solo', options: [] }],
+    });
+    expect(onlyCustom.enabled).toBe(true);
+
+    const zeroValid = clampPq({ enabled: true, questionIds: ['c_ghost1'], custom: [] });
+    expect(zeroValid.enabled).toBe(false);
+
+    // No custom input ⇒ no custom key — existing docs round-trip byte-stable.
+    const legacyShape = clampPq({ enabled: true, questionIds: ['language'], requiredIds: [] });
+    expect(Object.keys(legacyShape).sort()).toEqual(['enabled', 'questionIds', 'requiredIds', 'showZh']);
+  });
+
+  it('clamp is IDEMPOTENT over a custom-question doc (Studio adopts the clamped response — no phantom dirty)', () => {
+    const doc = v2({
+      enabled: true,
+      questionIds: ['language', 'c_ok0001'],
+      requiredIds: ['c_ok0001'],
+      custom: [{ id: 'c_ok0001', type: 'multi', prompt: 'Pick', promptZh: '选', options: [{ id: 'o1', label: 'A', labelZh: '甲' }, { id: 'o2', label: 'B' }] }],
+    });
+    const once = clampDesignConfigV2(doc, undefined, 'admin');
+    const twice = clampDesignConfigV2(once, undefined, 'admin');
+    expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+});

--- a/backend/test/publicDesignConfig.test.js
+++ b/backend/test/publicDesignConfig.test.js
@@ -240,3 +240,60 @@ describe('buildPublicDesignConfig — content.submitFontSize', () => {
     expect(out.content.submitFontSize).toBeUndefined();
   });
 });
+
+describe('profileQuestions.custom leaf-pick (studio-custom-questions §3)', () => {
+  const v2 = (pq) => ({
+    version: 2,
+    template: { id: 'express' },
+    theme: { preset: 'warm-cream' },
+    profileQuestions: pq,
+  });
+
+  test('projects EXACTLY {id,type,prompt,promptZh?,options[{id,label,labelZh?}]} — internal keys stripped', () => {
+    const out = buildPublicDesignConfig(v2({
+      enabled: true,
+      questionIds: ['language', 'c_abc123'],
+      requiredIds: ['c_abc123'],
+      custom: [{
+        id: 'c_abc123',
+        type: 'single',
+        prompt: 'Which outlet?',
+        promptZh: 'ZH',
+        internalNote: 'never ships',
+        options: [
+          { id: 'o1', label: 'East', labelZh: 'E', weight: 99 },
+          { id: 'o2', label: 'West' },
+        ],
+      }],
+    }));
+    expect(out.profileQuestions.custom).toEqual([{
+      id: 'c_abc123',
+      type: 'single',
+      prompt: 'Which outlet?',
+      promptZh: 'ZH',
+      options: [{ id: 'o1', label: 'East', labelZh: 'E' }, { id: 'o2', label: 'West' }],
+    }]);
+    expect(JSON.stringify(out)).not.toContain('internalNote');
+    expect(JSON.stringify(out)).not.toContain('weight');
+  });
+
+  test('defs not in questionIds are excluded (defensive re-filter); no custom key when none survive', () => {
+    const out = buildPublicDesignConfig(v2({
+      enabled: true,
+      questionIds: ['language'],
+      requiredIds: [],
+      custom: [{ id: 'c_ghost1', type: 'text', prompt: 'Unreferenced', options: [] }],
+    }));
+    expect(out.profileQuestions).toBeDefined();
+    expect(out.profileQuestions.custom).toBeUndefined();
+  });
+
+  test('disabled subtree stays absent from the anonymous payload (unchanged)', () => {
+    const out = buildPublicDesignConfig(v2({
+      enabled: false,
+      questionIds: ['c_abc123'],
+      custom: [{ id: 'c_abc123', type: 'text', prompt: 'X', options: [] }],
+    }));
+    expect(out.profileQuestions).toBeUndefined();
+  });
+});

--- a/backend/test/unit/customQuestionsScoring.test.js
+++ b/backend/test/unit/customQuestionsScoring.test.js
@@ -1,0 +1,134 @@
+import { makeScoringStage } from '../../src/services/prospectScoring.js';
+
+/**
+ * Custom questions — the SCORE-stage acceptance matrix
+ * (studio-custom-questions §6). Pure: no DB, no app. The DB-backed
+ * integration legs (persistence, observations-zero, erasure, scrub) live in
+ * test/consumerEnrichment.test.js.
+ */
+
+const logger = { warn: () => {}, error: () => {} };
+const scoreSubmission = makeScoringStage({ d: { logger } });
+
+const CUSTOM = [
+  { id: 'c_showrm', type: 'single', prompt: 'Which showroom is closer?', options: [{ id: 'o1', label: 'Jurong' }, { id: 'o2', label: 'Tampines' }] },
+  { id: 'c_hobby1', type: 'multi', prompt: 'What do you enjoy?', options: [{ id: 'o1', label: 'Golf' }, { id: 'o2', label: 'Travel' }, { id: 'o3', label: 'Food' }] },
+  { id: 'c_notes1', type: 'text', prompt: 'Anything else?' },
+];
+
+function campaignWith(pqOverrides = {}, campaignOverrides = {}) {
+  return {
+    type: 'lead_generation',
+    design_config: {
+      version: 2,
+      template: { id: 'express' },
+      profileQuestions: {
+        enabled: true,
+        questionIds: ['language', 'c_showrm', 'c_hobby1', 'c_notes1'],
+        requiredIds: [],
+        custom: CUSTOM,
+        ...pqOverrides,
+      },
+    },
+    ...campaignOverrides,
+  };
+}
+
+function run(profileAnswers, sourceCampaign = campaignWith()) {
+  return scoreSubmission({
+    quizSubmission: null,
+    safeBody: { profileAnswers },
+    sourceCampaign,
+    campaignId: 'test-campaign',
+  });
+}
+
+describe('custom-question acceptance (scoreSubmission)', () => {
+  it('freezes prompt + labels in questionIds/def-option order; text trimmed; library facts ride beside', () => {
+    const { sourceMetadataPatch, acceptedProfileFacts } = run({
+      language: 'zh',
+      c_showrm: 'o2',
+      c_hobby1: ['o3', 'o1'],
+      c_notes1: '  Call after 6pm  ',
+    });
+    expect(sourceMetadataPatch.profileAnswers).toEqual({ language: 'zh' });
+    expect(sourceMetadataPatch.customAnswers).toEqual([
+      { qid: 'c_showrm', prompt: 'Which showroom is closer?', values: ['Tampines'] },
+      { qid: 'c_hobby1', prompt: 'What do you enjoy?', values: ['Golf', 'Food'] },
+      { qid: 'c_notes1', prompt: 'Anything else?', values: ['Call after 6pm'] },
+    ]);
+    // Custom answers NEVER mint facts — only the library answer does.
+    expect(acceptedProfileFacts.map((f) => f.key)).toEqual(['identity.preferred_language']);
+  });
+
+  it('drop-not-fail per answer: unknown option / non-subset multi / dup multi / wrong shapes', () => {
+    const { sourceMetadataPatch } = run({
+      c_showrm: 'o9', // unknown option id
+      c_hobby1: ['o1', 'o1'], // dup
+      c_notes1: ['not', 'a', 'string'], // wrong shape for text
+    });
+    expect(sourceMetadataPatch.customAnswers).toBeUndefined();
+
+    const ok = run({ c_showrm: ['o1'], c_hobby1: 'o1', c_notes1: 'fine' });
+    // single given an array + multi given a string are both dropped; text survives
+    expect(ok.sourceMetadataPatch.customAnswers).toEqual([
+      { qid: 'c_notes1', prompt: 'Anything else?', values: ['fine'] },
+    ]);
+  });
+
+  it('whitespace-only and control-char-only text answers are skipped, not stored', () => {
+    expect(run({ c_notes1: '   ' }).sourceMetadataPatch.customAnswers).toBeUndefined();
+    expect(run({ c_notes1: '\u200E\u202E' }).sourceMetadataPatch.customAnswers).toBeUndefined();
+  });
+
+  it('text answers are sanitized (control chars stripped, 200-char cap) before freezing', () => {
+    const { sourceMetadataPatch } = run({ c_notes1: `AB\u202E\u0007${'x'.repeat(400)}` });
+    const [answer] = sourceMetadataPatch.customAnswers;
+    expect(answer.values[0].startsWith('ABx')).toBe(true);
+    // eslint-disable-next-line no-control-regex
+    expect(answer.values[0]).not.toMatch(/[\u0000-\u001F\u202A-\u202E]/);
+    expect(answer.values[0].length).toBeLessThanOrEqual(200);
+  });
+
+  it('hostile direct-DB defs: prompts/labels are re-sanitized at freeze; empty-after-sanitize prompt skips the def', () => {
+    const campaign = campaignWith({
+      questionIds: ['c_evil01', 'c_blank1'],
+      custom: [
+        { id: 'c_evil01', type: 'single', prompt: '\u202EEvil prompt', options: [{ id: 'o1', label: 'Jurong\u202E' }, { id: 'o2', label: 'B' }] },
+        { id: 'c_blank1', type: 'text', prompt: '\u202E' },
+      ],
+    });
+    const { sourceMetadataPatch } = run({ c_evil01: 'o1', c_blank1: 'hello' }, campaign);
+    expect(sourceMetadataPatch.customAnswers).toEqual([
+      { qid: 'c_evil01', prompt: 'Evil prompt', values: ['Jurong'] },
+    ]);
+  });
+
+  it('the repaired gate: guided-review TYPE rejects even with a non-guided template id; template.id leg still holds', () => {
+    const byType = run({ c_notes1: 'hi' }, campaignWith({}, { type: 'guided_review' }));
+    expect(byType.sourceMetadataPatch.customAnswers).toBeUndefined();
+    expect(byType.sourceMetadataPatch.profileAnswers).toBeUndefined();
+
+    const byTemplate = run({ c_notes1: 'hi' }, (() => {
+      const c = campaignWith();
+      c.design_config.template.id = 'guided_review';
+      return c;
+    })());
+    expect(byTemplate.sourceMetadataPatch.customAnswers).toBeUndefined();
+  });
+
+  it('answers for ids not in questionIds are ignored even when a def exists (membership is the authority)', () => {
+    const campaign = campaignWith({ questionIds: ['c_showrm'] }); // hobby/notes defs exist but unasked
+    const { sourceMetadataPatch } = run({ c_showrm: 'o1', c_hobby1: ['o1'], c_notes1: 'hi' }, campaign);
+    expect(sourceMetadataPatch.customAnswers).toEqual([
+      { qid: 'c_showrm', prompt: 'Which showroom is closer?', values: ['Jurong'] },
+    ]);
+  });
+
+  it('disabled subtree / legacy config ignores everything (unchanged eligibility)', () => {
+    expect(run({ c_notes1: 'hi' }, campaignWith({ enabled: false })).sourceMetadataPatch.customAnswers)
+      .toBeUndefined();
+    expect(run({ c_notes1: 'hi' }, { type: 'lead_generation', design_config: {} }).sourceMetadataPatch.customAnswers)
+      .toBeUndefined();
+  });
+});

--- a/docs/plans/studio-custom-questions.md
+++ b/docs/plans/studio-custom-questions.md
@@ -1,0 +1,584 @@
+# Studio custom questions — owner-authored questions in the profile block
+
+**Status:** v5 — **APPROVED, Codex round 5 (gpt-5.6-sol xhigh,
+2026-08-18)** ("the explicit-snapshot design closes the sole Round 4
+defect… internally consistent and implementable as written"). Convergence
+16 → 10 → 3 → 1 → APPROVE; logs §11–§13; load-bearing claims re-verified
+in code every round (zero Codex claims refuted across all five).
+**READY TO BUILD** pending Shawn's §10 calls (free-text in v1; caps;
+agent-visibility follow-up; CSV; marketplace door).
+**Author:** Claude, 2026-08-18
+**Parent:** `docs/plans/studio-profile-questions.md` (the PR 0 collection
+block — LIVE; this plan extends its subtree and reuses its §5.4 wire
+contract where stated)
+
+## 1. Why and what
+
+The profile-questions block is pick-only: a fixed 5-question library,
+"admins pick, never author" (`profileQuestionLibrary.js` header). That rule
+exists to protect the **deterministic fact ledger** — free-authored
+questions can't map to taxonomy keys. It was never a rule about display.
+
+Shawn wants campaign-specific questions at the bottom of the signup form,
+right before submit ("which showroom is closer to you?"-class intel). This
+plan adds **`profileQuestions.custom[]`** — owner-authored questions that
+render in the SAME block (after the library questions, before consent/CTA,
+i.e. exactly the requested position) and whose answers are
+**display-only**:
+
+- frozen onto the prospect (`sourceMetadata.customAnswers`),
+- shown on the admin Lead Profile,
+- carried in webhook payloads (already true for all of `sourceMetadata`,
+  §7),
+- and **NEVER** entering the consumer-observation ledger, taxonomy, map
+  jobs, or Meet×Buy scoring. The library keeps that job exclusively. The
+  library-header rule is preserved as: *custom answers never mint facts.*
+
+Product rules carried over: per-campaign selection is the owner's
+conversion-vs-data call; the AI flows never AUTHOR or ENABLE profile
+questions — and §5b now also makes look apply/revert carry the live
+subtree forward so an AI interaction can never destroy question edits.
+
+**Scope boundary (R1 #1):** the marketplace door
+(`MarketplaceFlow.jsx`) has NEVER asked profile questions — it runs its
+own step machine with fixed fields and posts no `profileAnswers`, and its
+public config is rebuilt from the v1-downgraded view
+(`marketplaceService.js` `buildPublicDesignConfig`), which excludes
+`profileQuestions` (a `V2_TOP_KEY` skipped by `toLegacy`'s passthrough).
+Custom questions keep that exact parity: marketplace-door leads simply
+carry no `customAnswers`, the same way they carry no library answers
+today. Extending the marketplace flow is a possible later arc (§10), not
+this PR — and a parity test pins it.
+
+## 2. Config shape — the `profileQuestions` subtree grows one key
+
+```
+profileQuestions: {
+  enabled: boolean,            // unchanged
+  questionIds: string[],       // THE single order+membership authority — library ∪ custom ids
+  requiredIds: string[],       // unchanged mechanism — ⊆ questionIds, custom ids allowed
+  showZh: boolean,             // unchanged — governs custom promptZh/labelZh too
+  custom: [                    // NEW: definitions ONLY (unordered set, unique ids)
+    {
+      id: 'c_<rand>',          // /^c_[a-z0-9]{4,12}$/ — prefix-disjoint from every
+                               // library id AND matches the §6 Joi key pattern
+      type: 'single' | 'multi' | 'text',
+      prompt: string,          // ≤ 140, non-empty after sanitize
+      promptZh?: string,       // ≤ 140, optional
+      options: [               // select types: 2–MAX_CUSTOM_OPTIONS valid rows;
+                               // type 'text': forced []
+        { id: string,          // /^[a-z0-9_]{1,24}$/, UNIQUE within the question
+          label: string,       // ≤ 48, non-empty after sanitize (else row dropped)
+          labelZh?: string },  // ≤ 48, optional
+      ],
+    },
+  ],
+}
+```
+
+**One ordering authority (R1 #3).** `questionIds` stays what every
+consumer already treats it as — ordered membership (clamp preserves input
+order; public projection copies it; the renderer and `scoreSubmission`
+iterate it). `custom[]` holds definitions only; it carries NO ordering
+semantics. There are no server-side drafts: the clamp keeps only defs
+referenced by the final `questionIds` (§3 — ordered so an unreferenced
+def can never cost a referenced one, R2 closure #3), and the panel never
+writes one (§4). Freeze order (§6), render order (§5), and panel order
+(§4) are all reads of `questionIds`.
+
+Caps and patterns are named constants in the **designConfigV2 twins**
+(`src/lib/designConfigV2.js` ↔ `backend/src/utils/designConfigV2.js`):
+`MAX_CUSTOM_QUESTIONS = 5`, `MAX_TOTAL_PROFILE_QUESTIONS = 10`,
+`MAX_CUSTOM_OPTIONS = 8` (R2 new #3 — aligned with the existing Joi
+array bound `.max(8)`), `CUSTOM_QUESTION_ID_RE`, `CUSTOM_OPTION_ID_RE`,
+the length caps, `CUSTOM_ANSWER_TEXT_MAX = 200`, and a shared
+**`sanitizeQuestionText(v, max)`** (trim + strip C0/C1 control chars and
+bidi-override codepoints + length cap — the clamp's existing
+`cleanString` only slices, R1 #15).
+`MAX_PROFILE_QUESTIONS` (5) keeps its current meaning: the library cap.
+
+**Twin discipline, stated precisely (R1 #11, R2 closure #11):** the
+designConfigV2 twins are NOT byte-parity files — they are kept in
+lockstep by `designConfigV2.lockstep.test.js`: new **constants/regex
+sources** join `CONSTANT_EXPORTS` (structural equality);
+`sanitizeQuestionText` is a FUNCTION and joins **`FUNCTION_EXPORTS`**
+(the suite's existing function-parity mechanism) with behavioral parity
+fixtures (same hostile inputs → same outputs on both imports). Byte
+identity applies to `profileQuestionLibrary` only. `V2_TOP_KEYS` is
+unchanged (`custom` is nested), so upgrade-preservation carries the
+subtree; the lockstep/upgrade fixtures gain a `custom` doc to prove it.
+
+## 3. Three config surfaces, in lockstep (mirrors parent §3)
+
+1. **Twins:** constants + `sanitizeQuestionText` above; no new top-level
+   key.
+2. **Clamp** (`designConfigV2Clamp.js` `clampProfileQuestions`), extended
+   in this order, sanitize-never-reject — **ordered so referenced defs
+   can never lose the cap to unreferenced ones (R2 closure #3):**
+   1. **Validity-sanitize `custom[]` WITHOUT a count cap:** non-object
+      rows dropped; id must match `CUSTOM_QUESTION_ID_RE`, be unique
+      among custom ids, and not equal any library id (the `c_` prefix
+      guarantees this; the clamp checks anyway); `type` outside the enum
+      ⇒ row dropped; `prompt` empty after `sanitizeQuestionText` ⇒ row
+      dropped; option rows sanitized (id pattern + uniqueness within the
+      question, label non-empty after sanitize — invalid rows dropped),
+      then capped at `MAX_CUSTOM_OPTIONS` (surviving rows beyond 8
+      dropped, R2 new #3); select types with < 2 surviving options ⇒ row
+      dropped; `text` rows get `options` forced to `[]`. Result: a
+      validity map, NOT yet the stored array.
+   2. **Build `questionIds`:** iterate the raw ids; keep library ids and
+      custom ids present in the validity map; custom acceptances capped
+      at `MAX_CUSTOM_QUESTIONS` during selection; order preserved,
+      deduped, total capped at `MAX_TOTAL_PROFILE_QUESTIONS`.
+   3. **Store `custom` = validity-map defs referenced by the final
+      `questionIds`**, in their original array order. Unreferenced defs
+      are dropped (no server-side drafts) and — by construction — never
+      consumed the cap.
+   4. `requiredIds ⊆ questionIds` (unchanged rule, now admits custom
+      ids).
+   5. `enabled` requires ≥ 1 valid id in `questionIds` (unchanged — a
+      campaign with only custom questions is fully valid).
+3. **Public projection** (`publicDesignConfig.js`): the existing
+   `profileQuestions` leaf-pick gains `custom`, leaf-picked to exactly
+   `{id, type, prompt, promptZh?, options: [{id, label, labelZh?}]}` —
+   nothing else. Membership is already guaranteed by the clamp (defs ⊆
+   questionIds), and the projection re-filters defensively. Disabled ⇒
+   absent ⇒ funnel renders nothing (unchanged).
+
+## 4. Studio FormPanel — the authoring card
+
+**One mutation door (R1 #2), with a real contract (R2 new #4).** Today's
+FormPanel mutation sites each rebuild the subtree lossily — the master
+toggle writes only `{enabled, questionIds}` (dropping
+`requiredIds`/`showZh`, a pre-existing loss this plan fixes), and the
+brief-suggestion add, library ticks, and required toggles rebuild ids
+from `PROFILE_QUESTION_IDS` alone (`FormPanel.jsx:216/:44/:275/:293`) —
+any of which would silently delete `custom`. Fix: a single
+`mutatePQ(mut, fn)` helper owning the subtree write, defined as an
+**atomic transformation inside one `mut((d) => …)` draft** (never spread
+across renders or stale closures):
+
+- **Decompose** the draft's current subtree into `{enabled,
+  libraryPicks, defsById, customOrder, requiredIds, showZh}` —
+  reconciling on read: `customOrder` deduped and intersected with
+  `defsById` keys; defs never in `customOrder` appended at the end (a
+  hand-edited doc must not lose data on first touch).
+- Apply `fn` to that normalized value.
+- **Reconstruct and write**: `questionIds = [library picks in canonical
+  library order, …customOrder]`; `custom` emitted ONLY for ids in
+  `customOrder`, in that order; `requiredIds` filtered to membership;
+  `showZh`/`enabled` carried. Idempotent: `mutatePQ(mut, x => x)` is a
+  no-op on already-normalized state.
+- EVERY mutation site (master toggle, brief-suggestion add, library
+  tick, required toggles, all custom authoring) is rewritten through it;
+  tests cover per-site preservation, mismatched
+  `custom`-vs-`questionIds` input, and back-to-back mutations.
+
+**Editor-local drafts with a durable owner (R1 #4, R2 new #1).** The
+clamp drops incomplete rows and Studio adopts the clamped save response
+(`useStudioDoc.js:173`), so a half-typed question written to the doc
+would vanish on Save — drafts therefore never touch the doc. And because
+the rail unmounts non-active panels (`AdminCampaignStudio.jsx` renders
+one panel at a time) and the dirty guard watches only doc + slug,
+component-local state would silently die on a rail switch. Contract:
+
+- Draft state (at most ONE open draft) lives in the **Studio page**
+  beside the doc, keyed by campaign id, passed into FormPanel — it
+  survives rail switches and save-response adoption (it is not part of
+  the doc).
+- `draftDirty` joins the existing dirty computation, so navigation/
+  campaign-switch guards fire for an uncommitted draft too — **including
+  the guard's "Save & continue" primary action (R3 residual):** that
+  branch saves the doc and then executes the parked navigation, and a
+  draft lives OUTSIDE the doc, so without special handling "Save" would
+  still destroy it. Contract: when `draftDirty`, Save-and-continue first
+  COMMITS a complete draft and then saves; if the draft is incomplete,
+  that path is blocked (button disabled with an inline reason) until the
+  user completes it or explicitly chooses Discard.
+  **Commit-then-save must be snapshot-explicit (R4):** `mut()` schedules
+  `setDoc` while `save()` PUTs the doc captured by the CURRENT render
+  (`useStudioDoc.js` — `const snapshot = doc`), so "mutatePQ then
+  save()" would PUT the pre-commit doc and navigate, losing the question
+  anyway. Fix: `save(extra, { snapshot })` gains an optional explicit
+  doc snapshot (precedent: `extra` already merges the guard's pending
+  slug draft into the same PUT). The guard handler computes the
+  post-commit doc SYNCHRONOUSLY (pure `mutatePQ` transform of the
+  current doc), passes the SAME object reference to `setDoc` (no clone)
+  and to `save` as the snapshot — so the PUT body is the committed doc
+  by construction and the existing in-flight-edit adoption comparison
+  (`prev === snapshot`) still holds. Both guard buttons are tested with
+  complete and incomplete drafts, and the Save-and-continue test asserts
+  the `Campaign.update` payload contains the new def + question id
+  BEFORE the parked navigation runs.
+- *Add question* is disabled while a draft is open (one at a time) AND
+  at the cap — `customOrder.length >= MAX_CUSTOM_QUESTIONS` (R3 new #1:
+  a hint alone lets a sixth question be authored and then silently
+  clamped away on save); commit re-checks the cap as the belt. Test: a
+  sixth question can never enter the doc.
+- **Completeness uses the server's own sanitizer (R2 closure #4):** the
+  draft commits only when `sanitizeQuestionText(prompt)` is non-empty
+  and (select types) ≥ 2 options have non-empty sanitized labels — and
+  the commit writes the SANITIZED values, so panel-authored content is
+  clamp-stable by construction (a control-char-only prompt can never
+  commit, then vanish).
+- Commit writes the def AND appends its id to `questionIds` atomically
+  (one `mutatePQ` call). Editing an existing question writes through
+  ONLY while it remains complete; an incomplete edit state stays local
+  with an inline "incomplete — not saved" badge and the last complete
+  value stays in the doc.
+- Tests: rail switch away/back keeps the draft; save-response adoption
+  keeps it; campaign switch guards it; second Add disabled; incomplete
+  edit never reaches the doc.
+
+Panel specifics, inside the existing PROFILE QUESTIONS `PanelSection`,
+visible when `enabled === true`, below the library tick-list:
+
+- Per-question editor: prompt, optional 中文 prompt, type select, options
+  editor (add/remove/edit; ids auto-allocated as the first unused `oN`;
+  *Add option* disabled at `MAX_CUSTOM_OPTIONS`), a **Required** toggle
+  writing the shared `requiredIds`, delete, and **↑/↓ reorder** (moves
+  the id within the custom segment of `questionIds`, reusing the
+  FIELDS-list arrow affordance).
+- **Membership model:** an authored custom question is always asked —
+  commit adds its id to `questionIds`; delete removes the def and its id
+  from `questionIds` + `requiredIds`. No tick state for custom; the
+  library keeps its tick model.
+- **Placement:** the panel writes library picks first (canonical order,
+  as today), custom ids after — so custom questions render at the BOTTOM
+  of the block, immediately before consent + submit, and ↑/↓ arranges
+  them among themselves. (Direct-JSON interleaving is tolerated by the
+  clamp — order is honored verbatim; the panel just never produces it.)
+- `genId()`: `'c_' + <random base36, 6 chars>`, regenerated on collision
+  with any existing id — matches `CUSTOM_QUESTION_ID_RE` and the §6 Joi
+  key pattern by construction.
+- Click-to-edit: the existing `'profileQuestions'` target
+  (`studioEditTargets.js:46`, section `form`) already lands on this card —
+  no new target.
+
+## 5. Funnel rendering (owners per parent §6)
+
+- **`funnelAdapter.js`**: the `profileQuestions` prop it builds gains
+  `custom: doc.profileQuestions.custom` (already leaf-picked upstream).
+  This door serves the standard lead-capture funnel; the marketplace door
+  is out of scope by §1.
+- **`CampaignSignupForm.jsx`** — one normalized resolver (R1 #5): library
+  defs expose `multi: boolean` while custom defs expose `type`; the
+  existing render loop and required-submit gate both branch on `q.multi`
+  (`CampaignSignupForm.jsx:986/:318`), and the gate resolves from the
+  library only — a required custom id would be silently skipped today.
+  Fix: `resolveQuestion(qid, custom) → { id, kind: 'single'|'multi'|'text',
+  prompt, promptZh, options, isCustom }` normalizing BOTH shapes, used by
+  the render loop AND the gate, plus a shared type-aware
+  `isAnswered(q, value)` (text: non-empty after trim — whitespace-only
+  never satisfies a required question; single: non-empty string; multi:
+  non-empty array).
+- Rendering: `single`/`multi` reuse the existing chip UI verbatim (an
+  options list already capped at 8 by the clamp bounds selectable values
+  at 8 — consistent with Joi's array `.max(8)`); `text` renders a
+  bounded single-line input (`maxLength = CUSTOM_ANSWER_TEXT_MAX`),
+  theme-token styled like the core fields. `showZh` governs custom
+  `promptZh`/`labelZh` exactly like library copy. Long-content safety
+  (R1 #16): the chip row and prompt get an explicit `overflow-wrap:
+  anywhere` + `max-width: 100%` constraint so a 48-char unbroken label
+  or 140-char prompt cannot overflow 390×844. `data-se` markers per
+  custom question for tests.
+- Answer state joins the existing `profileAnswers` map:
+  `{ [qid]: optionId | optionId[] | string }` — the server distinguishes
+  text by the campaign's def, never by shape-sniffing.
+- **`LeadCapture.jsx`** payload construction is UNCHANGED — custom
+  answers ride the existing `profileAnswers` field.
+
+## 5b. Studio AI interaction — looks must not eat question edits (R2 new #2)
+
+`useStudioAi` swaps the WHOLE doc on both look application (`pickLook`
+builds from the pick-time `prev.doc` on re-picks) and revert
+(`revertLook` does `replaceDoc(p.prev.doc)`), so a custom-question edit
+made while a proposal is active would be destroyed — contradicting the
+"AI never touches profileQuestions" contract. Fix: **every doc
+replacement inside `useStudioAi` grafts the LIVE doc's
+`profileQuestions` subtree over the replacement** (pick, re-pick, and
+revert alike — the subtree is never the AI's to change in either
+direction). Tests: edit-after-pick → revert keeps the edit;
+edit-after-pick → re-pick keeps the edit; Fill-everything/apply/revert
+leaves the subtree byte-identical.
+
+## 6. Wire + acceptance — same field, same gate (extends parent §5.4)
+
+- **Joi** (`validation.js:270` — in checkJs scope via the middleware
+  include): `profileAnswers` keeps its key pattern (`c_` ids already
+  match), `.max(5)` → `.max(10)` (`MAX_TOTAL_PROFILE_QUESTIONS`), string
+  alternative `.max(32)` → `.max(200)` (`CUSTOM_ANSWER_TEXT_MAX`; library
+  answers unaffected — semantic validation still drops non-option
+  values). Array alternative unchanged (`.max(8)` = `MAX_CUSTOM_OPTIONS`).
+  Nested `.unknown(false)` + 400-vs-429 ordering unchanged, re-tested
+  THROUGH the middleware with the route's global `stripUnknown` (backend
+  validation tests, R1 #16).
+- **Eligibility gate — repaired, not just reused (R1 #7):** the parent
+  plan specified "campaign type is not `guided_review`", but the shipped
+  gate checks `design_config.template.id` only
+  (`prospectScoring.js:89`) while the UI branches on `campaign.type`
+  (`LeadCapture.jsx:581`) — a guided-review-TYPE campaign carrying a v2
+  doc with a different template id accepts hidden answers via direct
+  POST. The gate gains the leg the parent plan intended:
+  `sourceCampaign?.type !== 'guided_review'` (template check kept,
+  belt + braces; `sourceCampaign` is the full `findByPk` row, so `type`
+  is present). This also closes the same latent gap for LIBRARY answers;
+  a direct-API regression test pins it.
+- **`prospectScoring.js` `scoreSubmission`:** after the existing library
+  loop, a **custom loop** iterating `questionIds` in order, taking ids
+  that resolve to a campaign custom def (never attacker-provided keys):
+  - `single`: value must be a string equal to one option id → freeze that
+    option's `label`.
+  - `multi`: value must be a unique string array ⊆ option ids (≤
+    `MAX_CUSTOM_OPTIONS`) → freeze labels in the def's option order.
+  - `text`: value must be a string → `sanitizeQuestionText` at
+    `CUSTOM_ANSWER_TEXT_MAX`; empty after trim ⇒ skipped.
+  - Accepted answers build `sourceMetadataPatch.customAnswers =
+    [{ qid, prompt, values: string[] }]` in `questionIds` order — prompt
+    and labels FROZEN server-side from the campaign config at capture (a
+    later Studio edit can't re-caption history; the §5.2 frozen-input
+    principle). Client-sent labels are never trusted. **The historical
+    record is English-canonical by definition (R1 #14):** the snapshot
+    freezes the EN `prompt` and EN `label`s (plus the customer's
+    sanitized literal text), NOT the bilingual as-seen rendering —
+    `label` is the required field and the admin surface is EN; a stated
+    redefinition, not an omission.
+  - Violations drop THAT answer, joining the existing single aggregated
+    log line — which logs **ids only**, never answer content or prompts
+    (log-injection surface, R1 #15). A bad answer never costs a lead.
+    Ineligible campaigns ignore the whole object (existing branch).
+  - **`acceptedProfileFacts` is untouched** — custom answers mint zero
+    observations and zero map-job facts by construction (test pins the
+    zero). Note: `prospectScoring.js` sits OUTSIDE the checkJs include
+    set (`tsconfig.check.json` covers `src/utils` + `src/middleware`) —
+    no typecheck claim is made for it; behavior is test-pinned (R1 #16).
+- **Mass assignment — the claim was wrong; now it's work (R1 #6):**
+  `profileAnswers` is NOT currently destructured out of the body — it
+  rides `incoming` into `Prospect.create` (`prospectService.js:223` strip
+  list, `prospectCreateTx.js:165` spread), inert only because Sequelize
+  ignores non-attribute keys. It joins the strip destructure explicitly.
+  Separately, internal callers' `sourceMetadata` is preserved with only
+  the `marketplace` subkey scrubbed (`prospectService.js:237`) — so
+  `customAnswers` (and `profileAnswers`) join the server-only scrub
+  list: caller-supplied values are deleted before the server-built patch
+  merges. Verified unaffected legitimate callers: Retell creates
+  prospects directly via `Prospect.create` with server-built metadata
+  (`retellService.js`), and marketplace submits its validated top-level
+  `marketplace` field — neither path supplies these keys. Tests assert
+  neither key reaches create attributes from the body NOR survives via
+  caller-supplied `sourceMetadata`.
+- **Erasure:** `erasureService.js` `erasedSourceMetadata` rebuilds from an
+  allowlist (utm + `erased:true`) — `customAnswers` is wiped from the
+  prospect automatically; tests pin it (§8, incl. the webhook-payload
+  legs in §7).
+
+## 7. Display + delivery (PII boundary stated in full — R1 #9, R2 #9)
+
+`sourceMetadata.customAnswers` is **PII** (free text may contain
+anything the customer types). Its full propagation surface:
+
+- **MKTR admin:** `AdminV2LeadProfile.jsx` gains a "Custom answers" card
+  rendering the frozen `{qid, prompt, values}` list (Q above, A below,
+  plain text — React escaping, no `dangerouslySetInnerHTML`; hostile
+  strings render as literal text, test-pinned). No backend change: the
+  card reads `p.sourceMetadata` from the lead-profile ROOT projection —
+  the unrestricted `Prospect.findOne` (`prospectReadService.js:31`) —
+  which serves consumer-linked and consumer-less leads alike (the
+  `getSignupProfile` fallback does NOT return `sourceMetadata` and is
+  not relied on — R2 new #5). Tested on both profile paths.
+- **Webhooks — all three lead events forward `sourceMetadata` verbatim:**
+  `lead.created` (`prospectHelpers.js:118`), `lead.assigned` (`:177`),
+  and `lead.unassigned` (`:231` — fires on admin pull-back, R2 #9), to
+  both destinations (Lyfe app and MKTR Leads external buyers,
+  `prospectHelpers.js:47`). External buyers seeing campaign Q&A on a
+  lead they bought is correct product behavior — stated, not accidental.
+- **Erasure covers all three stores:** the prospect rebuild (§6), pending
+  webhook deliveries (cancelled before firing), and historical delivery
+  payloads (scrubbed — `erasureService.js:195` block). Tests cover the
+  webhook legs with `customAnswers` present.
+- **Lyfe receiver (sibling repo — external dependency):** the
+  `receive-mktr-lead` EF composes lead notes from
+  Company/Title/Industry/Campaign/QR only, so agents do NOT see custom
+  answers in the app from this PR. That claim is about `lyfe-app` code
+  and is verified there, not here; the §10 follow-up owns it.
+- **CSV exports — explicitly OUT (R1 #10):** the shared admin exporter
+  (`src/lib/adminV2/csv.js` fixed `COLUMNS`, used by Prospects +
+  Dashboard) does NOT gain a custom-answers column in v1 — the Lead
+  Profile card is the read surface. If Shawn wants export, it's a
+  fast-follow through the existing formula-injection-safe `csvCell()`
+  path (and needs the list API to carry the data) — §10.
+
+## 8. Tests
+
+- **Twins/lockstep:** new constants/regexes into `CONSTANT_EXPORTS`;
+  `sanitizeQuestionText` into `FUNCTION_EXPORTS` with behavioral parity
+  fixtures (same hostile inputs → same outputs both sides);
+  upgrade-preservation fixture with `custom`.
+- **Clamp** (`designConfigV2StudioClamp.test.js` style): the §3 matrix —
+  bad shapes/types dropped, id patterns, question-id uniqueness +
+  library-collision, option-id uniqueness within a question, empty
+  labels/prompts dropped, **option cap: a 9th valid option is dropped**,
+  text-row options stripped, **cap-ordering: 5 unreferenced defs + 1
+  referenced def ⇒ the referenced question SURVIVES**, caps (5 custom /
+  10 total), unreferenced defs dropped, order preserved verbatim,
+  `requiredIds ⊆`, enabled-with-only-custom valid, control-char/bidi
+  stripping, golden suites unchanged.
+- **Public projection** (`publicDesignConfig.test.js`): custom leaf-pick
+  is exactly the §3 shape; disabled ⇒ absent; no extra keys leak.
+- **Capture** (backend integration + validation suites): Joi 400 matrix
+  at the new bounds THROUGH the middleware (stripUnknown interaction);
+  custom accepted → frozen `{qid, prompt, values}` snapshot with
+  server-resolved labels in `questionIds` order; text
+  trim/cap/control-strip; whitespace-only text skipped; unknown option
+  ids / shape mismatches dropped (lead still created);
+  ineligible ignores; **guided-review-TYPE direct-POST rejected (the
+  repaired gate)**; **zero consumer observations from custom answers**;
+  mass-assign: body `profileAnswers` never a create attribute AND
+  caller-`sourceMetadata.customAnswers` scrubbed; logs carry ids only
+  (CR/LF in answers never lands in log content); erasure: prospect
+  rebuild + pending-delivery cancel + historical-payload scrub all shed
+  `customAnswers`; `lead.unassigned` payload carries-then-sheds them
+  too; marketplace-door parity per §1.
+- **Panel** (`FormQuizPanels.test.jsx`): the per-site
+  destructive-mutation matrix (master toggle, brief-suggestion add,
+  library tick, required toggle, custom authoring — each preserves the
+  rest of the subtree, including the pre-existing `requiredIds`/`showZh`
+  loss now fixed); `mutatePQ` reconciliation (mismatched
+  `custom`-vs-`questionIds` input, back-to-back mutations, idempotence);
+  draft lifecycle (rail switch away/back, save-response adoption,
+  campaign-switch guard through BOTH buttons — Save-and-continue commits
+  a complete draft and the `Campaign.update` PUT payload is asserted to
+  contain the new def + id before navigation (the R4 snapshot rule) /
+  blocks an incomplete one, Discard discards; second
+  Add disabled; incomplete edit never reaches the doc; control-char-only
+  prompt cannot commit); commit atomicity; delete cleans `questionIds` +
+  `requiredIds`; reorder moves within the custom segment; first-unused
+  `oN`; Add-option disabled at 8; **Add-question disabled at 5 and a
+  sixth question never enters the doc**.
+- **Renderer** (`CampaignSignupForm` tests): renders single/multi/text
+  from the normalized resolver; multi-custom actually multi-selects;
+  required gate blocks unanswered required CUSTOM questions and
+  whitespace-only text; payload carries custom answers; showZh off ⇒
+  EN-only; hostile prompt/label renders as literal text; long unbroken
+  strings stay inside 390px (overflow-wrap pinned); disabled ⇒ nothing.
+- **Admin:** Lead Profile card on consumer-linked AND consumer-less
+  leads (both via the root projection); hostile answer text renders
+  inert.
+- **Duplication + AI:** campaign duplication carries `custom` intact
+  (`campaignService` clone path); §5b matrix — edit-after-pick →
+  revert/re-pick keeps edits; Fill-everything/apply/revert leaves the
+  subtree untouched.
+- **Full path** (parent §6 pattern): public endpoint → adapter → form
+  renders custom → POST carries `profileAnswers` with custom ids.
+- **Feature verification commands (R3 new #2 — local repro per
+  CLAUDE.md, not a mirror of `ci.yml`, which additionally runs coverage
+  and Playwright E2E jobs):** backend Jest — unit, integration, and
+  migration suites; `cd backend && npm run typecheck` (validation.js and
+  the `src/utils` twin/clamp/projection changes are in scope); root
+  **Vitest** (`npm test`) + frontend build; `npx eslint src/ --quiet` at
+  both the repo root and `backend/`. The PR merges only on full CI
+  green, whatever the workflow runs.
+
+## 9. Rollout
+
+One PR, **no migration** — `campaigns.design_config` and
+`prospects.sourceMetadata` are schema-less `DataTypes.JSON` columns
+(R1 #12), and no new table/column/index is introduced. Naturally dark: no
+campaign carries `custom[]` until Shawn authors one, and the
+clamp/projection changes are no-ops on existing docs (golden suites
+prove). `DESIGN_CONFIG_V2_WRITES_ENABLED` preflight as always. Single
+service; nothing to choreograph.
+
+## 10. Open questions (Shawn)
+
+1. **Free-text type in v1?** The plan includes `text` (200-char cap).
+   Cutting it shrinks the PR; options-only still covers most campaign
+   intel. Recommendation: keep it.
+2. **Caps OK?** 5 custom / 10 total / 8 options / 200-char text — named
+   constants, trivially tunable later.
+3. **Agent visibility follow-up:** a lyfe-app EF change appending a
+   compact "Q: … | A: …" line to lead notes so agents see answers in the
+   app (separate repo/PR; the webhook payload already carries the data).
+4. **CSV export fast-follow:** want custom answers in the Prospects
+   export? (Needs a serialized column via `csvCell()` + list-API
+   exposure — deliberately out of v1.)
+5. **Marketplace door:** should marketplace flows EVER ask profile
+   questions (library or custom)? Today they never have; v1 keeps that.
+
+## 11. Codex rounds 3–5 — disposition log
+
+**Round 5** (APPROVE, zero new findings): the explicit-snapshot guard
+contract verified against `useStudioDoc.js` (`mut` scheduling, the
+`prev === snapshot` reference-identity adoption) and
+`AdminCampaignStudio.jsx` `handleGuardPrimary` — "closes the sole Round 4
+defect without weakening save gates, slug merging, or in-flight-edit
+protection."
+
+**Round 3** (REWORK: 9/10 closed): all four reopened round-1 items
+CLOSED; round-2 new findings #2–#6 CLOSED (the §5b graft was confirmed
+to cover every replacement site including `toggleKeep`); #1 residual + 2
+new. **Round 4** (REWORK: 2/3 closed, ZERO new findings): cap-disable and
+CI relabel CLOSED; the guard fix reopened once more on a React
+state-lifecycle defect — `mut()` schedules `setDoc` while `save()` PUTs
+the render-captured doc (`useStudioDoc.js` `const snapshot = doc`), so
+commit-then-save would PUT the pre-commit doc; round-3 log renumbering
+verified accurate.
+
+| # | Finding | Disposition |
+|---|---|---|
+| R4 (residual of R2 new 1) | B: "mutatePQ then save()" PUTs the stale pre-commit doc and navigates — the exact loss the guard exists to prevent | **Adopted** — `save(extra, { snapshot })` explicit-snapshot parameter (precedent: `extra` already carries the guard's slug draft); guard computes the post-commit doc synchronously and hands the SAME reference to `setDoc` and `save`; test asserts the PUT payload before navigation (§4, §8). |
+
+| # | Finding | Disposition |
+|---|---|---|
+| R2 new 1 (residual) | The guard's "Save & continue" saves the doc then navigates — a draft (outside the doc) is destroyed even though the user chose Save | **Adopted** — Save-and-continue commits a complete draft before `save()`; blocked (with reason) for incomplete drafts until completed or explicitly Discarded; both guard buttons tested with complete + incomplete drafts (§4, §8). |
+| New 1 | M: Add-question was only draft-gated — a sixth question could be authored, then silently clamped away on save | **Adopted** — Add disabled at `MAX_CUSTOM_QUESTIONS`, commit re-checks, sixth-question-never-enters-doc test (§4, §8). |
+| New 2 | m: "exact CI gates" list wasn't exact (`--runInBand` isn't in ci.yml; coverage + Playwright jobs omitted) | **Adopted** — relabeled as local feature-verification commands per CLAUDE.md; CI green stays the merge gate (§8). |
+
+## 12. Codex round 2 — disposition log (REWORK: 12/16 closed, 4 reopened + 6 new, all adopted)
+
+Round-2 verdicts on the 16 round-1 items: #1–#2, #5–#8, #10, #12–#16
+CLOSED as written (the alternate single-authority ordering fix for #3 was
+judged viable). Reopened + new findings, all verified in code before
+adoption (`buildLeadUnassignedPayload` forwards `sourceMetadata`;
+`FUNCTION_EXPORTS` exists at `designConfigV2.lockstep.test.js:22`;
+`revertLook` does a whole-doc `replaceDoc(p.prev.doc)`):
+
+| # | Finding | Disposition |
+|---|---|---|
+| R1 #3 (reopened) | Clamp order still let 5 unreferenced defs consume the cap before a referenced 6th | **Adopted** — §3 reordered: validity map without count cap → questionIds built with custom-acceptance cap → defs retained only for final membership (§3). Cap-ordering test added (§8). |
+| R1 #4 (reopened) | Panel "complete" used `trim()` while the server strips C0/C1+bidi — control-only prompts commit then vanish | **Adopted** — completeness = non-empty after the SHARED `sanitizeQuestionText`, and commits write the sanitized values (clamp-stable by construction) (§4). |
+| R1 #9 (reopened) | `lead.unassigned` also forwards `sourceMetadata` verbatim; inventory claimed fullness without it | **Adopted** — all three events documented + tested (§7, §8). |
+| R1 #11 (reopened) | `sanitizeQuestionText` can't live in `CONSTANT_EXPORTS` (structural equality fails on functions) | **Adopted** — it joins `FUNCTION_EXPORTS` with behavioral parity fixtures (§2, §8). |
+| New 1 | B: editor-local drafts had no durable owner — rail switch unmounts FormPanel, dirty guard watches doc+slug only | **Adopted** — drafts lifted to the Studio page keyed by campaign id; `draftDirty` joins the dirty guard; one draft at a time; lifecycle test matrix (§4). |
+| New 2 | M: AI look apply/revert are whole-doc swaps from the pick-time snapshot — post-pick question edits destroyed | **Adopted** — every `useStudioAi` doc replacement grafts the LIVE `profileQuestions` subtree; §5b + tests. |
+| New 3 | M: 8-option bound stated but not enforced anywhere (clamp/editor/scoring/tests) | **Adopted** — `MAX_CUSTOM_OPTIONS = 8` constant, clamp drop-beyond-8, Add-option disabled at 8, scoring bound, 9th-option tests (§2–§4, §6, §8). |
+| New 4 | M: `mutatePQ` invariants undefined (atomicity, customOrder↔defs reconciliation) | **Adopted** — atomic single-draft contract with read-side reconciliation, ordered-ids-only emission, idempotence + mismatch tests (§4, §8). |
+| New 5 | m: consumer-less fallback does NOT return `sourceMetadata`; the root projection is what the card reads | **Adopted** — claim corrected; both test paths read the root projection (§7). |
+| New 6 | m: frontend runner is Vitest, not "frontend jest" | **Adopted** — exact CI gate list named (§8). |
+
+## 13. Codex round 1 — disposition log (REWORK 3B/8M/5m, all 16 adopted)
+
+Load-bearing claims re-verified in code before adoption (marketplace
+flow/`buildPublicDesignConfig`, FormPanel mutation sites, the strip
+destructure + `marketplace`-only scrub, the `template.id` gate,
+`CONSTANT_EXPORTS`, `tsconfig.check.json` include set, CSV `COLUMNS`,
+erasure's webhook blocks) — all confirmed true; zero refuted.
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | B: "marketplace inherits the funnel door" is false — own step machine, fixed fields, no `profileAnswers`, v1-downgraded public config excludes the subtree | **Adopted** — reframed as explicit parity: marketplace has never asked profile questions and v1 keeps that; parity test + §10 owner question (§1). |
+| 2 | B: existing FormPanel mutation sites rebuild the subtree lossily and would delete `custom` | **Adopted** — single `mutatePQ` helper owns every subtree write; per-site preservation test matrix; also fixes the pre-existing `requiredIds`/`showZh` loss (§4). |
+| 3 | B: two ordering authorities (`custom[]` order vs `questionIds`), unpicked defs consume the cap | **Adopted, alternate fix** — `questionIds` stays the SINGLE authority; `custom[]` demoted to an unordered def set; clamp drops unreferenced defs (§2, §3). R2 confirmed the ordering half; the cap half was re-fixed in v3 (§12). |
+| 4 | M: blank starter row written to the doc vanishes on Save (clamp drops + Studio adopts clamped response) | **Adopted** — editor-local drafts; a def reaches the doc only when complete, atomically with its id (§4). R2 tightened completeness to the shared sanitizer (§12). |
+| 5 | M: `resolveQuestion` doesn't normalize `multi` vs `type`; custom multi degrades to single; whitespace-only required text passes | **Adopted** — normalized resolver shape + shared type-aware `isAnswered` with trim (§5). |
+| 6 | M: mass-assignment claim factually wrong; forged `sourceMetadata.customAnswers` possible from internal callers | **Adopted** — claim corrected; `profileAnswers` joins the strip destructure; `customAnswers`/`profileAnswers` join the `marketplace`-style server-only scrub; Retell/marketplace verified unaffected; tested (§6). |
+| 7 | M: backend gate checks `template.id`, not campaign `type` — direct-POST leak on guided-review-type campaigns | **Adopted** — add the `sourceCampaign.type` leg (keep template check), repairing the same latent gap for library answers; regression test (§6). |
+| 8 | M: option-id uniqueness/non-empty labels unspecified; `oN`/`c_` generation collision-unchecked | **Adopted** — per-question option-id uniqueness + non-empty-after-sanitize labels in the clamp; first-unused `oN`; collision-checked random `c_` ids (§2–§4). |
+| 9 | M: PII boundary broader than documented (`lead.assigned`, MKTR Leads destination, historical webhook payloads, sibling-repo claim) | **Adopted** — §7 rewritten: PII classification, events/destinations stated, erasure tested across all three stores, Lyfe receiver = external dependency (§7). R2 added `lead.unassigned` (§12). |
+| 10 | M: both CSV exports omit the answers | **Adopted as explicit decision** — out of v1, stated in §7; fast-follow path named; owner question §10.4. |
+| 11 | M: twins aren't byte-parity; lockstep covers only enumerated constants | **Adopted** — terminology corrected; constants into `CONSTANT_EXPORTS` (§2). R2 moved the function into `FUNCTION_EXPORTS` (§12). |
+| 12 | m: columns are `DataTypes.JSON`, not JSONB | **Adopted** — §9 wording. |
+| 13 | m: cited admin projection is the consumer-less fallback only | **Adopted** — root projection (`prospectReadService.js:31`) cited (§7). R2 removed the residual fallback overclaim (§12). |
+| 14 | m: frozen snapshot isn't the bilingual as-seen record | **Adopted as explicit decision** — historical record is English-canonical (EN prompt + EN labels + literal text); stated redefinition (§6). |
+| 15 | m: `cleanString` only slices; XSS/log-injection tests unpinned | **Adopted** — shared `sanitizeQuestionText` (trim + C0/C1 + bidi) in the twins; hostile-render + ids-only logging tests (§2, §6, §8). |
+| 16 | M: test/CI gaps (FormPanel mutation matrix, duplication, AI preservation, `lead.assigned`, historical erasure, middleware-level Joi, 390px overflow, checkJs scope overclaim) | **Adopted** — §8 matrix expanded; `prospectScoring` typecheck claim removed; chip `overflow-wrap` constraint added (§5). |

--- a/src/components/campaignPage/funnelAdapter.js
+++ b/src/components/campaignPage/funnelAdapter.js
@@ -66,6 +66,11 @@ export function deriveFunnelProps(adapted, { onSubmit, previewMode = false, prev
         questionIds: doc.profileQuestions.questionIds,
         requiredIds: Array.isArray(doc.profileQuestions.requiredIds) ? doc.profileQuestions.requiredIds : [],
         showZh: doc.profileQuestions.showZh !== false,
+        // Owner-authored custom question defs (studio-custom-questions §5) —
+        // already leaf-picked upstream (public projection / Studio raw doc).
+        ...(Array.isArray(doc.profileQuestions.custom) && doc.profileQuestions.custom.length
+          ? { custom: doc.profileQuestions.custom }
+          : {}),
       }
       : undefined,
   };

--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -12,8 +12,44 @@ import {
   isSponsoredCampaign, sponsorNameLine,
 } from '@/lib/consentCopy';
 import { formatDateInput, getAgeValidationError, getAgeRestrictionHint, displayPhone } from '@/components/campaigns/signup/dateUtils';
-import { LIMITS } from '@/lib/designConfigV2';
+import { CUSTOM_ANSWER_TEXT_MAX, LIMITS } from '@/lib/designConfigV2';
 import { getProfileQuestion } from '@/lib/profileQuestionLibrary';
+
+// One normalized question resolver (studio-custom-questions §5): library defs
+// expose `multi` while custom defs expose `type` — both the render loop AND
+// the required-submit gate go through this shape, so a required CUSTOM
+// question can never be silently skipped by the library-only lookup.
+function resolveQuestion(qid, custom) {
+  const lib = getProfileQuestion(qid);
+  if (lib) {
+    return {
+      id: lib.id,
+      kind: lib.multi ? 'multi' : 'single',
+      prompt: lib.prompt,
+      promptZh: lib.promptZh,
+      options: lib.options,
+      isCustom: false,
+    };
+  }
+  const c = Array.isArray(custom) ? custom.find((q) => q && q.id === qid) : null;
+  if (!c || typeof c !== 'object') return null;
+  return {
+    id: c.id,
+    kind: c.type === 'multi' ? 'multi' : c.type === 'text' ? 'text' : 'single',
+    prompt: c.prompt,
+    promptZh: c.promptZh,
+    options: Array.isArray(c.options) ? c.options : [],
+    isCustom: true,
+  };
+}
+
+// Type-aware answered check, shared by the required gate — whitespace-only
+// text never satisfies a required question (the server trims it away anyway).
+function isQuestionAnswered(q, answer) {
+  if (q.kind === 'multi') return Array.isArray(answer) && answer.length > 0;
+  if (q.kind === 'text') return typeof answer === 'string' && answer.trim().length > 0;
+  return typeof answer === 'string' && answer.length > 0;
+}
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 import { isValidSgMobile } from '@/utils/validation';
 
@@ -315,12 +351,12 @@ export default function CampaignSignupForm({
 
     // Required profile questions (owner control, 2026-07-26): client-side
     // gate only — the server keeps its drop-not-fail policy as the net.
+    // Resolves library AND custom defs through the shared resolver
+    // (studio-custom-questions §5).
     for (const requiredId of profileQuestions?.requiredIds || []) {
-      const q = getProfileQuestion(requiredId);
+      const q = resolveQuestion(requiredId, profileQuestions?.custom);
       if (!q) continue;
-      const answer = profileAnswers[requiredId];
-      const answered = q.multi ? Array.isArray(answer) && answer.length > 0 : Boolean(answer);
-      if (!answered) {
+      if (!isQuestionAnswered(q, profileAnswers[requiredId])) {
         setError(`Please answer: ${q.prompt}`);
         return;
       }
@@ -979,16 +1015,16 @@ export default function CampaignSignupForm({
                 : 'Helps us serve you better'}
             </div>
             {profileQuestions.questionIds.map((qid) => {
-              const q = getProfileQuestion(qid);
+              const q = resolveQuestion(qid, profileQuestions.custom);
               if (!q) return null;
               const isRequired = (profileQuestions.requiredIds || []).includes(q.id);
               const current = profileAnswers[q.id];
-              const isSelected = (optId) => (q.multi
+              const isSelected = (optId) => (q.kind === 'multi'
                 ? Array.isArray(current) && current.includes(optId)
                 : current === optId);
               const toggle = (optId) => setProfileAnswers((prev) => {
                 const next = { ...prev };
-                if (!q.multi) {
+                if (q.kind !== 'multi') {
                   if (prev[q.id] === optId) delete next[q.id];
                   else next[q.id] = optId;
                 } else {
@@ -1004,10 +1040,13 @@ export default function CampaignSignupForm({
                 return next;
               });
               return (
-                <div key={q.id} style={{ marginBottom: 14 }}>
+                <div key={q.id} data-question-id={q.id} style={{ marginBottom: 14, maxWidth: '100%' }}>
                   <div style={{
                     fontSize: 13.5, fontWeight: 600, color: TOKENS.body, marginBottom: 8,
                     fontFamily: 'Albert Sans, system-ui, sans-serif',
+                    // Long unbroken owner-authored prompts must wrap, never
+                    // overflow 390px (studio-custom-questions §5).
+                    overflowWrap: 'anywhere', maxWidth: '100%',
                   }}>
                     {q.prompt}
                     {q.promptZh && profileQuestions.showZh !== false
@@ -1015,32 +1054,61 @@ export default function CampaignSignupForm({
                       : null}
                     {isRequired ? <span aria-hidden="true" style={{ color: themeColor || TOKENS.body }}> *</span> : null}
                   </div>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-                    {q.options.map((opt) => {
-                      const on = isSelected(opt.id);
-                      return (
-                        <button
-                          key={opt.id}
-                          type="button"
-                          onClick={() => toggle(opt.id)}
-                          aria-pressed={on}
-                          style={{
-                            padding: '9px 14px',
-                            borderRadius: 999,
-                            border: `1px solid ${on ? (themeColor || TOKENS.body) : TOKENS.hairline}`,
-                            backgroundColor: on ? (themeColor || TOKENS.body) : (TOKENS.inputBg || '#ffffff'),
-                            color: on ? '#ffffff' : TOKENS.body,
-                            fontSize: 13.5,
-                            fontWeight: 600,
-                            cursor: 'pointer',
-                            fontFamily: 'Albert Sans, system-ui, sans-serif',
-                          }}
-                        >
-                          {opt.label}
-                        </button>
-                      );
-                    })}
-                  </div>
+                  {q.kind === 'text' ? (
+                    <input
+                      type="text"
+                      value={typeof current === 'string' ? current : ''}
+                      maxLength={CUSTOM_ANSWER_TEXT_MAX}
+                      onChange={(e) => setProfileAnswers((prev) => {
+                        const next = { ...prev };
+                        if (e.target.value) next[q.id] = e.target.value; else delete next[q.id];
+                        return next;
+                      })}
+                      placeholder="Type your answer"
+                      aria-label={q.prompt}
+                      style={{
+                        width: '100%',
+                        maxWidth: '100%',
+                        boxSizing: 'border-box',
+                        padding: '12px 14px',
+                        borderRadius: 12,
+                        border: `1px solid ${TOKENS.hairline}`,
+                        backgroundColor: TOKENS.inputBg || '#ffffff',
+                        color: TOKENS.body,
+                        fontSize: 14.5,
+                        fontFamily: 'Albert Sans, system-ui, sans-serif',
+                      }}
+                    />
+                  ) : (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, maxWidth: '100%' }}>
+                      {q.options.map((opt) => {
+                        const on = isSelected(opt.id);
+                        return (
+                          <button
+                            key={opt.id}
+                            type="button"
+                            onClick={() => toggle(opt.id)}
+                            aria-pressed={on}
+                            style={{
+                              padding: '9px 14px',
+                              borderRadius: 999,
+                              border: `1px solid ${on ? (themeColor || TOKENS.body) : TOKENS.hairline}`,
+                              backgroundColor: on ? (themeColor || TOKENS.body) : (TOKENS.inputBg || '#ffffff'),
+                              color: on ? '#ffffff' : TOKENS.body,
+                              fontSize: 13.5,
+                              fontWeight: 600,
+                              cursor: 'pointer',
+                              fontFamily: 'Albert Sans, system-ui, sans-serif',
+                              overflowWrap: 'anywhere',
+                              maxWidth: '100%',
+                            }}
+                          >
+                            {opt.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -691,3 +691,142 @@ describe('CampaignSignupForm — profile question controls (required + showZh)',
     expect(block.textContent).not.toContain('*');
   });
 });
+
+describe('CampaignSignupForm — custom questions (studio-custom-questions §5)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const CQ = {
+    enabled: true,
+    questionIds: ['language', 'c_showrm', 'c_hobby1', 'c_notes1'],
+    requiredIds: [],
+    showZh: true,
+    custom: [
+      { id: 'c_showrm', type: 'single', prompt: 'Which showroom?', promptZh: '哪个门店？', options: [{ id: 'o1', label: 'East' }, { id: 'o2', label: 'West' }] },
+      { id: 'c_hobby1', type: 'multi', prompt: 'What do you enjoy?', options: [{ id: 'o1', label: 'Golf' }, { id: 'o2', label: 'Travel' }] },
+      { id: 'c_notes1', type: 'text', prompt: 'Anything else?' },
+    ],
+  };
+
+  it('renders custom questions through the shared resolver, in questionIds order, after the library ones', () => {
+    renderForm({ profileQuestions: CQ });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    const text = block.textContent;
+    expect(text.indexOf('Which language do you prefer?')).toBeLessThan(text.indexOf('Which showroom?'));
+    expect(text.indexOf('Which showroom?')).toBeLessThan(text.indexOf('What do you enjoy?'));
+    expect(text).toContain('哪个门店？');
+    expect(block.querySelector('[data-question-id="c_notes1"] input')).toBeTruthy();
+    expect(block.querySelector('[data-question-id="c_notes1"] input').maxLength).toBe(200);
+  });
+
+  it('a custom MULTI question actually multi-selects (the q.multi/type normalization regression)', () => {
+    renderForm({ profileQuestions: CQ });
+    const golf = screen.getByRole('button', { name: 'Golf' });
+    const travel = screen.getByRole('button', { name: 'Travel' });
+    fireEvent.click(golf);
+    fireEvent.click(travel);
+    expect(golf).toHaveAttribute('aria-pressed', 'true');
+    expect(travel).toHaveAttribute('aria-pressed', 'true');
+    // single-custom stays single
+    const east = screen.getByRole('button', { name: 'East' });
+    const west = screen.getByRole('button', { name: 'West' });
+    fireEvent.click(east);
+    fireEvent.click(west);
+    expect(east).toHaveAttribute('aria-pressed', 'false');
+    expect(west).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('hostile prompts/labels render as literal text (React escaping), never markup', () => {
+    renderForm({
+      profileQuestions: {
+        enabled: true,
+        questionIds: ['c_evil01'],
+        requiredIds: [],
+        custom: [{ id: 'c_evil01', type: 'single', prompt: '<b>Bold?</b><img src=x onerror=alert(1)>', options: [{ id: 'o1', label: '<i>it</i>' }, { id: 'o2', label: 'ok' }] }],
+      },
+    });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block.textContent).toContain('<b>Bold?</b>');
+    expect(block.querySelector('b')).toBeNull();
+    expect(block.querySelector('img')).toBeNull();
+    expect(screen.getByRole('button', { name: '<i>it</i>' })).toBeTruthy();
+  });
+
+  it('showZh:false hides custom Chinese prompts too; unknown custom ids render nothing', () => {
+    renderForm({
+      profileQuestions: {
+        enabled: true,
+        questionIds: ['c_showrm', 'c_ghost9'],
+        requiredIds: [],
+        showZh: false,
+        custom: [CQ.custom[0]],
+      },
+    });
+    const block = document.querySelector('[data-se="profileQuestions"]');
+    expect(block.textContent).toContain('Which showroom?');
+    expect(block.textContent).not.toContain('哪个门店？');
+    expect(block.querySelector('[data-question-id="c_ghost9"]')).toBeNull();
+  });
+
+  it('a required CUSTOM question blocks submit (the library-only gate regression), and whitespace-only text never satisfies it', async () => {
+    const user = userEvent.setup();
+    renderForm({
+      previewMode: true,
+      profileQuestions: { ...CQ, requiredIds: ['c_notes1'] },
+    });
+    await user.type(screen.getByPlaceholderText('John Tan'), 'Jane Tan');
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'jane@example.com');
+    await user.type(screen.getByPlaceholderText('9123 4567'), '91234567');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+    await user.type(await screen.findByPlaceholderText('6-digit code'), '123456');
+    await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument(), { timeout: 2500 });
+    fireEvent.click(document.getElementById('consent_all'));
+    const submit = screen.getByRole('button', { name: 'Submit Now' });
+    await waitFor(() => expect(submit).toBeEnabled(), { timeout: 2500 });
+
+    // Whitespace-only text does not satisfy the required gate.
+    const notesInput = document.querySelector('[data-question-id="c_notes1"] input');
+    fireEvent.change(notesInput, { target: { value: '   ' } });
+    await user.click(submit);
+    expect(await screen.findByText('Please answer: Anything else?')).toBeInTheDocument();
+
+    fireEvent.change(notesInput, { target: { value: 'after 6pm' } });
+    await user.click(submit);
+    expect(await screen.findByText('Preview — your details were not submitted.')).toBeInTheDocument();
+  });
+
+  it('live submit: the payload carries custom answers beside library ones in the existing profileAnswers field', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm({ profileQuestions: CQ });
+    apiClient.post.mockImplementation((url) => {
+      if (url === '/verify/send') return Promise.resolve({ success: true });
+      if (url === '/verify/check') return Promise.resolve({ success: true, data: { verified: true } });
+      return Promise.resolve({ success: true });
+    });
+    await user.type(screen.getByPlaceholderText('John Tan'), 'Jane Tan');
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'jane@example.com');
+    await user.type(screen.getByPlaceholderText('9123 4567'), '91234567');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
+    await user.type(await screen.findByPlaceholderText('6-digit code'), '123456');
+    await waitFor(() => expect(screen.getByText('Verified')).toBeInTheDocument(), { timeout: 2500 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'English' }));
+    fireEvent.click(screen.getByRole('button', { name: 'West' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Golf' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Travel' }));
+    fireEvent.change(document.querySelector('[data-question-id="c_notes1"] input'), { target: { value: 'call after 6pm' } });
+
+    fireEvent.click(document.getElementById('consent_all'));
+    const submit = screen.getByRole('button', { name: 'Submit Now' });
+    await waitFor(() => expect(submit).toBeEnabled(), { timeout: 2500 });
+    await user.click(submit);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.profileAnswers).toEqual({
+      language: 'en',
+      c_showrm: 'o2',
+      c_hobby1: ['o1', 'o2'],
+      c_notes1: 'call after 6pm',
+    });
+  });
+});

--- a/src/components/studio/StudioGuardModal.jsx
+++ b/src/components/studio/StudioGuardModal.jsx
@@ -14,13 +14,17 @@ const PRIMARY_LABELS = {
 
 const SAVE_FIRST_KINDS = ['copy', 'share'];
 
-export default function StudioGuardModal({ guard, saving, onPrimary, onDiscard, onCancel }) {
+export default function StudioGuardModal({ guard, saving, primaryBlockedReason, onPrimary, onDiscard, onCancel }) {
   if (!guard) return null;
   const saveFirst = SAVE_FIRST_KINDS.includes(guard.kind);
   const title = saveFirst ? 'Save first?' : 'Unsaved changes';
   const body = saveFirst
     ? 'Links always reflect the last saved design. Save now so what you share is what people see.'
     : 'You have unsaved changes. Save them, or discard and leave.';
+  // studio-custom-questions §4: an INCOMPLETE custom-question draft cannot be
+  // committed, so the save path is blocked (with the reason shown) until the
+  // operator completes it — or explicitly chooses Discard.
+  const primaryBlocked = !saving && !!primaryBlockedReason;
 
   return (
     <div
@@ -52,6 +56,11 @@ export default function StudioGuardModal({ guard, saving, onPrimary, onDiscard, 
       >
         <div style={{ fontWeight: 700, fontSize: 15.5, marginBottom: 6 }}>{title}</div>
         <div style={{ fontSize: 13, lineHeight: 1.55, color: 'var(--ink-2, #5B616E)', marginBottom: 16 }}>{body}</div>
+        {primaryBlocked && (
+          <div style={{ fontSize: 12, lineHeight: 1.5, color: '#B97D10', marginBottom: 12 }}>
+            {primaryBlockedReason}
+          </div>
+        )}
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
           <button type="button" className="av2-btn av2-btn--ghost" onClick={onCancel} disabled={saving}>
             Keep editing
@@ -61,7 +70,7 @@ export default function StudioGuardModal({ guard, saving, onPrimary, onDiscard, 
               Discard changes
             </button>
           )}
-          <button type="button" className="av2-btn av2-btn--primary" onClick={onPrimary} disabled={saving}>
+          <button type="button" className="av2-btn av2-btn--primary" onClick={onPrimary} disabled={saving || primaryBlocked}>
             {saving ? 'Saving…' : PRIMARY_LABELS[guard.kind] || 'Save & continue'}
           </button>
         </div>

--- a/src/components/studio/__tests__/FormQuizPanels.test.jsx
+++ b/src/components/studio/__tests__/FormQuizPanels.test.jsx
@@ -227,3 +227,116 @@ describe('StudioQuizPanel — the editing view over verbatim storage', () => {
     );
   });
 });
+
+// ── custom questions (studio-custom-questions §4) ──────────────────────────
+import { useState } from 'react';
+import { within } from '@testing-library/react';
+
+let latestDraft = null;
+
+function DraftHarness({ v1 }) {
+  const campaign = { id: 'c1', name: 'FairPrice Voucher', type: 'lead_generation', design_config: v1 };
+  const s = useStudioDoc(campaign);
+  const [cqDraft, setCqDraft] = useState(null);
+  latestDoc = s.doc;
+  latestDraft = cqDraft;
+  if (!s.doc) return null;
+  return <FormPanel doc={s.doc} setPath={s.setPath} mut={s.mut} cqDraft={cqDraft} onCqDraftChange={setCqDraft} />;
+}
+
+describe('FormPanel — custom questions (studio-custom-questions §4)', () => {
+  const CUSTOM_PQ = {
+    enabled: true,
+    questionIds: ['language', 'c_aaa111', 'c_bbb222'],
+    requiredIds: ['c_aaa111', 'language'],
+    showZh: false,
+    custom: [
+      { id: 'c_aaa111', type: 'single', prompt: 'Showroom?', options: [{ id: 'o1', label: 'East' }, { id: 'o2', label: 'West' }] },
+      { id: 'c_bbb222', type: 'text', prompt: 'Notes?', options: [] },
+    ],
+  };
+
+  it('the preservation matrix: master toggle, library tick, and required toggle never destroy the rest of the subtree', async () => {
+    const user = userEvent.setup();
+    render(<Harness v1={{ profileQuestions: CUSTOM_PQ }} Panel={FormPanel} />);
+
+    // Master toggle OFF: requiredIds/showZh/custom all survive (the old
+    // rebuild dropped requiredIds + showZh and would have deleted custom).
+    await user.click(screen.getByRole('switch', { name: /Ask profile questions/ }));
+    expect(latestDoc.profileQuestions).toEqual({ ...CUSTOM_PQ, enabled: false });
+    await user.click(screen.getByRole('switch', { name: /Ask profile questions/ }));
+    expect(latestDoc.profileQuestions).toEqual(CUSTOM_PQ);
+
+    // Library untick: custom block untouched; the library requiredId follows.
+    await user.click(screen.getByRole('switch', { name: /Which language do you prefer/ }));
+    expect(latestDoc.profileQuestions.questionIds).toEqual(['c_aaa111', 'c_bbb222']);
+    expect(latestDoc.profileQuestions.requiredIds).toEqual(['c_aaa111']);
+    expect(latestDoc.profileQuestions.custom).toEqual(CUSTOM_PQ.custom);
+    expect(latestDoc.profileQuestions.showZh).toBe(false);
+  });
+
+  it('authoring: Add opens a page-owned draft; commit is gated on completeness; commit writes def + id atomically', async () => {
+    const user = userEvent.setup();
+    render(<DraftHarness v1={{ profileQuestions: { enabled: true, questionIds: ['language'], requiredIds: [] } }} />);
+
+    await user.click(screen.getByTestId('custom-question-add'));
+    expect(latestDraft).not.toBeNull();
+    const draftBox = screen.getByTestId('custom-question-draft');
+    expect(screen.getByTestId('custom-question-draft-commit')).toBeDisabled();
+
+    await user.type(within(draftBox).getByLabelText('Question prompt'), 'Which outlet?');
+    expect(screen.getByTestId('custom-question-draft-commit')).toBeDisabled(); // options still unlabelled
+    await user.click(within(draftBox).getByRole('button', { name: 'Short text' }));
+    expect(screen.getByTestId('custom-question-draft-commit')).toBeEnabled();
+
+    await user.click(screen.getByTestId('custom-question-draft-commit'));
+    expect(latestDraft).toBeNull();
+    expect(screen.queryByTestId('custom-question-draft')).toBeNull();
+    const custom = latestDoc.profileQuestions.custom;
+    expect(custom).toHaveLength(1);
+    expect(custom[0].type).toBe('text');
+    expect(custom[0].prompt).toBe('Which outlet?');
+    expect(latestDoc.profileQuestions.questionIds).toEqual(['language', custom[0].id]);
+  });
+
+  it('Add question is disabled at the 5-question cap — a sixth can never enter the doc', () => {
+    const five = [1, 2, 3, 4, 5].map((n) => ({ id: `c_q${n}00000`, type: 'text', prompt: `Q${n}`, options: [] }));
+    render(<DraftHarness v1={{ profileQuestions: { enabled: true, questionIds: five.map((q) => q.id), requiredIds: [], custom: five } }} />);
+    expect(screen.getByTestId('custom-question-add')).toBeDisabled();
+    expect(screen.getByText(/Limit of 5 custom questions/)).toBeTruthy();
+  });
+
+  it('delete cleans questionIds + requiredIds; reorder moves within the custom segment only', async () => {
+    const user = userEvent.setup();
+    render(<Harness v1={{ profileQuestions: CUSTOM_PQ }} Panel={FormPanel} />);
+
+    await user.click(screen.getByRole('button', { name: 'Move question 1 down' }));
+    expect(latestDoc.profileQuestions.questionIds).toEqual(['language', 'c_bbb222', 'c_aaa111']);
+    expect(latestDoc.profileQuestions.custom.map((q) => q.id)).toEqual(['c_bbb222', 'c_aaa111']);
+
+    await user.click(screen.getByRole('button', { name: 'Delete question 2' }));
+    expect(latestDoc.profileQuestions.questionIds).toEqual(['language', 'c_bbb222']);
+    expect(latestDoc.profileQuestions.requiredIds).toEqual(['language']);
+    expect(latestDoc.profileQuestions.custom.map((q) => q.id)).toEqual(['c_bbb222']);
+  });
+
+  it('an incomplete EDIT of a committed question stays local — the doc keeps the last complete value, with a badge', async () => {
+    const user = userEvent.setup();
+    render(<Harness v1={{ profileQuestions: CUSTOM_PQ }} Panel={FormPanel} />);
+    const row = screen.getByTestId('custom-question-c_aaa111');
+    const promptInput = within(row).getByLabelText('Question prompt');
+    await user.clear(promptInput);
+    expect(latestDoc.profileQuestions.custom.find((q) => q.id === 'c_aaa111').prompt).toBe('Showroom?');
+    expect(within(row).getByText('incomplete — not saved')).toBeTruthy();
+    await user.type(promptInput, 'Which branch?');
+    expect(latestDoc.profileQuestions.custom.find((q) => q.id === 'c_aaa111').prompt).toBe('Which branch?');
+  });
+
+  it('the Required toggle on a custom question writes the shared requiredIds', async () => {
+    const user = userEvent.setup();
+    render(<Harness v1={{ profileQuestions: { ...CUSTOM_PQ, requiredIds: [] } }} Panel={FormPanel} />);
+    const row = screen.getByTestId('custom-question-c_bbb222');
+    await user.click(within(row).getByRole('switch', { name: /Required/ }));
+    expect(latestDoc.profileQuestions.requiredIds).toEqual(['c_bbb222']);
+  });
+});

--- a/src/components/studio/__tests__/StudioGuardModal.test.jsx
+++ b/src/components/studio/__tests__/StudioGuardModal.test.jsx
@@ -39,3 +39,35 @@ describe('StudioGuardModal', () => {
     expect(screen.getByRole('button', { name: 'Discard changes' })).toBeDisabled();
   });
 });
+
+describe('StudioGuardModal — incomplete custom-question draft blocks the primary (studio-custom-questions §4)', () => {
+  it('disables Save & continue with the reason shown; Discard stays available', async () => {
+    const user = userEvent.setup();
+    const onPrimary = vi.fn();
+    const onDiscard = vi.fn();
+    render(
+      <StudioGuardModal
+        guard={{ kind: 'switch' }}
+        primaryBlockedReason="The custom question you are adding is incomplete — finish it in the Form panel (or discard it) before saving."
+        onPrimary={onPrimary}
+        onDiscard={onDiscard}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Save & continue' })).toBeDisabled();
+    expect(screen.getByText(/incomplete — finish it in the Form panel/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(onPrimary).not.toHaveBeenCalled();
+  });
+
+  it('no reason ⇒ primary works exactly as before', async () => {
+    const user = userEvent.setup();
+    const onPrimary = vi.fn();
+    render(
+      <StudioGuardModal guard={{ kind: 'switch' }} onPrimary={onPrimary} onDiscard={vi.fn()} onCancel={vi.fn()} />
+    );
+    await user.click(screen.getByRole('button', { name: 'Save & continue' }));
+    expect(onPrimary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/studio/__tests__/profileQuestionsModel.test.js
+++ b/src/components/studio/__tests__/profileQuestionsModel.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  commitDraftTransform,
+  draftComplete,
+  draftToDef,
+  emptyCustomQuestionDraft,
+  genCustomQuestionId,
+  mutatePQ,
+  nextOptionId,
+  transformPQ,
+} from '../profileQuestionsModel';
+import { CUSTOM_QUESTION_ID_RE, MAX_CUSTOM_QUESTIONS } from '@/lib/designConfigV2';
+
+/**
+ * The one mutation door + draft lifecycle (studio-custom-questions §4).
+ * Pure-function coverage; the panel wiring rides FormQuizPanels tests.
+ */
+
+const DEF_A = { id: 'c_aaa111', type: 'single', prompt: 'A?', options: [{ id: 'o1', label: 'x' }, { id: 'o2', label: 'y' }] };
+const DEF_B = { id: 'c_bbb222', type: 'text', prompt: 'B?', options: [] };
+
+const docWith = (pq) => ({ version: 2, profileQuestions: pq });
+
+// A mut() stand-in that applies the draft mutation to a plain object and
+// returns it (structuredClone semantics are useStudioDoc's job).
+function apply(doc, fn) {
+  let out;
+  mutatePQ((mutFn) => {
+    const d = JSON.parse(JSON.stringify(doc));
+    mutFn(d);
+    out = d;
+  }, fn);
+  return out.profileQuestions;
+}
+
+describe('transformPQ — decompose/reconstruct invariants', () => {
+  it('is idempotent on reconciled state and preserves every component (the old master-toggle loss)', () => {
+    const pq = {
+      enabled: true,
+      questionIds: ['language', 'c_aaa111'],
+      requiredIds: ['c_aaa111'],
+      showZh: false,
+      custom: [DEF_A],
+    };
+    const out = transformPQ(docWith(pq), (s) => s);
+    expect(out).toEqual(pq);
+    // toggling enabled off keeps requiredIds/showZh/custom intact
+    const off = transformPQ(docWith(pq), (s) => { s.enabled = false; return s; });
+    expect(off).toEqual({ ...pq, enabled: false });
+  });
+
+  it('reconciles a hand-edited doc on first touch: defs missing from questionIds are appended, ghosts dropped, dupes deduped', () => {
+    const messy = {
+      enabled: true,
+      questionIds: ['c_ghost9', 'c_aaa111', 'c_aaa111', 'language'],
+      requiredIds: ['c_ghost9', 'language'],
+      custom: [DEF_A, DEF_B], // B not referenced — must not be lost on touch
+    };
+    const out = transformPQ(docWith(messy), (s) => s);
+    expect(out.questionIds).toEqual(['language', 'c_aaa111', 'c_bbb222']);
+    expect(out.requiredIds).toEqual(['language']);
+    expect(out.custom).toEqual([DEF_A, DEF_B]);
+  });
+
+  it('emits library picks in canonical order first, custom after, and omits custom when empty', () => {
+    const out = transformPQ(docWith({ enabled: true, questionIds: ['pets', 'language'], requiredIds: [] }), (s) => s);
+    expect(out.questionIds).toEqual(['language', 'pets']); // canonical library order
+    expect('custom' in out).toBe(false);
+  });
+
+  it('back-to-back mutations compose (reorder after delete)', () => {
+    const pq = { enabled: true, questionIds: ['c_aaa111', 'c_bbb222'], requiredIds: [], custom: [DEF_A, DEF_B] };
+    const afterDelete = apply(docWith(pq), (s) => {
+      s.defsById.delete('c_aaa111');
+      s.customOrder = s.customOrder.filter((id) => id !== 'c_aaa111');
+      s.requiredIds = s.requiredIds.filter((id) => id !== 'c_aaa111');
+      return s;
+    });
+    expect(afterDelete.questionIds).toEqual(['c_bbb222']);
+    expect(afterDelete.custom).toEqual([DEF_B]);
+  });
+});
+
+describe('draft lifecycle', () => {
+  it('a fresh draft is incomplete; completeness needs a sanitized prompt AND (select) 2 labelled options', () => {
+    const draft = emptyCustomQuestionDraft();
+    expect(draftComplete(draft)).toBe(false);
+    expect(draftComplete({ ...draft, prompt: '  \u202E ' })).toBe(false); // control-only can never commit
+    expect(draftComplete({ ...draft, prompt: 'Q?' })).toBe(false); // options unlabelled
+    expect(draftComplete({ ...draft, prompt: 'Q?', options: [{ id: 'o1', label: 'a' }, { id: 'o2', label: ' ' }] })).toBe(false);
+    expect(draftComplete({ ...draft, prompt: 'Q?', options: [{ id: 'o1', label: 'a' }, { id: 'o2', label: 'b' }] })).toBe(true);
+    expect(draftComplete({ ...draft, type: 'text', prompt: 'Q?' })).toBe(true);
+  });
+
+  it('draftToDef writes SANITIZED values and drops unlabelled option rows', () => {
+    const def = draftToDef({
+      type: 'single',
+      prompt: '  Which?  ',
+      promptZh: ' ',
+      options: [{ id: 'o1', label: ' A ' }, { id: 'o2', label: '' }, { id: 'o3', label: 'B' }],
+    }, 'c_zzz999');
+    expect(def).toEqual({
+      id: 'c_zzz999',
+      type: 'single',
+      prompt: 'Which?',
+      options: [{ id: 'o1', label: 'A' }, { id: 'o3', label: 'B' }],
+    });
+  });
+
+  it('commitDraftTransform writes def + id atomically, flips enabled, and re-checks the cap as the belt', () => {
+    const state = transformPQNoop({ enabled: false, questionIds: [], requiredIds: [] });
+    const committed = commitDraftTransform(state, { type: 'text', prompt: 'Note?', promptZh: '', options: [] }, 'c_new001');
+    expect(committed.customOrder).toEqual(['c_new001']);
+    expect(committed.enabled).toBe(true);
+
+    // At the cap, a sixth question can never enter the doc.
+    const full = transformPQNoop({
+      enabled: true,
+      questionIds: ['c_q1', 'c_q2', 'c_q3', 'c_q4', 'c_q5'],
+      requiredIds: [],
+      custom: [1, 2, 3, 4, 5].map((n) => ({ id: `c_q${n}`, type: 'text', prompt: `Q${n}`, options: [] })),
+    });
+    expect(full.customOrder).toHaveLength(MAX_CUSTOM_QUESTIONS);
+    const blocked = commitDraftTransform(full, { type: 'text', prompt: 'Sixth', promptZh: '', options: [] }, 'c_new006');
+    expect(blocked.customOrder).toHaveLength(MAX_CUSTOM_QUESTIONS);
+    expect(blocked.defsById.has('c_new006')).toBe(false);
+  });
+});
+
+describe('id generation', () => {
+  it('genCustomQuestionId matches the shared pattern and avoids collisions', () => {
+    const existing = ['c_aaa111'];
+    const seen = new Set(existing);
+    for (let i = 0; i < 200; i += 1) {
+      const id = genCustomQuestionId([...seen]);
+      expect(CUSTOM_QUESTION_ID_RE.test(id)).toBe(true);
+      expect(seen.has(id)).toBe(false);
+      seen.add(id);
+    }
+  });
+
+  it('nextOptionId allocates the first unused oN', () => {
+    expect(nextOptionId([])).toBe('o1');
+    expect(nextOptionId([{ id: 'o1' }, { id: 'o3' }])).toBe('o2');
+  });
+});
+
+// Decompose helper for tests that need a raw state object.
+function transformPQNoop(pq) {
+  let captured;
+  transformPQ(docWith(pq), (s) => {
+    captured = s;
+    return s;
+  });
+  return captured;
+}

--- a/src/components/studio/__tests__/useStudioAi.test.jsx
+++ b/src/components/studio/__tests__/useStudioAi.test.jsx
@@ -1105,3 +1105,43 @@ describe('useStudioAi — draw T&Cs never contradict the channel in the same res
     expect(termsRow.value.html).toContain('one-time SMS code');
   });
 });
+
+describe('useStudioAi — profileQuestions graft (studio-custom-questions §5b)', () => {
+  const PQ = {
+    enabled: true,
+    questionIds: ['c_abc123'],
+    requiredIds: [],
+    showZh: true,
+    custom: [{ id: 'c_abc123', type: 'text', prompt: 'Note?', options: [] }],
+  };
+
+  it('a question edit made DURING a proposal survives revert (the whole-doc restore grafts the live subtree)', async () => {
+    const { result } = renderAi();
+    await looksReady(result);
+    act(() => result.current.ai.pickLook(0));
+    act(() => result.current.docApi.mut((d) => { d.profileQuestions = PQ; }));
+    act(() => result.current.ai.revertLook());
+    expect(result.current.docApi.doc.profileQuestions).toEqual(PQ);
+  });
+
+  it('the edit also survives a re-pick and a keep-toggle (every replacement site grafts)', async () => {
+    const { result } = renderAi();
+    await looksReady(result, [LOOK, LOOK]);
+    act(() => result.current.ai.pickLook(0));
+    act(() => result.current.docApi.mut((d) => { d.profileQuestions = PQ; }));
+    act(() => result.current.ai.pickLook(1));
+    expect(result.current.docApi.doc.profileQuestions).toEqual(PQ);
+    act(() => result.current.ai.toggleKeep('copy'));
+    expect(result.current.docApi.doc.profileQuestions).toEqual(PQ);
+    act(() => result.current.ai.revertLook());
+    expect(result.current.docApi.doc.profileQuestions).toEqual(PQ);
+  });
+
+  it('a pick can never INTRODUCE profileQuestions the live doc does not carry', async () => {
+    const { result } = renderAi();
+    await looksReady(result);
+    expect(result.current.docApi.doc.profileQuestions).toBeUndefined();
+    act(() => result.current.ai.pickLook(0));
+    expect(result.current.docApi.doc.profileQuestions).toBeUndefined();
+  });
+});

--- a/src/components/studio/__tests__/useStudioDoc.test.js
+++ b/src/components/studio/__tests__/useStudioDoc.test.js
@@ -259,3 +259,50 @@ describe('sanity — twins agreement', () => {
     expect(isV2(result.current.doc)).toBe(true);
   });
 });
+
+describe('useStudioDoc — save with an explicit snapshot (studio-custom-questions §4)', () => {
+  it('PUTs the OVERRIDE doc (not the render-captured one) and the adoption identity still holds', async () => {
+    const campaign = v2Campaign();
+    const { result } = renderHook(() => useStudioDoc(campaign));
+    const committed = {
+      ...result.current.doc,
+      profileQuestions: {
+        enabled: true,
+        questionIds: ['c_new001'],
+        requiredIds: [],
+        showZh: true,
+        custom: [{ id: 'c_new001', type: 'text', prompt: 'Note?', options: [] }],
+      },
+    };
+    Campaign.update.mockResolvedValue({ id: 'c2', design_config: committed });
+
+    let res;
+    await act(async () => {
+      // The guard handler derives the committed doc synchronously and hands
+      // the SAME reference to save — the PUT body must be the committed doc.
+      res = await result.current.save({}, { snapshot: committed });
+    });
+    expect(res.ok).toBe(true);
+    expect(Campaign.update).toHaveBeenCalledWith('c2', { design_config: committed });
+    // No intervening edit → the server doc is adopted as the working doc
+    // (prev === snapshot reference identity survived the override path).
+    expect(result.current.doc.profileQuestions.custom[0].id).toBe('c_new001');
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('the draw invariant runs against the OVERRIDE doc', async () => {
+    const campaign = v2Campaign();
+    const { result } = renderHook(() => useStudioDoc(campaign));
+    const badDraw = {
+      ...result.current.doc,
+      luckyDraw: { enabled: true, closesAt: 'not-a-date' },
+    };
+    let res;
+    await act(async () => {
+      res = await result.current.save({}, { snapshot: badDraw });
+    });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('draw-invariant');
+    expect(Campaign.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/studio/panels/FormPanel.jsx
+++ b/src/components/studio/panels/FormPanel.jsx
@@ -1,6 +1,17 @@
+import { useState } from 'react';
 import { makeBind, PanelSection, TextField, TextAreaField, Seg, ToggleRow, WarnNote } from './panelKit';
-import { PROFILE_QUESTION_LIBRARY, PROFILE_QUESTION_IDS, getProfileQuestion } from '@/lib/profileQuestionLibrary';
+import { PROFILE_QUESTION_LIBRARY, getProfileQuestion } from '@/lib/profileQuestionLibrary';
 import { suggestProfileQuestions } from '@/lib/campaignBrief';
+import { LIMITS, MAX_CUSTOM_OPTIONS, MAX_CUSTOM_QUESTIONS, sanitizeQuestionText } from '@/lib/designConfigV2';
+import {
+  commitDraftTransform,
+  draftComplete,
+  draftToDef,
+  emptyCustomQuestionDraft,
+  genCustomQuestionId,
+  mutatePQ,
+  nextOptionId,
+} from '../profileQuestionsModel';
 
 /**
  * Form panel (Studio PR 3) — fields order/visibility/required with 2-col
@@ -33,23 +44,30 @@ const pairId = () => `row-${Date.now().toString(36)}${(pairCounter += 1)}`;
 // §6.4) — drives the SUGGESTED profile questions below. Suggestions are
 // one-click adds, never auto-applied: enabling a question changes a live
 // funnel's conversion, and that stays a human decision.
-export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, campaignBrief }) {
+export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, campaignBrief, cqDraft, onCqDraftChange }) {
   const bind = makeBind(doc, setPath);
   const fields = doc.form?.fields || [];
   const gates = doc.form?.gates || {};
   const verification = doc.form?.verification === 'whatsapp' ? 'whatsapp' : 'sms';
   const askedIds = doc.profileQuestions?.questionIds || [];
   const suggestions = suggestProfileQuestions(campaignBrief).filter((s) => !askedIds.includes(s.id));
+  const customDefs = (Array.isArray(doc.profileQuestions?.custom) ? doc.profileQuestions.custom : [])
+    .filter((q) => q && typeof q === 'object' && typeof q.id === 'string');
 
-  const addSuggestedQuestion = (id) => mut((d) => {
-    const cur = d.profileQuestions || {};
-    const set = new Set([...(cur.questionIds || []), id]);
-    d.profileQuestions = {
-      ...cur,
-      enabled: true, // the click is the human decision — it may switch the section on
-      questionIds: PROFILE_QUESTION_IDS.filter((qid) => set.has(qid)),
-      requiredIds: (cur.requiredIds || []).filter((qid) => set.has(qid)),
-    };
+  // Incomplete EDITS of committed questions stay panel-local (badge shows;
+  // the last complete value stays in the doc — studio-custom-questions §4).
+  // NEW-question drafts live one level up (the Studio page owns cqDraft, so a
+  // rail switch can't destroy them).
+  const [editBuffers, setEditBuffers] = useState({});
+
+  // Every profileQuestions write goes through the ONE mutation door
+  // (profileQuestionsModel.mutatePQ) — the old per-site rebuilds were lossy
+  // (the master toggle dropped requiredIds/showZh; library/suggestion writes
+  // would have deleted custom state).
+  const addSuggestedQuestion = (id) => mutatePQ(mut, (s) => {
+    s.enabled = true; // the click is the human decision — it may switch the section on
+    if (!s.libraryPicks.includes(id)) s.libraryPicks.push(id);
+    return s;
   });
 
   const mutFields = (fn) => mut((d) => fn(d.form.fields));
@@ -203,22 +221,21 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
       </PanelSection>
 
       <PanelSection title="PROFILE QUESTIONS">
-        {/* Enrichment collection block (studio-profile-questions §3): fixed
-            library only — admins pick, never author; answers are structured
-            choices that build the customer profile. All skippable on the
-            funnel. The AI Fill-everything flow never enables this on its
-            own (conversion-vs-data is the owner's per-campaign call). */}
+        {/* Enrichment collection block (studio-profile-questions §3): library
+            questions are PICKED (structured choices that build the customer
+            profile); custom questions below are AUTHORED and display-only
+            (studio-custom-questions §1 — answers land on the lead, never the
+            fact ledger). All skippable on the funnel unless marked required.
+            The AI Fill-everything flow never enables or authors any of this
+            (conversion-vs-data is the owner's per-campaign call). */}
         <ToggleRow
           id="studio-profile-questions"
           label="Ask profile questions"
           hint="Optional questions after the signup fields — answers build the customer profile"
           checked={doc.profileQuestions?.enabled === true}
-          onChange={(v) => mut((d) => {
-            const cur = d.profileQuestions || {};
-            d.profileQuestions = {
-              enabled: v === true,
-              questionIds: Array.isArray(cur.questionIds) ? cur.questionIds : [],
-            };
+          onChange={(v) => mutatePQ(mut, (s) => {
+            s.enabled = v === true;
+            return s;
           })}
         />
         {suggestions.length > 0 && (
@@ -258,8 +275,9 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
             label="Show Chinese text"
             hint="Off = English-only prompts on the funnel"
             checked={doc.profileQuestions?.showZh !== false}
-            onChange={(v) => mut((d) => {
-              d.profileQuestions = { ...(d.profileQuestions || { enabled: true, questionIds: [] }), showZh: v === true };
+            onChange={(v) => mutatePQ(mut, (s) => {
+              s.showZh = v === true;
+              return s;
             })}
           />
         )}
@@ -272,15 +290,12 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
                 label={q.prompt}
                 hint={q.promptZh}
                 checked={asked}
-                onChange={(v) => mut((d) => {
-                  const cur = d.profileQuestions || { enabled: true, questionIds: [] };
-                  const set = new Set(cur.questionIds || []);
-                  if (v) set.add(q.id); else set.delete(q.id);
-                  // Canonical library order, deduped — mirrors the clamp,
-                  // which also drops a requiredId whose question is unasked.
-                  const questionIds = PROFILE_QUESTION_IDS.filter((id) => set.has(id));
-                  const requiredIds = (cur.requiredIds || []).filter((id) => questionIds.includes(id));
-                  d.profileQuestions = { ...cur, questionIds, requiredIds };
+                onChange={(v) => mutatePQ(mut, (s) => {
+                  // Canonical library order is reconstruction's job; the clamp
+                  // also drops a requiredId whose question is unasked.
+                  s.libraryPicks = s.libraryPicks.filter((id) => id !== q.id);
+                  if (v) s.libraryPicks.push(q.id);
+                  return s;
                 })}
               />
               {asked && (
@@ -290,14 +305,10 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
                     label="Required"
                     hint="Signup blocked until answered (this campaign only)"
                     checked={(doc.profileQuestions?.requiredIds || []).includes(q.id)}
-                    onChange={(v) => mut((d) => {
-                      const cur = d.profileQuestions || { enabled: true, questionIds: [] };
-                      const set = new Set(cur.requiredIds || []);
-                      if (v) set.add(q.id); else set.delete(q.id);
-                      d.profileQuestions = {
-                        ...cur,
-                        requiredIds: PROFILE_QUESTION_IDS.filter((id) => set.has(id) && (cur.questionIds || []).includes(id)),
-                      };
+                    onChange={(v) => mutatePQ(mut, (s) => {
+                      s.requiredIds = s.requiredIds.filter((id) => id !== q.id);
+                      if (v) s.requiredIds.push(q.id);
+                      return s;
                     })}
                   />
                 </div>
@@ -305,6 +316,17 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
             </div>
           );
         })}
+        {doc.profileQuestions?.enabled === true && (
+          <CustomQuestionsBlock
+            mut={mut}
+            customDefs={customDefs}
+            requiredIds={doc.profileQuestions?.requiredIds || []}
+            editBuffers={editBuffers}
+            setEditBuffers={setEditBuffers}
+            cqDraft={cqDraft}
+            onCqDraftChange={onCqDraftChange}
+          />
+        )}
       </PanelSection>
 
       <PanelSection title="ELIGIBILITY GATES">
@@ -380,6 +402,264 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
           the platform and is not editable here.
         </p>
       </PanelSection>
+    </div>
+  );
+}
+
+// ─────────────── custom questions (studio-custom-questions §4) ───────────────
+
+const cqInputStyle = {
+  width: '100%',
+  boxSizing: 'border-box',
+  height: 30,
+  padding: '0 9px',
+  borderRadius: 8,
+  border: '1px solid var(--line-strong, #C6CAD2)',
+  background: 'var(--surface, #fff)',
+  color: 'var(--ink, #171A20)',
+  fontSize: 12,
+};
+
+const cqSubLabel = { fontSize: 10, fontWeight: 700, letterSpacing: 0.4, color: 'var(--ink-3, #9BA0AB)' };
+
+function defToDraft(def) {
+  return {
+    type: def.type === 'multi' || def.type === 'text' ? def.type : 'single',
+    prompt: def.prompt || '',
+    promptZh: def.promptZh || '',
+    options: (Array.isArray(def.options) ? def.options : []).map((o) => ({
+      id: o.id,
+      label: o.label || '',
+      ...(o.labelZh ? { labelZh: o.labelZh } : {}),
+    })),
+  };
+}
+
+/** One controlled editor for both the NEW-question draft and committed-question
+ * edits — prompt, optional 中文 prompt, answer style, options. */
+function CustomQuestionEditor({ idPrefix, value, onChange }) {
+  const set = (patch) => onChange({ ...value, ...patch });
+  const setType = (type) => {
+    let options = Array.isArray(value.options) ? [...value.options] : [];
+    if (type !== 'text') {
+      while (options.length < 2) options = [...options, { id: nextOptionId(options), label: '' }];
+    }
+    onChange({ ...value, type, options });
+  };
+  const options = Array.isArray(value.options) ? value.options : [];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <input
+        id={`${idPrefix}-prompt`}
+        type="text"
+        aria-label="Question prompt"
+        placeholder="e.g. Which showroom is closer to you?"
+        maxLength={LIMITS.cqPrompt}
+        style={cqInputStyle}
+        value={value.prompt}
+        onChange={(e) => set({ prompt: e.target.value })}
+      />
+      <input
+        id={`${idPrefix}-prompt-zh`}
+        type="text"
+        aria-label="Question prompt (Chinese, optional)"
+        placeholder="中文提问（可选）"
+        maxLength={LIMITS.cqPrompt}
+        style={cqInputStyle}
+        value={value.promptZh}
+        onChange={(e) => set({ promptZh: e.target.value })}
+      />
+      <Seg
+        ariaLabel="Answer style"
+        options={[
+          { value: 'single', label: 'One choice' },
+          { value: 'multi', label: 'Multi' },
+          { value: 'text', label: 'Short text' },
+        ]}
+        value={value.type}
+        onChange={setType}
+      />
+      {value.type !== 'text' && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {options.map((opt, i) => (
+            <div key={opt.id} style={{ display: 'flex', gap: 4 }}>
+              <input
+                type="text"
+                aria-label={`Option ${i + 1} label`}
+                placeholder={`Option ${i + 1}`}
+                maxLength={LIMITS.cqOption}
+                style={{ ...cqInputStyle, flex: 1 }}
+                value={opt.label}
+                onChange={(e) => set({
+                  options: options.map((o) => (o.id === opt.id ? { ...o, label: e.target.value } : o)),
+                })}
+              />
+              <button
+                type="button"
+                aria-label={`Remove option ${i + 1}`}
+                className="av2-btn av2-btn--ghost av2-btn--sm"
+                onClick={() => set({ options: options.filter((o) => o.id !== opt.id) })}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="av2-btn av2-btn--ghost av2-btn--sm"
+            disabled={options.length >= MAX_CUSTOM_OPTIONS}
+            onClick={() => set({ options: [...options, { id: nextOptionId(options), label: '' }] })}
+          >
+            + Add option{options.length >= MAX_CUSTOM_OPTIONS ? ` (max ${MAX_CUSTOM_OPTIONS})` : ''}
+          </button>
+        </div>
+      )}
+      {value.type === 'text' && (
+        <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3, #9BA0AB)' }}>
+          Customers type a short answer (200 characters max).
+        </p>
+      )}
+    </div>
+  );
+}
+
+function CustomQuestionsBlock({ mut, customDefs, requiredIds, editBuffers, setEditBuffers, cqDraft, onCqDraftChange }) {
+  const atCap = customDefs.length >= MAX_CUSTOM_QUESTIONS;
+
+  const commitDraft = () => {
+    if (!draftComplete(cqDraft) || atCap) return;
+    const qid = genCustomQuestionId(customDefs.map((q) => q.id));
+    mutatePQ(mut, (s) => commitDraftTransform(s, cqDraft, qid));
+    onCqDraftChange?.(null);
+  };
+
+  const move = (qid, delta) => mutatePQ(mut, (s) => {
+    const i = s.customOrder.indexOf(qid);
+    const j = i + delta;
+    if (i < 0 || j < 0 || j >= s.customOrder.length) return s;
+    [s.customOrder[i], s.customOrder[j]] = [s.customOrder[j], s.customOrder[i]];
+    return s;
+  });
+
+  const remove = (qid) => {
+    mutatePQ(mut, (s) => {
+      s.defsById.delete(qid);
+      s.customOrder = s.customOrder.filter((id) => id !== qid);
+      s.requiredIds = s.requiredIds.filter((id) => id !== qid);
+      return s;
+    });
+    setEditBuffers((prev) => {
+      const { [qid]: _gone, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  return (
+    <div
+      data-testid="custom-questions-block"
+      style={{ borderTop: '1px dashed var(--line-strong, #C6CAD2)', paddingTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}
+    >
+      <span style={cqSubLabel}>YOUR OWN QUESTIONS</span>
+      <p style={{ margin: 0, fontSize: 10.5, color: 'var(--ink-3, #9BA0AB)' }}>
+        Campaign-specific questions, shown after the profile questions. Answers appear on the lead — they never feed
+        lead scoring or the customer profile.
+      </p>
+      {customDefs.map((def, i) => {
+        const buffer = editBuffers[def.id];
+        const editorValue = buffer || defToDraft(def);
+        const incomplete = buffer && !draftComplete(buffer);
+        return (
+          <div
+            key={def.id}
+            data-testid={`custom-question-${def.id}`}
+            style={{ border: '1px solid var(--line, #E3E6EB)', borderRadius: 8, padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ flex: 1, minWidth: 0, fontSize: 11, fontWeight: 700, color: 'var(--ink-2, #5B616E)' }}>
+                Question {i + 1}
+                {incomplete ? (
+                  <span style={{ marginLeft: 6, fontWeight: 600, color: '#B97D10' }}>incomplete — not saved</span>
+                ) : null}
+              </span>
+              <button type="button" aria-label={`Move question ${i + 1} up`} disabled={i === 0} className="av2-btn av2-btn--ghost av2-btn--sm" onClick={() => move(def.id, -1)}>↑</button>
+              <button type="button" aria-label={`Move question ${i + 1} down`} disabled={i === customDefs.length - 1} className="av2-btn av2-btn--ghost av2-btn--sm" onClick={() => move(def.id, 1)}>↓</button>
+              <button type="button" aria-label={`Delete question ${i + 1}`} className="av2-btn av2-btn--ghost av2-btn--sm" onClick={() => remove(def.id)}>Delete</button>
+            </div>
+            <CustomQuestionEditor
+              idPrefix={`studio-cq-${def.id}`}
+              value={editorValue}
+              onChange={(candidate) => {
+                // Incomplete edits stay panel-local; complete edits write
+                // through the mutation door with SANITIZED values, so the doc
+                // always holds the last complete state (§4).
+                setEditBuffers((prev) => ({ ...prev, [def.id]: candidate }));
+                if (draftComplete(candidate)) {
+                  mutatePQ(mut, (s) => {
+                    s.defsById.set(def.id, draftToDef(candidate, def.id));
+                    return s;
+                  });
+                }
+              }}
+            />
+            <ToggleRow
+              id={`studio-cq-${def.id}-required`}
+              label="Required"
+              hint="Signup blocked until answered (this campaign only)"
+              checked={requiredIds.includes(def.id)}
+              onChange={(v) => mutatePQ(mut, (s) => {
+                s.requiredIds = s.requiredIds.filter((id) => id !== def.id);
+                if (v) s.requiredIds.push(def.id);
+                return s;
+              })}
+            />
+          </div>
+        );
+      })}
+      {cqDraft ? (
+        <div
+          data-testid="custom-question-draft"
+          style={{ border: '1px dashed var(--accent, #4059C8)', borderRadius: 8, padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
+          <span style={cqSubLabel}>NEW QUESTION — NOT SAVED YET</span>
+          <CustomQuestionEditor idPrefix="studio-cq-draft" value={cqDraft} onChange={(v) => onCqDraftChange?.(v)} />
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <button
+              type="button"
+              className="av2-btn av2-btn--sm"
+              data-testid="custom-question-draft-commit"
+              disabled={!draftComplete(cqDraft) || atCap}
+              onClick={commitDraft}
+            >
+              Add to form
+            </button>
+            <button type="button" className="av2-btn av2-btn--ghost av2-btn--sm" onClick={() => onCqDraftChange?.(null)}>
+              Discard
+            </button>
+            {!draftComplete(cqDraft) ? (
+              <span style={{ fontSize: 10.5, color: '#B97D10' }}>
+                {sanitizeQuestionText(cqDraft.prompt, LIMITS.cqPrompt) ? 'Needs 2 labelled options' : 'Needs a prompt'}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : (
+        <div>
+          <button
+            type="button"
+            className="av2-btn av2-btn--ghost av2-btn--sm"
+            data-testid="custom-question-add"
+            disabled={atCap}
+            onClick={() => onCqDraftChange?.(emptyCustomQuestionDraft())}
+          >
+            + Add question
+          </button>
+          {atCap ? (
+            <p style={{ margin: '4px 0 0', fontSize: 10.5, color: 'var(--ink-3, #9BA0AB)' }}>
+              Limit of {MAX_CUSTOM_QUESTIONS} custom questions — delete one to add another.
+            </p>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/studio/profileQuestionsModel.js
+++ b/src/components/studio/profileQuestionsModel.js
@@ -1,0 +1,165 @@
+import {
+  CUSTOM_QUESTION_ID_RE,
+  LIMITS,
+  MAX_CUSTOM_OPTIONS,
+  MAX_CUSTOM_QUESTIONS,
+  sanitizeQuestionText,
+} from '@/lib/designConfigV2';
+import { PROFILE_QUESTION_IDS } from '@/lib/profileQuestionLibrary';
+
+/**
+ * The ONE mutation door for the profileQuestions subtree
+ * (studio-custom-questions §4, Codex R1 #2 / R2 #4).
+ *
+ * Every FormPanel mutation used to rebuild the subtree by hand and each site
+ * was lossy in its own way (the master toggle dropped requiredIds/showZh; the
+ * library tick and brief-suggestion rebuilds would have deleted custom state).
+ * All writes now decompose → transform → reconstruct through here.
+ *
+ * `transformPQ` is the PURE core: it also serves the guard's
+ * "Save & continue" path, which must derive the post-commit doc SYNCHRONOUSLY
+ * and hand the same object to setDoc and save (§4 snapshot rule) — a mut()-only
+ * API cannot do that.
+ *
+ * Read-side reconciliation (R2 new #4): customOrder = questionIds ∩ defs,
+ * deduped, with defs never referenced appended at the end — a hand-edited doc
+ * must not lose data on its first touch. Reconstruction emits defs ONLY for
+ * ordered ids, requiredIds filtered to membership, library picks in canonical
+ * library order first, custom after. Idempotent on reconciled state.
+ */
+export function transformPQ(doc, fn) {
+  const cur = doc?.profileQuestions && typeof doc.profileQuestions === 'object'
+    ? doc.profileQuestions
+    : {};
+  const defsIn = (Array.isArray(cur.custom) ? cur.custom : [])
+    .filter((q) => q && typeof q === 'object' && typeof q.id === 'string');
+  const defsById = new Map(defsIn.map((q) => [q.id, q]));
+  const idsIn = Array.isArray(cur.questionIds) ? cur.questionIds : [];
+  const customOrder = [];
+  for (const id of idsIn) {
+    if (defsById.has(id) && !customOrder.includes(id)) customOrder.push(id);
+  }
+  for (const q of defsIn) {
+    if (!customOrder.includes(q.id)) customOrder.push(q.id);
+  }
+  const state = {
+    enabled: cur.enabled === true,
+    libraryPicks: idsIn.filter((id) => PROFILE_QUESTION_IDS.includes(id)),
+    defsById,
+    customOrder,
+    requiredIds: Array.isArray(cur.requiredIds) ? [...cur.requiredIds] : [],
+    showZh: cur.showZh !== false,
+  };
+  const next = fn(state) || state;
+  const libraryIds = PROFILE_QUESTION_IDS.filter((id) => next.libraryPicks.includes(id));
+  const orderedCustom = next.customOrder.filter(
+    (id, i) => next.defsById.has(id) && next.customOrder.indexOf(id) === i
+  );
+  const questionIds = [...libraryIds, ...orderedCustom];
+  return {
+    enabled: next.enabled === true,
+    questionIds,
+    requiredIds: next.requiredIds.filter(
+      (id, i) => questionIds.includes(id) && next.requiredIds.indexOf(id) === i
+    ),
+    showZh: next.showZh !== false,
+    ...(orderedCustom.length
+      ? { custom: orderedCustom.map((id) => next.defsById.get(id)) }
+      : {}),
+  };
+}
+
+/** The mut()-flavored wrapper every FormPanel mutation site uses. */
+export function mutatePQ(mut, fn) {
+  mut((d) => {
+    d.profileQuestions = transformPQ(d, fn);
+  });
+}
+
+// ─────────────────────────── draft lifecycle (§4) ───────────────────────────
+
+/** A NEW question lives as an editor-local draft (owned by the Studio PAGE,
+ * not the panel — the rail unmounts inactive panels) until minimally
+ * complete; only the commit writes the doc. */
+export function emptyCustomQuestionDraft() {
+  return {
+    type: 'single',
+    prompt: '',
+    promptZh: '',
+    options: [
+      { id: 'o1', label: '' },
+      { id: 'o2', label: '' },
+    ],
+  };
+}
+
+/** Completeness uses the SERVER'S OWN sanitizer (Codex R2 closure #4) — a
+ * value sanitizeQuestionText empties (whitespace, control chars) can never
+ * commit, then vanish in the clamp. */
+export function draftComplete(draft) {
+  if (!draft || typeof draft !== 'object') return false;
+  if (!sanitizeQuestionText(draft.prompt, LIMITS.cqPrompt)) return false;
+  if (draft.type === 'text') return true;
+  const labeled = (Array.isArray(draft.options) ? draft.options : [])
+    .filter((o) => o && sanitizeQuestionText(o.label, LIMITS.cqOption));
+  return labeled.length >= 2;
+}
+
+/** Sanitized def from a complete draft — the commit writes THESE values, so
+ * panel-authored content is clamp-stable by construction. */
+export function draftToDef(draft, id) {
+  const promptZh = sanitizeQuestionText(draft.promptZh, LIMITS.cqPrompt);
+  const options = draft.type === 'text'
+    ? []
+    : (Array.isArray(draft.options) ? draft.options : [])
+      .filter((o) => o && sanitizeQuestionText(o.label, LIMITS.cqOption))
+      .slice(0, MAX_CUSTOM_OPTIONS)
+      .map((o) => {
+        const labelZh = sanitizeQuestionText(o.labelZh, LIMITS.cqOption);
+        return {
+          id: o.id,
+          label: sanitizeQuestionText(o.label, LIMITS.cqOption),
+          ...(labelZh ? { labelZh } : {}),
+        };
+      });
+  return {
+    id,
+    type: draft.type === 'multi' || draft.type === 'text' ? draft.type : 'single',
+    prompt: sanitizeQuestionText(draft.prompt, LIMITS.cqPrompt),
+    ...(promptZh ? { promptZh } : {}),
+    options,
+  };
+}
+
+/** Collision-checked random id matching CUSTOM_QUESTION_ID_RE (R1 #8). */
+export function genCustomQuestionId(existingIds) {
+  const taken = new Set(existingIds || []);
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const id = `c_${Math.random().toString(36).slice(2, 8).padEnd(6, '0')}`;
+    if (CUSTOM_QUESTION_ID_RE.test(id) && !taken.has(id)) return id;
+  }
+  // Deterministic fallback — counter past the collision set.
+  let n = taken.size + 1;
+  while (taken.has(`c_q${n}`)) n += 1;
+  return `c_q${n}`;
+}
+
+/** First unused oN option id within one question (R1 #8). */
+export function nextOptionId(options) {
+  const taken = new Set((options || []).map((o) => o?.id));
+  let n = 1;
+  while (taken.has(`o${n}`)) n += 1;
+  return `o${n}`;
+}
+
+/** The state-transform the draft commit applies (used by BOTH the panel's
+ * commit button and the guard's Save-and-continue path): writes the def AND
+ * appends its id atomically; re-checks the cap as the belt (R3 new #1). */
+export function commitDraftTransform(state, draft, id) {
+  if (state.customOrder.length >= MAX_CUSTOM_QUESTIONS) return state;
+  if (!draftComplete(draft)) return state;
+  state.defsById.set(id, draftToDef(draft, id));
+  state.customOrder.push(id);
+  state.enabled = true;
+  return state;
+}

--- a/src/components/studio/useStudioAi.js
+++ b/src/components/studio/useStudioAi.js
@@ -677,6 +677,23 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
     [campaign?.id, templateId, briefOrName, startRequest, noteCall, fail]
   );
 
+  /** profileQuestions is never the AI's to change, in EITHER direction
+   * (studio-custom-questions §5b): every whole-doc replacement this hook
+   * performs — pick, re-pick, keep-toggle, revert — grafts the LIVE doc's
+   * subtree over the replacement, so a question edit made before or during a
+   * proposal can never be destroyed by an AI interaction. */
+  const withLivePQ = useCallback((nextDoc) => {
+    if (!nextDoc || typeof nextDoc !== 'object') return nextDoc;
+    const live = docRef.current;
+    const out = { ...nextDoc };
+    if (live && typeof live === 'object' && 'profileQuestions' in live) {
+      out.profileQuestions = clone(live.profileQuestions);
+    } else {
+      delete out.profileQuestions;
+    }
+    return out;
+  }, []);
+
   /** Use this look — whole-doc swap built from the pre-proposal doc. */
   const pickLook = useCallback(
     (index) => {
@@ -685,7 +702,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       const baseDoc = proposalRef.current ? proposalRef.current.prev.doc : clone(docRef.current);
       if (lookBlockedReason(docRef.current, look)) return; // belt — the button is disabled with the reason
       const keep = { template: false, theme: false, copy: false };
-      replaceDoc(buildLookDoc(baseDoc, look, keep));
+      replaceDoc(withLivePQ(buildLookDoc(baseDoc, look, keep)));
       setProposal({ prev: { doc: baseDoc }, look, keep, adopted: false });
       setMediaHint(look.media?.note ? { kind: look.media.kind || 'none', note: look.media.note } : null);
       setSugs([]);
@@ -694,7 +711,7 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       setPhase('proposal');
       onPickLookRef.current?.(); // F12: subject → page, jump cleared, funnel remount
     },
-    [replaceDoc]
+    [replaceDoc, withLivePQ]
   );
 
   /** Keep-my-template/theme/copy — rebuild the doc from prev with the toggle. */
@@ -703,10 +720,10 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
       const p = proposalRef.current;
       if (!p || p.adopted) return;
       const keep = { ...p.keep, [key]: !p.keep[key] };
-      replaceDoc(buildLookDoc(p.prev.doc, p.look, keep));
+      replaceDoc(withLivePQ(buildLookDoc(p.prev.doc, p.look, keep)));
       setProposal({ ...p, keep });
     },
-    [replaceDoc]
+    [replaceDoc, withLivePQ]
   );
 
   /** Discard / ↩ Revert look — restore the pre-proposal doc (works before AND
@@ -714,13 +731,13 @@ export default function useStudioAi({ campaign, doc, setPath, replaceDoc, onPick
   const revertLook = useCallback(() => {
     const p = proposalRef.current;
     if (!p || !replaceDoc) return;
-    replaceDoc(p.prev.doc);
+    replaceDoc(withLivePQ(p.prev.doc));
     setProposal(null);
     setMediaHint(null);
     setSugs([]);
     setScope(null);
     setPhase(looksRef.current.length ? 'looks' : 'brief');
-  }, [replaceDoc]);
+  }, [replaceDoc, withLivePQ]);
 
   /** Adopt — all-three-kept is a no-op discard (F9); otherwise the look's
    * landed copy becomes an `applied` review list (old = pre-look values),

--- a/src/components/studio/useStudioDoc.js
+++ b/src/components/studio/useStudioDoc.js
@@ -159,16 +159,25 @@ export default function useStudioDoc(campaign) {
   // `extra` merges into the PUT body — the guard modal's "Save & continue"
   // passes { slug } when a slug draft is pending so nothing is silently lost
   // (slug is a campaign column; same endpoint, own field).
-  const save = useCallback(async (extra = {}) => {
-    if (!doc || !campaign?.id || saving) return { ok: false, reason: 'busy' };
-    const drawProblem = drawInvariantProblem(doc);
+  //
+  // `opts.snapshot` (studio-custom-questions §4): an explicit post-commit doc
+  // to persist. `mut()` schedules setDoc while this closure captures the doc
+  // of the CURRENT render — so "commit then save()" would PUT the pre-commit
+  // doc. A caller that just derived the committed doc synchronously passes it
+  // here; we adopt it as state with the SAME reference (no clone), so the
+  // in-flight-edit adoption below (`prev === snapshot`) still holds.
+  const save = useCallback(async (extra = {}, { snapshot: snapshotOverride } = {}) => {
+    const base = snapshotOverride && typeof snapshotOverride === 'object' ? snapshotOverride : doc;
+    if (!base || !campaign?.id || saving) return { ok: false, reason: 'busy' };
+    const drawProblem = drawInvariantProblem(base);
     if (drawProblem) {
       setSaveError({ kind: 'draw-invariant', section: 'form', ...drawProblem });
       return { ok: false, reason: 'draw-invariant', problem: drawProblem };
     }
     setSaving(true);
     setSaveError(null);
-    const snapshot = doc;
+    const snapshot = base;
+    if (snapshotOverride) setDoc(snapshot);
     try {
       const updated = await Campaign.update(campaign.id, { design_config: snapshot, ...extra });
       const serverDoc = updated?.design_config;

--- a/src/lib/__tests__/designConfigV2.lockstep.test.js
+++ b/src/lib/__tests__/designConfigV2.lockstep.test.js
@@ -17,6 +17,10 @@ const CONSTANT_EXPORTS = [
   'PRESET_IDS', 'LIMITS', 'FIELD_IDS', 'LOCKED_FIELD_IDS', 'V1_TO_V2_FIELD_ID',
   'V2_TO_V1_FIELD_ID', 'MARKETPLACE_V1_TO_V2', 'V1_CONSUMED_KEYS', 'V2_TOP_KEYS',
   'QR_V1_TO_V2', 'QR_V2_TO_V1',
+  // Custom profile questions (studio-custom-questions §2). RegExp constants
+  // compare by source+flags under toEqual, so drift still fails the build.
+  'MAX_CUSTOM_QUESTIONS', 'MAX_TOTAL_PROFILE_QUESTIONS', 'MAX_CUSTOM_OPTIONS',
+  'CUSTOM_QUESTION_ID_RE', 'CUSTOM_OPTION_ID_RE', 'CUSTOM_ANSWER_TEXT_MAX',
 ];
 
 const FUNCTION_EXPORTS = [
@@ -24,6 +28,7 @@ const FUNCTION_EXPORTS = [
   'downgradeDesignConfig', 'readLegacyView', 'resolveTheme', 'defaultFields',
   'fieldsFromV1', 'fieldsToV1', 'marketplaceToV1', 'nearestPresetForAccent',
   'onColor', 'youTubeIdFrom', 'getMarketplaceListedFromDoc',
+  'sanitizeQuestionText',
 ];
 
 describe('designConfigV2 twins — constant drift', () => {
@@ -196,5 +201,66 @@ describe('L7 — content.submitFontSize is v2-only in BOTH twins', () => {
         expect(twin.upgradeDesignConfig(v1).content?.submitFontSize).toBeUndefined();
       }
     }
+  });
+});
+
+describe('designConfigV2 twins — sanitizeQuestionText behavioral parity (studio-custom-questions §2)', () => {
+  const HOSTILE = [
+    '  plain  ',
+    'ok',
+    '',
+    null,
+    undefined,
+    42,
+    '\u0007ctrl',
+    'A\u202Ebidi\u202CB',
+    '\u200E\u200Fmarks',
+    '\u2066iso\u2069',
+    `${'x'.repeat(300)}  `,
+    '   \u202E   ',
+    '<b>html stays literal text</b>',
+  ];
+  it('same output on both imports for every hostile input × caps', () => {
+    for (const input of HOSTILE) {
+      for (const max of [undefined, 0, 5, 140, 200]) {
+        expect(mirror.sanitizeQuestionText(input, max)).toBe(backend.sanitizeQuestionText(input, max));
+      }
+    }
+  });
+  it('strips controls + bidi, trims, caps — and never invents content', () => {
+    expect(backend.sanitizeQuestionText('A\u202Ebidi\u202CB', 140)).toBe('AbidiB');
+    expect(backend.sanitizeQuestionText('   \u202E   ', 140)).toBe('');
+    expect(backend.sanitizeQuestionText('x'.repeat(300), 200)).toHaveLength(200);
+    expect(backend.sanitizeQuestionText('<b>x</b>', 140)).toBe('<b>x</b>'); // not an HTML stripper — React escaping owns render safety
+  });
+});
+
+describe('designConfigV2 twins — custom-question subtree preservation', () => {
+  const V2_WITH_CUSTOM = {
+    version: 2,
+    template: { id: 'express', params: {} },
+    theme: { preset: 'warm-cream', accent: null },
+    content: {},
+    form: { fields: [], verification: 'sms', gates: {} },
+    distribution: { host: 'redeem' },
+    profileQuestions: {
+      enabled: true,
+      questionIds: ['language', 'c_abc123'],
+      requiredIds: ['c_abc123'],
+      showZh: true,
+      custom: [
+        { id: 'c_abc123', type: 'single', prompt: 'Which outlet?', options: [{ id: 'o1', label: 'East' }, { id: 'o2', label: 'West' }] },
+      ],
+    },
+  };
+  it('upgrade of a v2 doc preserves the custom subtree verbatim on both twins', () => {
+    const m = mirror.upgradeDesignConfig(V2_WITH_CUSTOM);
+    const b = backend.upgradeDesignConfig(V2_WITH_CUSTOM);
+    expect(m).toEqual(b);
+    expect(m.profileQuestions).toEqual(V2_WITH_CUSTOM.profileQuestions);
+  });
+  it('the legacy downgrade view still excludes profileQuestions (marketplace parity, studio-custom-questions §1)', () => {
+    expect(mirror.downgradeDesignConfig(V2_WITH_CUSTOM).profileQuestions).toBeUndefined();
+    expect(backend.downgradeDesignConfig(V2_WITH_CUSTOM).profileQuestions).toBeUndefined();
   });
 });

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -32,6 +32,8 @@ export const LIMITS = {
   drawCtaSubline: 90, drawFreeEntryTag: 40, drawBoostBody: 280,
   // Submit CTA font size in px (content.submitFontSize — v2-only, L7)
   submitFontSizeMin: 12, submitFontSizeMax: 24,
+  // Custom profile questions (profileQuestions.custom — studio-custom-questions §2)
+  cqPrompt: 140, cqOption: 48,
 };
 
 /**
@@ -222,6 +224,35 @@ export const V1_CONSUMED_KEYS = [
 
 /** Top-level v2 schema keys (used by downgrade + the clamp's alias scrub). */
 export const V2_TOP_KEYS = ['version', 'template', 'theme', 'content', 'form', 'distribution', 'ai', 'profileQuestions'];
+
+// ─────────── custom profile questions (studio-custom-questions §2) ───────────
+
+/** Owner-authored questions in the profileQuestions block. The library cap
+ * (MAX_PROFILE_QUESTIONS, profileQuestionLibrary.js) keeps its meaning — these
+ * bound the NEW `custom[]` defs and the combined `questionIds` membership.
+ * Custom answers are DISPLAY-ONLY (frozen onto sourceMetadata.customAnswers);
+ * they never mint consumer-observation facts. */
+export const MAX_CUSTOM_QUESTIONS = 5;
+export const MAX_TOTAL_PROFILE_QUESTIONS = 10;
+export const MAX_CUSTOM_OPTIONS = 8; // aligned with the capture Joi array bound
+export const CUSTOM_QUESTION_ID_RE = /^c_[a-z0-9]{4,12}$/;
+export const CUSTOM_OPTION_ID_RE = /^[a-z0-9_]{1,24}$/;
+export const CUSTOM_ANSWER_TEXT_MAX = 200;
+
+/** Shared sanitizer for owner-authored question copy AND customer free-text
+ * answers: strip C0/C1 controls + bidi overrides, trim, cap. The clamp's
+ * cleanString only slices — question copy renders on redeem.sg and in admin,
+ * so control/bidi stripping is non-negotiable. The Studio's completeness
+ * check MUST use this exact function (a value this sanitizer empties can
+ * never commit, then vanish in the clamp — studio-custom-questions §4). */
+export function sanitizeQuestionText(v, max) {
+  if (typeof v !== 'string') return '';
+  // eslint-disable-next-line no-control-regex
+  const stripped = v.replace(/[\u0000-\u001F\u007F-\u009F\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, '');
+  const trimmed = stripped.trim();
+  if (typeof max === 'number' && max >= 0 && trimmed.length > max) return trimmed.slice(0, max).trimEnd();
+  return trimmed;
+}
 
 // ───────────────────────── helpers (dependency-free) ─────────────────────────
 

--- a/src/pages/AdminCampaignStudio.jsx
+++ b/src/pages/AdminCampaignStudio.jsx
@@ -29,6 +29,12 @@ import useStudioAi from '@/components/studio/useStudioAi';
 import { useEditTargetFocus } from '@/components/studio/studioEditTargets';
 import StudioAiPanel from '@/components/studio/StudioAiPanel';
 import { studioPath, studioSupportsCampaign } from '@/components/studio/studioFlag';
+import {
+  commitDraftTransform,
+  draftComplete,
+  genCustomQuestionId,
+  transformPQ,
+} from '@/components/studio/profileQuestionsModel';
 import '@/styles/adminV2.css';
 
 /**
@@ -59,6 +65,19 @@ export default function AdminCampaignStudio() {
   const [slugError, setSlugError] = useState(null);
   const slugDirty = slugDraft !== null && slugDraft !== (campaign?.slug || '');
 
+  // Custom-question draft (studio-custom-questions §4) — a NEW question being
+  // authored in the Form panel. Owned HERE, not by the panel: the rail
+  // unmounts inactive panels, so panel-local state would die on a rail
+  // switch. At most one open draft; it never touches the doc until committed
+  // (the server clamp drops incomplete rows and the save path adopts the
+  // clamped response, so a half-typed question written to the doc would
+  // vanish on Save).
+  const [cqDraft, setCqDraft] = useState(null); // null = no draft
+  const cqDraftDirty = cqDraft !== null;
+  const cqDraftBlockedReason = cqDraft && !draftComplete(cqDraft)
+    ? 'The custom question you are adding is incomplete — finish it in the Form panel (or discard it) before saving.'
+    : null;
+
   const { data: serverReadiness, status: readinessStatus } = useServerReadiness(campaign?.id);
   const { data: marketplacePreview, status: previewStatus } = useMarketplacePreview(campaign?.id);
   const readiness = useMemo(
@@ -83,8 +102,9 @@ export default function AdminCampaignStudio() {
   const [subject, setSubject] = useState('page');
 
   // Unified dirty (Codex F10): the doc AND any unsaved slug draft drive every
-  // guard — a pending slug is as losable as pending copy.
-  const anyDirty = dirty || slugDirty;
+  // guard — a pending slug is as losable as pending copy. The custom-question
+  // draft joins for the same reason (studio-custom-questions §4).
+  const anyDirty = dirty || slugDirty || cqDraftDirty;
   const { guard, guardedRun, leaveViaHistory, closeGuard } = useStudioGuards({
     dirty: anyDirty,
     campaignId: campaign?.id,
@@ -186,6 +206,7 @@ export default function AdminCampaignStudio() {
     setSubject('page');
     setSlugDraft(null);
     setSlugError(null);
+    setCqDraft(null); // a question drafted for A must never ride into B
   }, [campaign?.id]);
 
   const switcherCampaigns = useMemo(() => {
@@ -216,15 +237,39 @@ export default function AdminCampaignStudio() {
       setSection('dist');
       return { ok: false, reason: 'slug-invalid' };
     }
+    // Open custom-question draft (studio-custom-questions §4): a COMPLETE
+    // draft is committed into an EXPLICIT snapshot handed to save — mut()
+    // schedules setDoc while save() PUTs the render-captured doc, so
+    // "commit then save()" would persist the pre-commit doc and lose the
+    // question. An incomplete draft blocks the save (the guard modal's
+    // primary is disabled with the same reason before it ever gets here).
+    let saveOpts;
+    if (cqDraft) {
+      if (!draftComplete(cqDraft)) {
+        toast.error('Finish or discard the custom question draft before saving.');
+        setSection('form');
+        return { ok: false, reason: 'cq-draft-incomplete' };
+      }
+      const existingIds = Array.isArray(doc?.profileQuestions?.custom)
+        ? doc.profileQuestions.custom.map((q) => q?.id).filter(Boolean)
+        : [];
+      const qid = genCustomQuestionId(existingIds);
+      const nextDoc = {
+        ...doc,
+        profileQuestions: transformPQ(doc, (s) => commitDraftTransform(s, cqDraft, qid)),
+      };
+      saveOpts = { snapshot: nextDoc };
+    }
     const slugRide = slugDirty ? { slug: slugDraft || null } : {};
     const sentSlug = slugDraft;
     // Codex diff #3: commit only the proposal THIS save carried — a look
     // picked while the PUT is in flight must survive with its gate intact.
     const proposalAtStart = aiRef.current.proposal;
-    const res = await save(slugRide);
+    const res = await save(slugRide, saveOpts);
     if (res.ok) {
       aiRef.current.notifySaved(proposalAtStart); // commit point — that look is no longer revertable
       if ('slug' in slugRide) setSlugDraft((cur) => (cur === sentSlug ? null : cur));
+      if (saveOpts) setCqDraft(null); // the draft is now IN the saved doc
       queryClient.invalidateQueries({ queryKey: ['campaigns', 'detail', id] });
       queryClient.invalidateQueries({ queryKey: ['studio', 'readiness', id] });
       queryClient.invalidateQueries({ queryKey: ['studio', 'marketplace-preview', id] });
@@ -233,7 +278,7 @@ export default function AdminCampaignStudio() {
     }
     return res;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [save, id, slugDirty, slugDraft]);
+  }, [save, id, slugDirty, slugDraft, cqDraft, doc]);
 
   // The explicit "Save slug" action (Distribution panel) — slug ONLY, its own
   // path per the handoff; 409 lock / 422 format surfaced inline.
@@ -326,6 +371,7 @@ export default function AdminCampaignStudio() {
   const handleGuardDiscard = useCallback(() => {
     const parked = guard;
     closeGuard();
+    setCqDraft(null); // Discard means everything pending, the draft included
     if (!parked) return;
     if (parked.kind === 'back-browser') leaveViaHistory();
     else parked.action?.();
@@ -441,6 +487,8 @@ export default function AdminCampaignStudio() {
               // failed refetch must not claim "verified".
               whatsappOtpConfigured={readinessStatus === 'success' ? serverReadiness?.whatsappOtpConfigured : undefined}
               campaignBrief={campaign?.targetAudience}
+              cqDraft={cqDraft}
+              onCqDraftChange={setCqDraft}
             />
           )}
           {doc && section === 'quiz' && <StudioQuizPanel doc={doc} campaign={campaign} setPath={setPath} />}
@@ -542,6 +590,7 @@ export default function AdminCampaignStudio() {
       <StudioGuardModal
         guard={guard}
         saving={saving}
+        primaryBlockedReason={cqDraftBlockedReason}
         onPrimary={handleGuardPrimary}
         onDiscard={handleGuardDiscard}
         onCancel={closeGuard}

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -776,6 +776,20 @@ export default function AdminV2LeadProfile() {
                     ))}
                 </Disclosure>
               )}
+              {/* Custom-question answers (studio-custom-questions §7) — the
+                  frozen {qid, prompt, values} snapshots from capture. Values
+                  include customer-typed free text: rendered as PLAIN React
+                  text only, never markup. */}
+              {Array.isArray(p.sourceMetadata?.customAnswers) && p.sourceMetadata.customAnswers.length > 0 && (
+                <Disclosure label="Custom answers" count={`${p.sourceMetadata.customAnswers.length}`}>
+                  {p.sourceMetadata.customAnswers.slice(0, 12).map((a, i) => (
+                    <div key={a?.qid || i} style={{ fontSize: 12, color: 'var(--ink-2)', padding: '4px 0', overflowWrap: 'anywhere' }}>
+                      <div style={{ fontSize: 10.5, fontWeight: 600, color: 'var(--ink-3)' }}>{String(a?.prompt || a?.qid || '')}</div>
+                      <div>{Array.isArray(a?.values) ? a.values.map((v) => String(v)).join(' · ') : ''}</div>
+                    </div>
+                  ))}
+                </Disclosure>
+              )}
             </Card>
 
             {hasScreening && (


### PR DESCRIPTION
Implements `docs/plans/studio-custom-questions.md` — **APPROVED by Codex round 5** (gpt-5.6-sol xhigh, 2026-08-18; convergence 16 → 10 → 3 → 1 → APPROVE, full disposition logs in the plan doc, which ships in this PR).

## What this adds

Owner-authored **custom questions** in the Campaign Studio profile-questions block. They render on the signup funnel in the same block as the library questions — after the sign-up fields, immediately before consent + Submit — and their answers are **display-only**: frozen onto the lead, shown in admin, never minting consumer-observation facts or feeding Meet×Buy scoring (the fixed library keeps that job; "admins pick, never author" survives as *custom answers never mint facts*).

- **Schema**: `profileQuestions.custom[]` defs (`single` / `multi` / `text`), ids `c_*`, joined into the existing `questionIds`/`requiredIds` mechanisms — `questionIds` stays the single order+membership authority. Caps: 5 custom / 10 total / 8 options / 200-char text, as named constants in the designConfigV2 twins (lockstep suite extended; `sanitizeQuestionText` added to `FUNCTION_EXPORTS` with hostile-input behavioral parity).
- **Clamp** (`clampProfileQuestions`): validity map WITHOUT a count cap → membership built with per-namespace caps → defs retained only for final membership — an unreferenced def can never cost a referenced question the cap. Shared sanitizer strips C0/C1 + bidi controls. Existing docs round-trip byte-identically (no `custom` key emitted when empty).
- **Capture** (`scoreSubmission`): custom loop iterates the CAMPAIGN's `questionIds` (never attacker keys); accepted answers freeze `{qid, prompt, values}` server-side (EN-canonical, labels resolved from the campaign config at capture — a later Studio edit can't re-caption history) into `sourceMetadata.customAnswers`. Drop-not-fail per answer; ids-only logging.
- **Gate repair**: the eligibility gate gains the `sourceCampaign.type !== 'guided_review'` leg the parent plan specified — the shipped gate checked only `template.id`, letting a guided-review-TYPE campaign accept hidden answers via direct POST (this also closed the same latent gap for LIBRARY answers). Regression-tested.
- **Mass-assignment hardening**: `profileAnswers` joins the body strip-destructure (it previously rode `incoming` into `Prospect.create`, inert only because Sequelize ignores non-attributes); `customAnswers`/`profileAnswers` join the `marketplace`-style server-only scrub of caller-supplied `sourceMetadata`.
- **Studio Form panel**: "YOUR OWN QUESTIONS" authoring — one `mutatePQ` mutation door for the whole subtree (the old per-site rebuilds were lossy: the master toggle dropped `requiredIds`/`showZh` — pre-existing bug, now fixed — and library/suggestion writes would have deleted custom state). New-question drafts are page-owned (survive rail switches), commit only when complete under the server's own sanitizer, join the dirty guard, and the guard's Save-and-continue commits via an explicit `save(extra, { snapshot })` handoff (mut() is scheduled; save() PUTs the render-captured doc — the snapshot rule closes that loss window). Add is disabled at the 5-cap; a sixth question can never enter the doc.
- **AI safety**: every whole-doc replacement in `useStudioAi` (pick, re-pick, keep-toggle, revert) grafts the LIVE `profileQuestions` subtree — an AI interaction can never destroy question edits.
- **Funnel renderer**: one normalized resolver for library (`multi`) and custom (`type`) shapes, used by BOTH the render loop and the required-submit gate (a required custom id was previously silently skipped); type-aware `isAnswered` (whitespace-only text never satisfies required); bounded text input; `overflow-wrap` so 48-char labels/140-char prompts hold 390×844.
- **Admin**: Lead Profile gains a "Custom answers" disclosure (plain-text render; hostile strings inert).
- **Scope boundaries** (per plan): marketplace door keeps its has-never-asked-questions parity; CSV exports unchanged; Lyfe app notes unchanged (webhooks already carry `sourceMetadata` verbatim on all three lead events — receiver display is a sibling-repo follow-up).

## Rollout

One PR, **no migration** (JSON columns only), naturally dark — nothing renders until a campaign authors a question in Studio. `DESIGN_CONFIG_V2_WRITES_ENABLED` already on in prod.

## Verification (local, full)

- Backend: unit + integration (`--runInBand`) + migration suites green against real Postgres; `npm run typecheck` green; eslint clean.
- Frontend: full Vitest **153 files / 1976 tests green** (incl. new suites: clamp matrix, lockstep parity, scoring acceptance, `profileQuestionsModel`, panel preservation matrix + draft lifecycle, renderer custom matrix incl. hostile-input + payload, snapshot-save, AI graft, guard modal); eslint clean; production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h6CXFYoeyPNmF3EwE9oZN
