### PR TITLE
feat(ads): Google offline outcomes — click-id capture, atomic sourceMetadata patches, events:ingest + workers + Lyfe reconciler (ships dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -744,3 +744,24 @@ GOOGLE_CM_FIRST_POLL_MINUTES=30
 GOOGLE_CM_SETTLE_INTERVAL_MINUTES=15
 # Per-request fetch timeout for the Data Manager client.
 GOOGLE_DM_TIMEOUT_MS=30000
+
+# --- Google offline outcomes (plan google-ads-signal-levers §4) ---
+# Master switch for the down-funnel events:ingest path + its workers +
+# the Lyfe outcome reconciler.
+GOOGLE_ADS_UPLOADS_ENABLED=false
+# Conversion-action ids (Ads UI import actions, UPLOAD_CLICKS, SECONDARY):
+# per-key worker preflight — a missing id aborts that key's pass, no marker.
+GOOGLE_CONV_ACTION_QUALIFIED=
+GOOGLE_CONV_ACTION_WON=
+# Static conversion values (SGD). Score weighting deliberately NOT in v1.
+GOOGLE_VALUE_QUALIFIED=40
+GOOGLE_VALUE_WON=500
+# Age guard measured from the CLICK (gcl.capturedAt; signup createdAt for
+# PII-only events) — never the outcome.
+GOOGLE_CONV_MAX_AGE_DAYS=60
+# Pending markers past this many days get one final retrieve then fail.
+GOOGLE_PENDING_MAX_DAYS=7
+# Send attempts per outcome across accepted-then-failed cycles.
+GOOGLE_SEND_MAX_RETRIES=5
+GOOGLE_OUTCOMES_WORKER_MINUTES=10
+GOOGLE_LYFE_RECONCILE_INTERVAL_HOURS=6

--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,0 +1,1 @@
+/Users/shawnlee/lyfe-master/mktr-platform/backend/node_modules

--- a/backend/node_modules
+++ b/backend/node_modules
@@ -1,1 +1,0 @@
-/Users/shawnlee/lyfe-master/mktr-platform/backend/node_modules

--- a/backend/scripts/google-dm-validate-smoke.mjs
+++ b/backend/scripts/google-dm-validate-smoke.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Opt-in, credentialed validateOnly smoke for the Data Manager envelopes
+ * (plan google-ads-signal-levers §4.4 / §9) — NEVER CI, never deployed
+ * (scripts/ is dockerignored). Run locally with the real GOOGLE_DM_* env
+ * before the first flip: validate-only requests are parsed and validated by
+ * Google but NOT executed, so this pins the envelope field names against
+ * the live API without ingesting anything.
+ *
+ * Usage:
+ *   GOOGLE_DM_OAUTH_CLIENT_ID=… GOOGLE_DM_OAUTH_CLIENT_SECRET=… \
+ *   GOOGLE_DM_REFRESH_TOKEN=… GOOGLE_ADS_CUSTOMER_ID=1829163947 \
+ *   GOOGLE_CM_USER_LIST_ID=… GOOGLE_CONV_ACTION_QUALIFIED=… \
+ *     node scripts/google-dm-validate-smoke.mjs
+ */
+import crypto from 'crypto';
+import { dmRequest } from '../src/utils/googleDataManagerClient.js';
+import { buildIngestBody } from '../src/services/googleCustomerMatchService.js';
+import { buildOutcomeEnvelope } from '../src/services/googleOfflineConversionsService.js';
+
+const sha = (v) => crypto.createHash('sha256').update(v).digest('hex');
+
+async function main() {
+  const results = [];
+  const run = async (name, method, body) => {
+    try {
+      const res = await dmRequest(method, { ...body, validateOnly: true });
+      results.push({ name, ok: true, requestId: res?.requestId || null });
+    } catch (err) {
+      results.push({ name, ok: false, error: err.message });
+    }
+  };
+
+  // Customer Match ingest — one synthetic member (validate-only: not stored).
+  await run('cm-ingest', 'audienceMembers:ingest', buildIngestBody([
+    { userIdentifiers: [{ emailAddress: sha('smoke@example.com') }, { phoneNumber: sha('+6590000000') }] },
+  ]));
+
+  // Outcome events — click-only and consented-PII variants.
+  const prospect = {
+    id: 'validate-smoke',
+    email: 'smoke@example.com',
+    phone: '+6590000000',
+    sourceMetadata: { gcl: { gclid: 'SMOKE_GCLID' } },
+  };
+  await run('outcome-click-only', 'events:ingest',
+    buildOutcomeEnvelope(prospect, 'confirmed_resident', new Date().toISOString(), {
+      adIdentifiers: { gclid: 'SMOKE_GCLID' },
+      userIdentifiers: [],
+    }));
+  await run('outcome-consented-pii', 'events:ingest',
+    buildOutcomeEnvelope(prospect, 'confirmed_resident', new Date().toISOString(), {
+      adIdentifiers: {},
+      userIdentifiers: [{ emailAddress: sha('smoke@example.com') }],
+    }));
+
+  for (const r of results) console.log(JSON.stringify(r));
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length) {
+    console.error(`\n${failed.length} envelope(s) rejected — fix field names before flipping.`);
+    process.exit(1);
+  }
+  console.log('\nAll envelopes validated. (validate-only: nothing was ingested.)');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/controllers/lyfeLeadOutcomeController.js
+++ b/backend/src/controllers/lyfeLeadOutcomeController.js
@@ -122,7 +122,12 @@ export async function handleLyfeLeadOutcome(req, res) {
   }
 
   try {
-    const result = await processLeadOutcome(req.body);
+    // The signed webhook timestamp is the TRUSTED occurred_at fallback for
+    // the durable outcome facts (plan google-ads-signal-levers §4.3) — the
+    // body field is caller-supplied and unvalidated.
+    const result = await processLeadOutcome(req.body, {
+      signedWebhookAt: new Date(tsMs).toISOString(),
+    });
     const summary = result.skipped
       ? result.skipped
       : `dispatched=[${(result.dispatched || []).join(',')}] dup=[${(result.duplicate || []).join(',')}] failed=[${(result.failed || []).join(',')}]`;

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -306,6 +306,48 @@ export async function bootstrapDatabase() {
       logger.info(`[GoogleCM] settlement drainer scheduled (${settleMinutes}m interval)`);
     }
 
+    // Google offline-outcome workers (plan google-ads-signal-levers §4.3):
+    // (a) re-send — rows with a durable outcomes fact whose gads marker is
+    //     absent or in a due retryWait;
+    // (b) settle — due pending markers polled to terminal states (Google's
+    //     diagnostics window: first poll ~30min, up to 24h);
+    // (c) the Lyfe outcome reconciler — the durability net (pg_net never
+    //     retries) that also backfills pre-arc outcomes.
+    // In-process single-flight; single-instance backend.
+    if (process.env.GOOGLE_ADS_UPLOADS_ENABLED === 'true') {
+      const workerMinutes = Math.max(1, Number(process.env.GOOGLE_OUTCOMES_WORKER_MINUTES) || 10);
+      const reconcileHours = Math.max(1, Number(process.env.GOOGLE_LYFE_RECONCILE_INTERVAL_HOURS) || 6);
+      let outcomesInFlight = false;
+      const runOutcomesWorker = async () => {
+        if (outcomesInFlight) return;
+        outcomesInFlight = true;
+        try {
+          const { resendDueOutcomes, settleDueOutcomes } = await import('../services/googleOfflineConversionsService.js');
+          await resendDueOutcomes();
+          await settleDueOutcomes();
+        } catch (err) {
+          logger.warn('[GoogleOutcomes] worker pass failed (non-fatal)', { error: err?.message });
+        } finally {
+          outcomesInFlight = false;
+        }
+      };
+      const runLyfeReconcile = async () => {
+        try {
+          const { reconcileLyfeOutcomes } = await import('../services/googleOutcomesReconciler.js');
+          await reconcileLyfeOutcomes();
+        } catch (err) {
+          logger.warn('[GoogleOutcomes] reconcile pass failed (non-fatal)', { error: err?.message });
+        }
+      };
+      setTimeout(runOutcomesWorker, 120_000);
+      setInterval(runOutcomesWorker, workerMinutes * 60 * 1000);
+      setTimeout(runLyfeReconcile, 180_000);
+      setInterval(runLyfeReconcile, reconcileHours * 60 * 60 * 1000);
+      logger.info(
+        `[GoogleOutcomes] workers scheduled (${workerMinutes}m worker, ${reconcileHours}h reconcile)`
+      );
+    }
+
     // Redemption CAPI reconciliation sweep — the no-rescan safety net for
     // VoucherRedeemed sends lost between the redemption commit and the
     // fire-and-forget dispatch (process death). Marker-guarded + Meta event_id

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -331,12 +331,17 @@ export async function bootstrapDatabase() {
           outcomesInFlight = false;
         }
       };
+      let reconcileInFlight = false;
       const runLyfeReconcile = async () => {
+        if (reconcileInFlight) return; // a stalled REST pass must not overlap the next tick
+        reconcileInFlight = true;
         try {
           const { reconcileLyfeOutcomes } = await import('../services/googleOutcomesReconciler.js');
           await reconcileLyfeOutcomes();
         } catch (err) {
           logger.warn('[GoogleOutcomes] reconcile pass failed (non-fatal)', { error: err?.message });
+        } finally {
+          reconcileInFlight = false;
         }
       };
       setTimeout(runOutcomesWorker, 120_000);

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -207,6 +207,16 @@ export const schemas = {
     // CompleteRegistration dedup id — set when a quiz reveal fired the browser
     // CompleteRegistration; the server fires a matching CAPI event with this id.
     registrationEventId: Joi.string().max(64).optional(),
+    // Google Ads click ids (gclid/gbraid/wbraid) + the CAPTURE timestamp —
+    // load-bearing for the offline-conversion age guard, which measures from
+    // the click (capture lands minutes after it), never the outcome
+    // (plan google-ads-signal-levers §4.1). Whitelisted so stripUnknown
+    // doesn't drop them (it logs a contract-drift warning, but the data is
+    // still lost).
+    gclid: Joi.string().max(512).optional(),
+    gbraid: Joi.string().max(512).optional(),
+    wbraid: Joi.string().max(512).optional(),
+    gclCapturedAt: Joi.string().isoDate().optional(),
     // TikTok attribution identifiers (ttclid click id + _ttp first-party cookie).
     // Captured at the landing page, stashed in sourceMetadata for the Phase 6
     // server-side TikTok Events API. Whitelisted here so they don't 400.

--- a/backend/src/services/googleOfflineConversionsService.js
+++ b/backend/src/services/googleOfflineConversionsService.js
@@ -54,6 +54,23 @@ const defaultDeps = {
 };
 
 const GADS = 'gads';
+const SENDING_LEASE_MS = 10 * 60_000; // stale-claim reclaim window (crash recovery)
+// Deterministic processing enums that a retry of the UNCHANGED event cannot
+// repair (official Data Manager status reasons; extend as observed).
+const PERMANENT_REASONS = new Set([
+  'INVALID_ARGUMENT',
+  'INVALID_EVENT',
+  'INVALID_TIMESTAMP',
+  'EVENT_TOO_OLD',
+  'CONSENT_DENIED',
+  'MISSING_CONSENT',
+  'DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED',
+  'DESTINATION_ACCOUNT_CUSTOMER_MATCH_TERMS_NOT_SIGNED',
+  'OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER',
+  'ONE_PER_CLICK_CONVERSION_ACTION_NOT_PERMITTED_WITH_BRAID',
+  'UNSUPPORTED_EVENT_SOURCE',
+  'MALFORMED_IDENTIFIER',
+]);
 const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
 const DEFAULT_VALUES = { confirmed_resident: 40, closed_won: 500 };
 
@@ -200,6 +217,14 @@ export async function dispatchOutcome(prospectId, eventKey, deps = {}) {
     if (!due) return { sent: false, reason: 'not_due' };
     retryCount = Number(existing.retryCount) || 0;
     claimCas = { path: [GADS, eventKey], contains: { state: 'retryWait', retryCount: existing.retryCount } };
+  } else if (existing?.state === 'sending') {
+    // The claim is a LEASE: a crash between claim and transition must not
+    // strand the fact forever. A stale lease (older than SENDING_LEASE_MS)
+    // is reclaimable, carrying its retryCount forward.
+    const age = d.now() - Date.parse(existing.claimedAt || 0);
+    if (age < SENDING_LEASE_MS) return { sent: false, reason: 'claim_held' };
+    retryCount = Number(existing.retryCount) || 0;
+    claimCas = { path: [GADS, eventKey], contains: { state: 'sending', claimToken: existing.claimToken } };
   } else {
     return { sent: false, reason: 'marker_present' };
   }
@@ -293,6 +318,22 @@ export async function dispatchOutcome(prospectId, eventKey, deps = {}) {
       return { sent: false, reason: 'no_identifier' };
     }
 
+    // FINAL erased re-check, immediately before the wire (Codex P3-2 #1):
+    // shrinks the erasure race to milliseconds. The residual (erasure
+    // committing inside this last gap) is accepted and matches the Meta CAPI
+    // dispatch path's own unguarded load→send window; a conversion event is
+    // a bounded, non-retained disclosure and the CM removal hook clears list
+    // memberships independently. A row lock is deliberately NOT held here —
+    // PDPA erasure must never block on a Google outage.
+    const freshErased = await d.sequelize.query(
+      `SELECT COALESCE("sourceMetadata"::jsonb->>'erased','false') AS erased FROM prospects WHERE id = $id`,
+      { bind: { id: prospect.id }, type: QueryTypes.SELECT }
+    );
+    if (!freshErased.length || freshErased[0].erased === 'true') {
+      await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount, 'erased_pre_send', d), { cas: claimGuard });
+      return { sent: false, reason: 'erased' };
+    }
+
     const envelope = buildOutcomeEnvelope(prospect, eventKey, fact, { adIdentifiers, userIdentifiers });
     const res = await d.dmRequest('events:ingest', envelope, d);
     if (!res?.requestId) {
@@ -312,9 +353,12 @@ export async function dispatchOutcome(prospectId, eventKey, deps = {}) {
       { cas: claimGuard }
     );
     if (n === 0) {
-      // Claim vanished under us (erasure is the only writer that can do
-      // that) — the upload happened; transactionId dedup absorbs a re-send.
-      logger.warn({ prospectId, eventKey }, 'google_outcomes.claim_lost_post_send');
+      // Claim vanished under us (erasure, or a lease reclaim after a long
+      // stall) — the upload DID happen but the marker no longer records it;
+      // transactionId dedup absorbs any re-send. Reported distinctly, never
+      // as plain success (Codex P3-2 #3).
+      logger.warn({ prospectId, eventKey, requestId: res.requestId }, 'google_outcomes.accepted_but_claim_lost');
+      return { sent: true, requestId: res.requestId, claimLost: true };
     }
     logger.info({ prospectId, eventKey, requestId: res.requestId }, 'google_outcomes.accepted');
     return { sent: true, requestId: res.requestId };
@@ -357,9 +401,12 @@ export function classifyStatusBody(body) {
   collect(body?.errorInfo);
   const reasons = countBuckets.filter(Boolean);
   const hasDuplicate = reasons.some((r) => r.includes('duplicate'));
-  const hasPermanent = reasons.some((r) =>
-    /(invalid|validation|malformed|consent|denied|too_old|age|unsupported)/.test(r)
-  );
+  // EXACT enum matching for permanence (Codex P3-2 #4): substring guessing
+  // misclassifies deterministic processing enums as transient (retrying an
+  // unchanged event cannot sign terms or fix an account mismatch) and broad
+  // substrings are unsafe against future enums. Unknown reasons default to
+  // RETRY. Set re-pinned by the validateOnly smoke / first live failures.
+  const hasPermanent = reasons.some((r) => PERMANENT_REASONS.has(r.toUpperCase()));
   if (status === 'SUCCESS') return 'delivered';
   if (status === 'PARTIAL_SUCCESS' || status === 'FAILED') {
     if (hasDuplicate) return 'delivered';
@@ -394,9 +441,20 @@ export async function resendDueOutcomes(deps = {}) {
               ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'state') = 'retryWait'
               AND ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'nextSendAt') <= $nowIso
             )
+            OR (
+              ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'state') = 'sending'
+              AND ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'claimedAt') <= $staleIso
+            )
           )
         LIMIT 200`,
-      { bind: { key: eventKey, nowIso: new Date(d.now()).toISOString() }, type: QueryTypes.SELECT }
+      {
+        bind: {
+          key: eventKey,
+          nowIso: new Date(d.now()).toISOString(),
+          staleIso: new Date(d.now() - SENDING_LEASE_MS).toISOString(),
+        },
+        type: QueryTypes.SELECT,
+      }
     );
     for (const { id } of rows) {
       const res = await dispatchOutcome(id, eventKey, d);
@@ -445,11 +503,11 @@ export async function settleDueOutcomes(deps = {}) {
         else logger.warn({ requestId, err: err.message }, 'google_outcomes.settle.retrieve_failed');
       }
       if (classification === 'delivered') {
-        await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
-        summary.delivered += 1;
+        const n = await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
+        if (n > 0) summary.delivered += 1;
       } else if (classification === 'permanent') {
-        await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'ingest_rejected', at: nowIso }, { cas });
-        summary.failedPermanent += 1;
+        const n = await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'ingest_rejected', at: nowIso }, { cas });
+        if (n > 0) summary.failedPermanent += 1;
         Sentry.captureMessage('google_outcomes.ingest_rejected', {
           level: 'warning',
           tags: { source: 'google_outcomes' },
@@ -457,16 +515,16 @@ export async function settleDueOutcomes(deps = {}) {
         });
       } else if (classification === 'transient') {
         const retryCount = (Number(marker.retryCount) || 0) + 1;
-        await d.setPath(id, [GADS, eventKey], retryWaitState(retryCount, 'ingest_failed', d), { cas });
-        summary.retried += 1;
+        const n = await d.setPath(id, [GADS, eventKey], retryWaitState(retryCount, 'ingest_failed', d), { cas });
+        if (n > 0) summary.retried += 1;
         Sentry.captureMessage('google_outcomes.ingest_failed', {
           level: 'warning',
           tags: { source: 'google_outcomes' },
           extra: { prospectId: id, eventKey, requestId },
         });
       } else if (pendingAgeMs > pendingMaxMs()) {
-        await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'pending_timeout', at: nowIso }, { cas });
-        summary.failedPermanent += 1;
+        const n = await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'pending_timeout', at: nowIso }, { cas });
+        if (n > 0) summary.failedPermanent += 1;
         Sentry.captureMessage('google_outcomes.pending_timeout', {
           level: 'warning',
           tags: { source: 'google_outcomes' },

--- a/backend/src/services/googleOfflineConversionsService.js
+++ b/backend/src/services/googleOfflineConversionsService.js
@@ -1,0 +1,403 @@
+import * as Sentry from '@sentry/node';
+import { QueryTypes } from 'sequelize';
+import { sequelize, Prospect } from '../models/index.js';
+import { hashEmailGoogle, hashPhoneE164 } from '../utils/piiHashing.js';
+import { dmRequest, dmRequestGet } from '../utils/googleDataManagerClient.js';
+import { mergeFirstWins, setPath } from '../utils/prospectJsonPatch.js';
+import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Google offline outcomes — the down-funnel "CAPI parity" arc
+ * (plan google-ads-signal-levers §4): ConfirmedResident / ClosedWon uploaded
+ * through Data Manager `events:ingest` so Google learns what a GOOD lead is,
+ * not just a lead.
+ *
+ * Truth model (§4.3):
+ *  - `sourceMetadata.outcomes.{eventKey} = RFC3339` is the DURABLE FACT,
+ *    written first-wins by the inbound paths (leadOutcomeService for
+ *    Lyfe/external, the admin edit transaction, the Lyfe reconciler).
+ *  - `sourceMetadata.gads.{eventKey}` is the delivery STATE MACHINE, every
+ *    transition an atomic CAS write (prospectJsonPatch): pending →
+ *    delivered / retryWait / failedPermanent, plus skippedPermanent for
+ *    facts that can never send. Key absence is never the retry ledger.
+ *  - Google's diagnostics window is 30min→24h, so settlement is DEFERRED to
+ *    the worker; in-run truth is acceptance-only.
+ *
+ * Eligibility is GOOGLE-specific, not a shouldFireCapi clone: upload ALL
+ * outcomes (Meta-Lead-Ads-origin leads included — unmatched events are
+ *  expected and free); skip call_bot for data quality. A missing
+ * conversion-action id is deployment CONFIG — a per-key preflight that
+ * aborts the key's pass without mutating rows, so supplying the env later
+ * sends the untouched facts.
+ */
+
+const TERMINAL = new Set(['SUCCESS', 'PARTIAL_SUCCESS', 'FAILED']);
+
+const defaultDeps = {
+  Prospect,
+  sequelize,
+  dmRequest,
+  dmRequestGet,
+  canMarketTo: ledgerCanMarketTo,
+  mergeFirstWins,
+  setPath,
+  now: Date.now,
+};
+
+/** Env-mapped conversion actions per event key (destination productDestinationId). */
+export function actionIdFor(eventKey) {
+  if (eventKey === 'confirmed_resident') return process.env.GOOGLE_CONV_ACTION_QUALIFIED || null;
+  if (eventKey === 'closed_won') return process.env.GOOGLE_CONV_ACTION_WON || null;
+  return null;
+}
+
+function valueFor(eventKey) {
+  const raw =
+    eventKey === 'confirmed_resident'
+      ? process.env.GOOGLE_VALUE_QUALIFIED
+      : eventKey === 'closed_won'
+        ? process.env.GOOGLE_VALUE_WON
+        : null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** Master switch + creds. Action ids are a per-key PREFLIGHT, not gated here. */
+export function uploadsEnabled() {
+  if (process.env.GOOGLE_ADS_UPLOADS_ENABLED !== 'true') return false;
+  if (!process.env.GOOGLE_DM_OAUTH_CLIENT_ID) return false;
+  if (!process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET) return false;
+  if (!process.env.GOOGLE_DM_REFRESH_TOKEN) return false;
+  if (!process.env.GOOGLE_ADS_CUSTOMER_ID) return false;
+  return true;
+}
+
+function maxAgeMs() {
+  return Math.max(1, Number(process.env.GOOGLE_CONV_MAX_AGE_DAYS) || 60) * 24 * 60 * 60 * 1000;
+}
+
+function maxRetries() {
+  return Math.max(0, Number(process.env.GOOGLE_SEND_MAX_RETRIES) || 5);
+}
+
+function pendingMaxMs() {
+  return Math.max(1, Number(process.env.GOOGLE_PENDING_MAX_DAYS) || 7) * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Fact-level eligibility. Returns `{ ok: true }` or
+ * `{ ok: false, reason }` where reason is PERMANENT (skippedPermanent):
+ * call_bot origin, no identifier ever, click/signup outside the import
+ * window. NOT here: missing action id (config preflight), erased rows
+ * (the atomic writes' guard blocks them; dispatch also re-checks).
+ */
+export function factEligibility(prospect, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (prospect?.leadSource === 'call_bot' || prospect?.retellCallId) {
+    return { ok: false, reason: 'call_bot' };
+  }
+  const gcl = prospect?.sourceMetadata?.gcl || null;
+  const hasClickId = Boolean(gcl?.gclid || gcl?.gbraid || gcl?.wbraid);
+  const hasPii = Boolean(hashEmailGoogle(prospect?.email) || hashPhoneE164(prospect?.phone));
+  if (!hasClickId && !hasPii) return { ok: false, reason: 'no_identifier' };
+  // Age guard measures from the CLICK (capture lands minutes after it), or
+  // the signup for PII-only events — never from the outcome (plan §4.2).
+  const anchor = gcl?.capturedAt || prospect?.createdAt;
+  const anchorMs = anchor ? Date.parse(anchor) : NaN;
+  if (!Number.isNaN(anchorMs) && d.now() - anchorMs > maxAgeMs()) {
+    return { ok: false, reason: 'age_window_expired' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Build the single-event ingest envelope. One event per request BY DESIGN:
+ * diagnostics is aggregate-only, so a requestId must map to exactly one
+ * marker (plan §4.2). Consent enums ride ONLY with userData — a
+ * CONSENT_GRANTED declaration on a click-only event for a withdrawn person
+ * would be false. encoding:HEX accompanies hashed userData and is omitted
+ * on click-only events.
+ */
+export function buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { marketingConsent }) {
+  const gcl = prospect?.sourceMetadata?.gcl || {};
+  const event = {
+    eventSource: 'OTHER',
+    eventTimestamp: new Date(occurredAtIso).toISOString(),
+    transactionId: `${eventKey}:${prospect.id}`,
+  };
+  const value = valueFor(eventKey);
+  if (value !== null) {
+    event.conversionValue = value;
+    event.currency = 'SGD';
+  }
+  const adIdentifiers = {};
+  if (gcl.gclid) adIdentifiers.gclid = gcl.gclid;
+  if (gcl.gbraid) adIdentifiers.gbraid = gcl.gbraid;
+  if (gcl.wbraid) adIdentifiers.wbraid = gcl.wbraid;
+  if (Object.keys(adIdentifiers).length) event.adIdentifiers = adIdentifiers;
+
+  let hasUserData = false;
+  if (marketingConsent === true) {
+    const userIdentifiers = [];
+    const em = hashEmailGoogle(prospect?.email);
+    const ph = hashPhoneE164(prospect?.phone);
+    if (em) userIdentifiers.push({ emailAddress: em });
+    if (ph) userIdentifiers.push({ phoneNumber: ph });
+    if (userIdentifiers.length) {
+      event.userData = { userIdentifiers };
+      hasUserData = true;
+    }
+  }
+
+  return {
+    destinations: [
+      {
+        operatingAccount: { product: 'GOOGLE_ADS', accountId: process.env.GOOGLE_ADS_CUSTOMER_ID },
+        productDestinationId: actionIdFor(eventKey),
+      },
+    ],
+    events: [event],
+    ...(hasUserData
+      ? {
+          encoding: 'HEX',
+          consent: { adUserData: 'CONSENT_GRANTED', adPersonalization: 'CONSENT_GRANTED' },
+        }
+      : {}),
+  };
+}
+
+const GADS = 'gads';
+
+/**
+ * Dispatch ONE outcome for one prospect. Assumes the caller verified: master
+ * switch on, action id present (preflight), a `outcomes.{eventKey}` fact
+ * exists, and no terminal/pending marker blocks the send. `retryCount`
+ * carries across accepted-then-failed cycles (it rides in BOTH pending and
+ * retryWait — plan round-5). Never throws.
+ */
+export async function dispatchOutcome(prospect, eventKey, occurredAtIso, retryCount, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  const eligible = factEligibility(prospect, d);
+  if (!eligible.ok) {
+    await d.setPath(prospect.id, [GADS, eventKey], {
+      state: 'skippedPermanent',
+      reason: eligible.reason,
+      at: new Date(d.now()).toISOString(),
+    });
+    logger.info({ prospectId: prospect.id, eventKey, reason: eligible.reason }, 'google_outcomes.skipped');
+    return { sent: false, reason: eligible.reason };
+  }
+  if (retryCount >= maxRetries()) {
+    await d.setPath(prospect.id, [GADS, eventKey], {
+      state: 'failedPermanent',
+      reason: 'retry_cap',
+      at: new Date(d.now()).toISOString(),
+    });
+    Sentry.captureMessage('google_outcomes.retry_cap', {
+      level: 'warning',
+      tags: { source: 'google_outcomes' },
+      extra: { prospectId: prospect.id, eventKey, retryCount },
+    });
+    return { sent: false, reason: 'retry_cap' };
+  }
+
+  let marketingConsent = false;
+  try {
+    marketingConsent =
+      (await d.canMarketTo({
+        consumerId: prospect.consumerId,
+        phone: prospect.phone,
+        channel: 'all',
+        campaignId: prospect.campaignId || null,
+      })) === true;
+  } catch (err) {
+    // FAIL CLOSED on ledger error: click-only event still sends (session
+    // identifiers), PII stays home — mirrors the Meta em/ph posture.
+    logger.warn({ err: err.message }, 'google_outcomes.canMarketTo_failed (PII omitted)');
+  }
+
+  const envelope = buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { marketingConsent });
+  try {
+    const res = await d.dmRequest('events:ingest', envelope, d);
+    if (!res?.requestId) {
+      // Un-settleable accept — schedule a bounded retry, never silent success.
+      await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'missing_request_id', d));
+      return { sent: false, reason: 'missing_request_id' };
+    }
+    await d.setPath(prospect.id, [GADS, eventKey], {
+      state: 'pending',
+      requestId: res.requestId,
+      retryCount,
+      sentAt: new Date(d.now()).toISOString(),
+      nextPollAt: new Date(d.now() + firstPollMs()).toISOString(),
+    });
+    logger.info({ prospectId: prospect.id, eventKey, requestId: res.requestId }, 'google_outcomes.accepted');
+    return { sent: true, requestId: res.requestId };
+  } catch (err) {
+    const permanent = typeof err.status === 'number' && err.status >= 400 && err.status < 500 && err.status !== 429;
+    if (permanent) {
+      await d.setPath(prospect.id, [GADS, eventKey], {
+        state: 'failedPermanent',
+        reason: `http_${err.status}`,
+        at: new Date(d.now()).toISOString(),
+      });
+      Sentry.captureException(err, { tags: { source: 'google_outcomes' } });
+      return { sent: false, reason: 'permanent' };
+    }
+    await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'transient', d));
+    logger.warn({ prospectId: prospect.id, eventKey, err: err.message }, 'google_outcomes.transient');
+    return { sent: false, reason: 'transient' };
+  }
+}
+
+function firstPollMs() {
+  return Math.max(1, Number(process.env.GOOGLE_CM_FIRST_POLL_MINUTES) || 30) * 60_000;
+}
+
+function retryWaitState(retryCount, lastReason, d) {
+  const backoff = Math.min(5 * 60_000 * 2 ** Math.max(0, retryCount - 1), 6 * 60 * 60_000);
+  return {
+    state: 'retryWait',
+    retryCount,
+    lastReason,
+    nextSendAt: new Date(d.now() + backoff + Math.floor(Math.random() * 60_000)).toISOString(),
+  };
+}
+
+const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
+
+/**
+ * Worker job (a): RE-SEND — rows holding an `outcomes.{key}` fact whose gads
+ * marker is absent or in a due retryWait. Per-key config preflight: a
+ * missing action id aborts THAT key's pass with a log (no row mutation) so
+ * later config still sends the untouched facts.
+ */
+export async function resendDueOutcomes(deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (!uploadsEnabled()) return { ran: false, reason: 'guarded' };
+  const summary = { ran: true, sent: 0, skipped: 0, failed: 0 };
+  for (const eventKey of EVENT_KEYS) {
+    if (!actionIdFor(eventKey)) {
+      logger.warn({ eventKey }, 'google_outcomes.preflight_missing_action_id (key pass aborted)');
+      continue;
+    }
+    const rows = await d.sequelize.query(
+      `SELECT id FROM prospects
+        WHERE ("sourceMetadata"::jsonb -> 'outcomes') ? $key
+          AND COALESCE("sourceMetadata"::jsonb ->> 'erased', 'false') <> 'true'
+          AND (
+            ("sourceMetadata"::jsonb -> 'gads' -> $key) IS NULL
+            OR (
+              ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'state') = 'retryWait'
+              AND ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'nextSendAt') <= $nowIso
+            )
+          )
+        LIMIT 200`,
+      { bind: { key: eventKey, nowIso: new Date(d.now()).toISOString() }, type: QueryTypes.SELECT }
+    );
+    for (const { id } of rows) {
+      const prospect = await d.Prospect.findByPk(id, { raw: true });
+      if (!prospect) continue;
+      const fact = prospect.sourceMetadata?.outcomes?.[eventKey];
+      if (!fact) continue;
+      const marker = prospect.sourceMetadata?.gads?.[eventKey];
+      const retryCount = marker?.state === 'retryWait' ? Number(marker.retryCount) || 0 : 0;
+      const res = await dispatchOutcome(prospect, eventKey, fact, retryCount, d);
+      if (res.sent) summary.sent += 1;
+      else if (res.reason === 'transient' || res.reason === 'missing_request_id') summary.failed += 1;
+      else summary.skipped += 1;
+    }
+  }
+  if (summary.sent || summary.failed) logger.info(summary, 'google_outcomes.resend.done');
+  return summary;
+}
+
+/**
+ * Worker job (b): SETTLE — poll due pending markers by requestId (deduped by
+ * construction: one event per request). CAS on requestId everywhere, so a
+ * stale poll can never regress a newer state. Duplicate-transaction error
+ * evidence counts as delivered (consistent with transactionId dedup).
+ */
+export async function settleDueOutcomes(deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (!uploadsEnabled()) return { ran: false, reason: 'guarded' };
+  const summary = { ran: true, delivered: 0, retried: 0, failedPermanent: 0, stillPending: 0 };
+  const nowIso = new Date(d.now()).toISOString();
+  for (const eventKey of EVENT_KEYS) {
+    const rows = await d.sequelize.query(
+      `SELECT id,
+              "sourceMetadata"::jsonb -> 'gads' -> $key AS marker
+         FROM prospects
+        WHERE ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'state') = 'pending'
+          AND ("sourceMetadata"::jsonb -> 'gads' -> $key ->> 'nextPollAt') <= $nowIso
+        LIMIT 200`,
+      { bind: { key: eventKey, nowIso }, type: QueryTypes.SELECT }
+    );
+    for (const { id, marker } of rows) {
+      const requestId = marker?.requestId;
+      if (!requestId) continue;
+      const cas = { path: ['gads', eventKey], contains: { state: 'pending', requestId } };
+      const pendingAgeMs = d.now() - Date.parse(marker.sentAt || nowIso);
+      let status = null;
+      try {
+        const body = await d.dmRequestGet(
+          `requestStatus:retrieve?requestId=${encodeURIComponent(requestId)}`,
+          d
+        );
+        status =
+          body?.requestStatusPerDestination?.[0]?.requestStatus ??
+          body?.requestStatus ??
+          body?.status ??
+          null;
+        status = status ? String(status).toUpperCase() : null;
+      } catch (err) {
+        if (/duplicate/i.test(err.message || '')) {
+          // Duplicate-transaction evidence: the event already landed.
+          await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
+          summary.delivered += 1;
+          continue;
+        }
+        logger.warn({ requestId, err: err.message }, 'google_outcomes.settle.retrieve_failed');
+      }
+      if (status === 'SUCCESS' || status === 'PARTIAL_SUCCESS') {
+        await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
+        summary.delivered += 1;
+      } else if (status === 'FAILED') {
+        const retryCount = (Number(marker.retryCount) || 0) + 1;
+        await d.setPath(id, [GADS, eventKey], retryWaitState(retryCount, 'ingest_failed', d), { cas });
+        summary.retried += 1;
+        Sentry.captureMessage('google_outcomes.ingest_failed', {
+          level: 'warning',
+          tags: { source: 'google_outcomes' },
+          extra: { prospectId: id, eventKey, requestId },
+        });
+      } else if (pendingAgeMs > pendingMaxMs()) {
+        await d.setPath(id, [GADS, eventKey], {
+          state: 'failedPermanent',
+          reason: 'pending_timeout',
+          at: nowIso,
+        }, { cas });
+        summary.failedPermanent += 1;
+        Sentry.captureMessage('google_outcomes.pending_timeout', {
+          level: 'warning',
+          tags: { source: 'google_outcomes' },
+          extra: { prospectId: id, eventKey, requestId },
+        });
+      } else {
+        // PROCESSING (or unknown): CAS-advance nextPollAt so in-flight
+        // requests aren't re-polled every tick (backoff toward 1h).
+        const nextDelay = Math.min(Math.round((Date.parse(marker.nextPollAt) - Date.parse(marker.sentAt) || firstPollMs()) * 1.3), 60 * 60_000);
+        await d.setPath(id, [GADS, eventKey], {
+          ...marker,
+          nextPollAt: new Date(d.now() + nextDelay + Math.floor(Math.random() * 30_000)).toISOString(),
+        }, { cas });
+        summary.stillPending += 1;
+      }
+    }
+  }
+  if (summary.delivered || summary.retried || summary.failedPermanent) {
+    logger.info(summary, 'google_outcomes.settle.done');
+  }
+  return summary;
+}

--- a/backend/src/services/googleOfflineConversionsService.js
+++ b/backend/src/services/googleOfflineConversionsService.js
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/node';
+import crypto from 'crypto';
 import { QueryTypes } from 'sequelize';
 import { sequelize, Prospect } from '../models/index.js';
 import { hashEmailGoogle, hashPhoneE164 } from '../utils/piiHashing.js';
 import { dmRequest, dmRequestGet } from '../utils/googleDataManagerClient.js';
-import { mergeFirstWins, setPath } from '../utils/prospectJsonPatch.js';
+import { setPath } from '../utils/prospectJsonPatch.js';
 import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
 import { logger } from '../utils/logger.js';
 
@@ -14,25 +15,32 @@ import { logger } from '../utils/logger.js';
  * not just a lead.
  *
  * Truth model (§4.3):
- *  - `sourceMetadata.outcomes.{eventKey} = RFC3339` is the DURABLE FACT,
- *    written first-wins by the inbound paths (leadOutcomeService for
- *    Lyfe/external, the admin edit transaction, the Lyfe reconciler).
- *  - `sourceMetadata.gads.{eventKey}` is the delivery STATE MACHINE, every
- *    transition an atomic CAS write (prospectJsonPatch): pending →
- *    delivered / retryWait / failedPermanent, plus skippedPermanent for
- *    facts that can never send. Key absence is never the retry ledger.
- *  - Google's diagnostics window is 30min→24h, so settlement is DEFERRED to
- *    the worker; in-run truth is acceptance-only.
+ *  - `sourceMetadata.outcomes.{eventKey}` is the DURABLE FACT (first-wins,
+ *    written by the inbound paths + the Lyfe reconciler).
+ *  - `sourceMetadata.gads.{eventKey}` is the delivery STATE MACHINE. Every
+ *    dispatch first CLAIMS the key with an atomic CAS write (state:
+ *    'sending' + a random claimToken) — the claim is what makes inline
+ *    dispatch and the worker race-safe: whichever loses the CAS walks away.
+ *    All post-send transitions CAS against that exact claim, so a stale
+ *    writer can never regress a newer marker or reset retry history. The
+ *    claim write carries the erased guard, so a freshly scrubbed row
+ *    rejects the claim and nothing sends (dispatch also reloads FRESH state
+ *    before building the envelope).
+ *  - States: sending → pending → delivered | retryWait | failedPermanent,
+ *    plus skippedPermanent for facts that can never send. retryCount rides
+ *    through sending AND pending. Key absence is never the retry ledger.
+ *  - Settlement classifies the diagnostics ERROR TAXONOMY, not just the
+ *    status enum: duplicate-transaction evidence = delivered; permanent
+ *    validation/consent/age reasons = failedPermanent; the rest retry.
  *
- * Eligibility is GOOGLE-specific, not a shouldFireCapi clone: upload ALL
- * outcomes (Meta-Lead-Ads-origin leads included — unmatched events are
- *  expected and free); skip call_bot for data quality. A missing
- * conversion-action id is deployment CONFIG — a per-key preflight that
- * aborts the key's pass without mutating rows, so supplying the env later
- * sends the untouched facts.
+ * Eligibility is GOOGLE-specific: upload ALL outcomes (Meta-Lead-Ads-origin
+ * leads included); skip call_bot for data quality. Identifier usability is
+ * decided AFTER the consent ledger: a click id always counts; PII counts
+ * only with a live grant. PII-only + ledger OUTAGE → retryWait (never send
+ * blind, never skip permanently); PII-only + actual denial → terminal skip.
+ * A missing conversion-action id is deployment CONFIG — a per-key worker
+ * preflight, never a row marker.
  */
-
-const TERMINAL = new Set(['SUCCESS', 'PARTIAL_SUCCESS', 'FAILED']);
 
 const defaultDeps = {
   Prospect,
@@ -40,10 +48,14 @@ const defaultDeps = {
   dmRequest,
   dmRequestGet,
   canMarketTo: ledgerCanMarketTo,
-  mergeFirstWins,
   setPath,
   now: Date.now,
+  randomUUID: () => crypto.randomUUID(),
 };
+
+const GADS = 'gads';
+const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
+const DEFAULT_VALUES = { confirmed_resident: 40, closed_won: 500 };
 
 /** Env-mapped conversion actions per event key (destination productDestinationId). */
 export function actionIdFor(eventKey) {
@@ -52,7 +64,8 @@ export function actionIdFor(eventKey) {
   return null;
 }
 
-function valueFor(eventKey) {
+/** Plan-contracted defaults (S$40 / S$500) survive missing/garbage env. */
+export function valueFor(eventKey) {
   const raw =
     eventKey === 'confirmed_resident'
       ? process.env.GOOGLE_VALUE_QUALIFIED
@@ -60,7 +73,8 @@ function valueFor(eventKey) {
         ? process.env.GOOGLE_VALUE_WON
         : null;
   const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? n : null;
+  if (Number.isFinite(n) && n > 0) return n;
+  return DEFAULT_VALUES[eventKey] ?? null;
 }
 
 /** Master switch + creds. Action ids are a per-key PREFLIGHT, not gated here. */
@@ -76,51 +90,46 @@ export function uploadsEnabled() {
 function maxAgeMs() {
   return Math.max(1, Number(process.env.GOOGLE_CONV_MAX_AGE_DAYS) || 60) * 24 * 60 * 60 * 1000;
 }
-
 function maxRetries() {
   return Math.max(0, Number(process.env.GOOGLE_SEND_MAX_RETRIES) || 5);
 }
-
 function pendingMaxMs() {
   return Math.max(1, Number(process.env.GOOGLE_PENDING_MAX_DAYS) || 7) * 24 * 60 * 60 * 1000;
 }
+function firstPollMs() {
+  return Math.max(1, Number(process.env.GOOGLE_CM_FIRST_POLL_MINUTES) || 30) * 60_000;
+}
 
 /**
- * Fact-level eligibility. Returns `{ ok: true }` or
- * `{ ok: false, reason }` where reason is PERMANENT (skippedPermanent):
- * call_bot origin, no identifier ever, click/signup outside the import
- * window. NOT here: missing action id (config preflight), erased rows
- * (the atomic writes' guard blocks them; dispatch also re-checks).
+ * CONSENT-INDEPENDENT permanent screens: bot origin, erased skeleton, click
+ * age. Identifier usability is decided later, after the ledger. The age
+ * anchor is the CLICK capture (or signup for click-less rows) and future
+ * anchors are clamped to `now` at intake — a forged future timestamp cannot
+ * extend the window.
  */
-export function factEligibility(prospect, deps = {}) {
+export function factScreen(prospect, deps = {}) {
   const d = { ...defaultDeps, ...deps };
+  if (prospect?.sourceMetadata?.erased === true) return { ok: false, reason: 'erased', terminal: false };
   if (prospect?.leadSource === 'call_bot' || prospect?.retellCallId) {
-    return { ok: false, reason: 'call_bot' };
+    return { ok: false, reason: 'call_bot', terminal: true };
   }
   const gcl = prospect?.sourceMetadata?.gcl || null;
-  const hasClickId = Boolean(gcl?.gclid || gcl?.gbraid || gcl?.wbraid);
-  const hasPii = Boolean(hashEmailGoogle(prospect?.email) || hashPhoneE164(prospect?.phone));
-  if (!hasClickId && !hasPii) return { ok: false, reason: 'no_identifier' };
-  // Age guard measures from the CLICK (capture lands minutes after it), or
-  // the signup for PII-only events — never from the outcome (plan §4.2).
   const anchor = gcl?.capturedAt || prospect?.createdAt;
   const anchorMs = anchor ? Date.parse(anchor) : NaN;
-  if (!Number.isNaN(anchorMs) && d.now() - anchorMs > maxAgeMs()) {
-    return { ok: false, reason: 'age_window_expired' };
+  const effectiveAnchor = Number.isNaN(anchorMs) ? d.now() : Math.min(anchorMs, d.now());
+  if (d.now() - effectiveAnchor > maxAgeMs()) {
+    return { ok: false, reason: 'age_window_expired', terminal: true };
   }
   return { ok: true };
 }
 
 /**
- * Build the single-event ingest envelope. One event per request BY DESIGN:
- * diagnostics is aggregate-only, so a requestId must map to exactly one
- * marker (plan §4.2). Consent enums ride ONLY with userData — a
- * CONSENT_GRANTED declaration on a click-only event for a withdrawn person
- * would be false. encoding:HEX accompanies hashed userData and is omitted
- * on click-only events.
+ * Build the single-event ingest envelope from a FRESH row. `identifiers`
+ * comes from the post-ledger decision — the envelope always carries at
+ * least one match surface by construction. `eventSource` is REQUIRED for
+ * offline conversions; consent enums ride ONLY with userData.
  */
-export function buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { marketingConsent }) {
-  const gcl = prospect?.sourceMetadata?.gcl || {};
+export function buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, identifiers) {
   const event = {
     eventSource: 'OTHER',
     eventTimestamp: new Date(occurredAtIso).toISOString(),
@@ -131,24 +140,9 @@ export function buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { market
     event.conversionValue = value;
     event.currency = 'SGD';
   }
-  const adIdentifiers = {};
-  if (gcl.gclid) adIdentifiers.gclid = gcl.gclid;
-  if (gcl.gbraid) adIdentifiers.gbraid = gcl.gbraid;
-  if (gcl.wbraid) adIdentifiers.wbraid = gcl.wbraid;
-  if (Object.keys(adIdentifiers).length) event.adIdentifiers = adIdentifiers;
-
-  let hasUserData = false;
-  if (marketingConsent === true) {
-    const userIdentifiers = [];
-    const em = hashEmailGoogle(prospect?.email);
-    const ph = hashPhoneE164(prospect?.phone);
-    if (em) userIdentifiers.push({ emailAddress: em });
-    if (ph) userIdentifiers.push({ phoneNumber: ph });
-    if (userIdentifiers.length) {
-      event.userData = { userIdentifiers };
-      hasUserData = true;
-    }
-  }
+  if (Object.keys(identifiers.adIdentifiers).length) event.adIdentifiers = identifiers.adIdentifiers;
+  const hasUserData = identifiers.userIdentifiers.length > 0;
+  if (hasUserData) event.userData = { userIdentifiers: identifiers.userIdentifiers };
 
   return {
     destinations: [
@@ -167,94 +161,6 @@ export function buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { market
   };
 }
 
-const GADS = 'gads';
-
-/**
- * Dispatch ONE outcome for one prospect. Assumes the caller verified: master
- * switch on, action id present (preflight), a `outcomes.{eventKey}` fact
- * exists, and no terminal/pending marker blocks the send. `retryCount`
- * carries across accepted-then-failed cycles (it rides in BOTH pending and
- * retryWait — plan round-5). Never throws.
- */
-export async function dispatchOutcome(prospect, eventKey, occurredAtIso, retryCount, deps = {}) {
-  const d = { ...defaultDeps, ...deps };
-  const eligible = factEligibility(prospect, d);
-  if (!eligible.ok) {
-    await d.setPath(prospect.id, [GADS, eventKey], {
-      state: 'skippedPermanent',
-      reason: eligible.reason,
-      at: new Date(d.now()).toISOString(),
-    });
-    logger.info({ prospectId: prospect.id, eventKey, reason: eligible.reason }, 'google_outcomes.skipped');
-    return { sent: false, reason: eligible.reason };
-  }
-  if (retryCount >= maxRetries()) {
-    await d.setPath(prospect.id, [GADS, eventKey], {
-      state: 'failedPermanent',
-      reason: 'retry_cap',
-      at: new Date(d.now()).toISOString(),
-    });
-    Sentry.captureMessage('google_outcomes.retry_cap', {
-      level: 'warning',
-      tags: { source: 'google_outcomes' },
-      extra: { prospectId: prospect.id, eventKey, retryCount },
-    });
-    return { sent: false, reason: 'retry_cap' };
-  }
-
-  let marketingConsent = false;
-  try {
-    marketingConsent =
-      (await d.canMarketTo({
-        consumerId: prospect.consumerId,
-        phone: prospect.phone,
-        channel: 'all',
-        campaignId: prospect.campaignId || null,
-      })) === true;
-  } catch (err) {
-    // FAIL CLOSED on ledger error: click-only event still sends (session
-    // identifiers), PII stays home — mirrors the Meta em/ph posture.
-    logger.warn({ err: err.message }, 'google_outcomes.canMarketTo_failed (PII omitted)');
-  }
-
-  const envelope = buildOutcomeEnvelope(prospect, eventKey, occurredAtIso, { marketingConsent });
-  try {
-    const res = await d.dmRequest('events:ingest', envelope, d);
-    if (!res?.requestId) {
-      // Un-settleable accept — schedule a bounded retry, never silent success.
-      await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'missing_request_id', d));
-      return { sent: false, reason: 'missing_request_id' };
-    }
-    await d.setPath(prospect.id, [GADS, eventKey], {
-      state: 'pending',
-      requestId: res.requestId,
-      retryCount,
-      sentAt: new Date(d.now()).toISOString(),
-      nextPollAt: new Date(d.now() + firstPollMs()).toISOString(),
-    });
-    logger.info({ prospectId: prospect.id, eventKey, requestId: res.requestId }, 'google_outcomes.accepted');
-    return { sent: true, requestId: res.requestId };
-  } catch (err) {
-    const permanent = typeof err.status === 'number' && err.status >= 400 && err.status < 500 && err.status !== 429;
-    if (permanent) {
-      await d.setPath(prospect.id, [GADS, eventKey], {
-        state: 'failedPermanent',
-        reason: `http_${err.status}`,
-        at: new Date(d.now()).toISOString(),
-      });
-      Sentry.captureException(err, { tags: { source: 'google_outcomes' } });
-      return { sent: false, reason: 'permanent' };
-    }
-    await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'transient', d));
-    logger.warn({ prospectId: prospect.id, eventKey, err: err.message }, 'google_outcomes.transient');
-    return { sent: false, reason: 'transient' };
-  }
-}
-
-function firstPollMs() {
-  return Math.max(1, Number(process.env.GOOGLE_CM_FIRST_POLL_MINUTES) || 30) * 60_000;
-}
-
 function retryWaitState(retryCount, lastReason, d) {
   const backoff = Math.min(5 * 60_000 * 2 ** Math.max(0, retryCount - 1), 6 * 60 * 60_000);
   return {
@@ -265,13 +171,209 @@ function retryWaitState(retryCount, lastReason, d) {
   };
 }
 
-const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
+/**
+ * CLAIM-then-send dispatch for ONE (prospect, eventKey). Race-safe by
+ * construction: the claim is an atomic CAS (absent → sending, or the exact
+ * due retryWait → sending), so inline dispatch and the worker can both call
+ * this concurrently and exactly one proceeds. Every subsequent transition
+ * CASes against the claim token; a zero-row CAS is logged and NEVER
+ * reported as success. Never throws.
+ */
+export async function dispatchOutcome(prospectId, eventKey, deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  const claimToken = d.randomUUID();
+
+  // FRESH row — stale callers must not upload stale identifiers (B2), and
+  // the durable fact is the canonical occurred_at.
+  const prospect = await d.Prospect.findByPk(prospectId, { raw: true });
+  if (!prospect) return { sent: false, reason: 'missing_row' };
+  const fact = prospect.sourceMetadata?.outcomes?.[eventKey];
+  if (!fact) return { sent: false, reason: 'no_fact' };
+
+  const existing = prospect.sourceMetadata?.gads?.[eventKey];
+  let retryCount = 0;
+  let claimCas;
+  if (existing === undefined) {
+    claimCas = { path: [GADS, eventKey], absent: true };
+  } else if (existing?.state === 'retryWait') {
+    const due = Date.parse(existing.nextSendAt || 0) <= d.now();
+    if (!due) return { sent: false, reason: 'not_due' };
+    retryCount = Number(existing.retryCount) || 0;
+    claimCas = { path: [GADS, eventKey], contains: { state: 'retryWait', retryCount: existing.retryCount } };
+  } else {
+    return { sent: false, reason: 'marker_present' };
+  }
+
+  const screen = factScreen(prospect, d);
+  if (!screen.ok && screen.terminal) {
+    const n = await d.setPath(
+      prospect.id,
+      [GADS, eventKey],
+      { state: 'skippedPermanent', reason: screen.reason, at: new Date(d.now()).toISOString() },
+      { cas: claimCas }
+    );
+    if (n > 0) logger.info({ prospectId, eventKey, reason: screen.reason }, 'google_outcomes.skipped');
+    return { sent: false, reason: screen.reason };
+  }
+  if (!screen.ok) return { sent: false, reason: screen.reason }; // erased: guard blocks writes anyway
+
+  if (retryCount >= maxRetries()) {
+    const n = await d.setPath(
+      prospect.id,
+      [GADS, eventKey],
+      { state: 'failedPermanent', reason: 'retry_cap', at: new Date(d.now()).toISOString() },
+      { cas: claimCas }
+    );
+    if (n > 0) {
+      Sentry.captureMessage('google_outcomes.retry_cap', {
+        level: 'warning',
+        tags: { source: 'google_outcomes' },
+        extra: { prospectId, eventKey, retryCount },
+      });
+    }
+    return { sent: false, reason: 'retry_cap' };
+  }
+
+  // THE CLAIM — losing it means someone else owns this send.
+  const claimed = await d.setPath(
+    prospect.id,
+    [GADS, eventKey],
+    { state: 'sending', claimToken, retryCount, claimedAt: new Date(d.now()).toISOString() },
+    { cas: claimCas }
+  );
+  if (claimed === 0) return { sent: false, reason: 'claim_lost' };
+  const claimGuard = { path: [GADS, eventKey], contains: { state: 'sending', claimToken } };
+
+  try {
+    // Identifier decision AFTER the ledger (M1): click ids always usable;
+    // PII only with a live grant. Ledger outage + PII-only → retryWait —
+    // never send an identifier-less event, never skip permanently on an
+    // infrastructure blip.
+    const gcl = prospect.sourceMetadata?.gcl || {};
+    const adIdentifiers = {};
+    if (gcl.gclid) adIdentifiers.gclid = gcl.gclid;
+    if (gcl.gbraid) adIdentifiers.gbraid = gcl.gbraid;
+    if (gcl.wbraid) adIdentifiers.wbraid = gcl.wbraid;
+    const hasClickId = Object.keys(adIdentifiers).length > 0;
+
+    let consent = false;
+    let ledgerOutage = false;
+    try {
+      consent =
+        (await d.canMarketTo({
+          consumerId: prospect.consumerId,
+          phone: prospect.phone,
+          channel: 'all',
+          campaignId: prospect.campaignId || null,
+        })) === true;
+    } catch (err) {
+      ledgerOutage = true;
+      logger.warn({ err: err.message }, 'google_outcomes.canMarketTo_failed');
+    }
+
+    const userIdentifiers = [];
+    if (consent) {
+      const em = hashEmailGoogle(prospect.email);
+      const ph = hashPhoneE164(prospect.phone);
+      if (em) userIdentifiers.push({ emailAddress: em });
+      if (ph) userIdentifiers.push({ phoneNumber: ph });
+    }
+
+    if (!hasClickId && userIdentifiers.length === 0) {
+      if (ledgerOutage) {
+        await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'ledger_outage', d), { cas: claimGuard });
+        return { sent: false, reason: 'ledger_outage' };
+      }
+      await d.setPath(
+        prospect.id,
+        [GADS, eventKey],
+        { state: 'skippedPermanent', reason: 'no_identifier', at: new Date(d.now()).toISOString() },
+        { cas: claimGuard }
+      );
+      return { sent: false, reason: 'no_identifier' };
+    }
+
+    const envelope = buildOutcomeEnvelope(prospect, eventKey, fact, { adIdentifiers, userIdentifiers });
+    const res = await d.dmRequest('events:ingest', envelope, d);
+    if (!res?.requestId) {
+      await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'missing_request_id', d), { cas: claimGuard });
+      return { sent: false, reason: 'missing_request_id' };
+    }
+    const n = await d.setPath(
+      prospect.id,
+      [GADS, eventKey],
+      {
+        state: 'pending',
+        requestId: res.requestId,
+        retryCount,
+        sentAt: new Date(d.now()).toISOString(),
+        nextPollAt: new Date(d.now() + firstPollMs()).toISOString(),
+      },
+      { cas: claimGuard }
+    );
+    if (n === 0) {
+      // Claim vanished under us (erasure is the only writer that can do
+      // that) — the upload happened; transactionId dedup absorbs a re-send.
+      logger.warn({ prospectId, eventKey }, 'google_outcomes.claim_lost_post_send');
+    }
+    logger.info({ prospectId, eventKey, requestId: res.requestId }, 'google_outcomes.accepted');
+    return { sent: true, requestId: res.requestId };
+  } catch (err) {
+    const permanent = typeof err.status === 'number' && err.status >= 400 && err.status < 500 && err.status !== 429;
+    if (permanent) {
+      await d.setPath(
+        prospect.id,
+        [GADS, eventKey],
+        { state: 'failedPermanent', reason: `http_${err.status}`, at: new Date(d.now()).toISOString() },
+        { cas: claimGuard }
+      );
+      Sentry.captureException(err, { tags: { source: 'google_outcomes' } });
+      return { sent: false, reason: 'permanent' };
+    }
+    await d.setPath(prospect.id, [GADS, eventKey], retryWaitState(retryCount + 1, 'transient', d), { cas: claimGuard });
+    logger.warn({ prospectId, eventKey, err: err.message }, 'google_outcomes.transient');
+    return { sent: false, reason: 'transient' };
+  }
+}
+
+/**
+ * Classify a diagnostics response (M2): the reason TAXONOMY decides, not the
+ * bare status enum. Returns 'delivered' | 'permanent' | 'transient' |
+ * 'processing'. Exported for testing; exact field names re-pinned by the
+ * validateOnly smoke before flip (§9).
+ */
+export function classifyStatusBody(body) {
+  const dest = body?.requestStatusPerDestination?.[0];
+  const status = String(dest?.requestStatus ?? body?.requestStatus ?? body?.status ?? '').toUpperCase();
+  const countBuckets = [];
+  const collect = (info) => {
+    const counts = info?.errorCounts || info?.errors || [];
+    for (const c of Array.isArray(counts) ? counts : []) {
+      countBuckets.push(String(c?.reason ?? c?.errorReason ?? c?.code ?? '').toLowerCase());
+    }
+  };
+  collect(dest?.errorInfo);
+  collect(dest?.eventsIngestionStatus?.errorInfo);
+  collect(body?.errorInfo);
+  const reasons = countBuckets.filter(Boolean);
+  const hasDuplicate = reasons.some((r) => r.includes('duplicate'));
+  const hasPermanent = reasons.some((r) =>
+    /(invalid|validation|malformed|consent|denied|too_old|age|unsupported)/.test(r)
+  );
+  if (status === 'SUCCESS') return 'delivered';
+  if (status === 'PARTIAL_SUCCESS' || status === 'FAILED') {
+    if (hasDuplicate) return 'delivered';
+    if (hasPermanent) return 'permanent';
+    return 'transient';
+  }
+  return 'processing';
+}
 
 /**
  * Worker job (a): RE-SEND — rows holding an `outcomes.{key}` fact whose gads
  * marker is absent or in a due retryWait. Per-key config preflight: a
- * missing action id aborts THAT key's pass with a log (no row mutation) so
- * later config still sends the untouched facts.
+ * missing action id aborts THAT key's pass (no row mutation). Dispatch does
+ * its own claiming, so overlap with inline sends is safe.
  */
 export async function resendDueOutcomes(deps = {}) {
   const d = { ...defaultDeps, ...deps };
@@ -297,15 +399,9 @@ export async function resendDueOutcomes(deps = {}) {
       { bind: { key: eventKey, nowIso: new Date(d.now()).toISOString() }, type: QueryTypes.SELECT }
     );
     for (const { id } of rows) {
-      const prospect = await d.Prospect.findByPk(id, { raw: true });
-      if (!prospect) continue;
-      const fact = prospect.sourceMetadata?.outcomes?.[eventKey];
-      if (!fact) continue;
-      const marker = prospect.sourceMetadata?.gads?.[eventKey];
-      const retryCount = marker?.state === 'retryWait' ? Number(marker.retryCount) || 0 : 0;
-      const res = await dispatchOutcome(prospect, eventKey, fact, retryCount, d);
+      const res = await dispatchOutcome(id, eventKey, d);
       if (res.sent) summary.sent += 1;
-      else if (res.reason === 'transient' || res.reason === 'missing_request_id') summary.failed += 1;
+      else if (['transient', 'missing_request_id', 'ledger_outage'].includes(res.reason)) summary.failed += 1;
       else summary.skipped += 1;
     }
   }
@@ -314,10 +410,8 @@ export async function resendDueOutcomes(deps = {}) {
 }
 
 /**
- * Worker job (b): SETTLE — poll due pending markers by requestId (deduped by
- * construction: one event per request). CAS on requestId everywhere, so a
- * stale poll can never regress a newer state. Duplicate-transaction error
- * evidence counts as delivered (consistent with transactionId dedup).
+ * Worker job (b): SETTLE — poll due pending markers by requestId. CAS on the
+ * exact pending marker everywhere; classification via the reason taxonomy.
  */
 export async function settleDueOutcomes(deps = {}) {
   const d = { ...defaultDeps, ...deps };
@@ -337,33 +431,31 @@ export async function settleDueOutcomes(deps = {}) {
     for (const { id, marker } of rows) {
       const requestId = marker?.requestId;
       if (!requestId) continue;
-      const cas = { path: ['gads', eventKey], contains: { state: 'pending', requestId } };
+      const cas = { path: [GADS, eventKey], contains: { state: 'pending', requestId } };
       const pendingAgeMs = d.now() - Date.parse(marker.sentAt || nowIso);
-      let status = null;
+      let classification = 'processing';
       try {
         const body = await d.dmRequestGet(
           `requestStatus:retrieve?requestId=${encodeURIComponent(requestId)}`,
           d
         );
-        status =
-          body?.requestStatusPerDestination?.[0]?.requestStatus ??
-          body?.requestStatus ??
-          body?.status ??
-          null;
-        status = status ? String(status).toUpperCase() : null;
+        classification = classifyStatusBody(body);
       } catch (err) {
-        if (/duplicate/i.test(err.message || '')) {
-          // Duplicate-transaction evidence: the event already landed.
-          await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
-          summary.delivered += 1;
-          continue;
-        }
-        logger.warn({ requestId, err: err.message }, 'google_outcomes.settle.retrieve_failed');
+        if (/duplicate/i.test(err.message || '')) classification = 'delivered';
+        else logger.warn({ requestId, err: err.message }, 'google_outcomes.settle.retrieve_failed');
       }
-      if (status === 'SUCCESS' || status === 'PARTIAL_SUCCESS') {
+      if (classification === 'delivered') {
         await d.setPath(id, [GADS, eventKey], { state: 'delivered', requestId, deliveredAt: nowIso }, { cas });
         summary.delivered += 1;
-      } else if (status === 'FAILED') {
+      } else if (classification === 'permanent') {
+        await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'ingest_rejected', at: nowIso }, { cas });
+        summary.failedPermanent += 1;
+        Sentry.captureMessage('google_outcomes.ingest_rejected', {
+          level: 'warning',
+          tags: { source: 'google_outcomes' },
+          extra: { prospectId: id, eventKey, requestId },
+        });
+      } else if (classification === 'transient') {
         const retryCount = (Number(marker.retryCount) || 0) + 1;
         await d.setPath(id, [GADS, eventKey], retryWaitState(retryCount, 'ingest_failed', d), { cas });
         summary.retried += 1;
@@ -373,11 +465,7 @@ export async function settleDueOutcomes(deps = {}) {
           extra: { prospectId: id, eventKey, requestId },
         });
       } else if (pendingAgeMs > pendingMaxMs()) {
-        await d.setPath(id, [GADS, eventKey], {
-          state: 'failedPermanent',
-          reason: 'pending_timeout',
-          at: nowIso,
-        }, { cas });
+        await d.setPath(id, [GADS, eventKey], { state: 'failedPermanent', reason: 'pending_timeout', at: nowIso }, { cas });
         summary.failedPermanent += 1;
         Sentry.captureMessage('google_outcomes.pending_timeout', {
           level: 'warning',
@@ -385,13 +473,16 @@ export async function settleDueOutcomes(deps = {}) {
           extra: { prospectId: id, eventKey, requestId },
         });
       } else {
-        // PROCESSING (or unknown): CAS-advance nextPollAt so in-flight
-        // requests aren't re-polled every tick (backoff toward 1h).
-        const nextDelay = Math.min(Math.round((Date.parse(marker.nextPollAt) - Date.parse(marker.sentAt) || firstPollMs()) * 1.3), 60 * 60_000);
-        await d.setPath(id, [GADS, eventKey], {
-          ...marker,
-          nextPollAt: new Date(d.now() + nextDelay + Math.floor(Math.random() * 30_000)).toISOString(),
-        }, { cas });
+        const nextDelay = Math.min(
+          Math.round((Date.parse(marker.nextPollAt) - Date.parse(marker.sentAt) || firstPollMs()) * 1.3),
+          60 * 60_000
+        );
+        await d.setPath(
+          id,
+          [GADS, eventKey],
+          { ...marker, nextPollAt: new Date(d.now() + nextDelay + Math.floor(Math.random() * 30_000)).toISOString() },
+          { cas }
+        );
         summary.stillPending += 1;
       }
     }

--- a/backend/src/services/googleOfflineConversionsService.js
+++ b/backend/src/services/googleOfflineConversionsService.js
@@ -55,14 +55,16 @@ const defaultDeps = {
 
 const GADS = 'gads';
 const SENDING_LEASE_MS = 10 * 60_000; // stale-claim reclaim window (crash recovery)
-// Deterministic processing enums that a retry of the UNCHANGED event cannot
-// repair (official Data Manager status reasons; extend as observed).
+// Deterministic ProcessingErrorReason values a retry of the UNCHANGED event
+// cannot repair. The API namespaces them as PROCESSING_ERROR_REASON_<SUFFIX>
+// (Codex P3-3 #1) — canonicalizeReason strips that prefix so this set holds
+// the documented suffixes. Unknown reasons default to RETRY.
+const PROCESSING_REASON_PREFIX = 'PROCESSING_ERROR_REASON_';
 const PERMANENT_REASONS = new Set([
-  'INVALID_ARGUMENT',
   'INVALID_EVENT',
   'INVALID_TIMESTAMP',
   'EVENT_TOO_OLD',
-  'CONSENT_DENIED',
+  'DENIED_CONSENT',
   'MISSING_CONSENT',
   'DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED',
   'DESTINATION_ACCOUNT_CUSTOMER_MATCH_TERMS_NOT_SIGNED',
@@ -71,6 +73,12 @@ const PERMANENT_REASONS = new Set([
   'UNSUPPORTED_EVENT_SOURCE',
   'MALFORMED_IDENTIFIER',
 ]);
+
+/** Strip the ProcessingErrorReason namespace; unknown shapes pass through. */
+export function canonicalizeReason(reason) {
+  const up = String(reason || '').toUpperCase();
+  return up.startsWith(PROCESSING_REASON_PREFIX) ? up.slice(PROCESSING_REASON_PREFIX.length) : up;
+}
 const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
 const DEFAULT_VALUES = { confirmed_resident: 40, closed_won: 500 };
 
@@ -406,7 +414,7 @@ export function classifyStatusBody(body) {
   // unchanged event cannot sign terms or fix an account mismatch) and broad
   // substrings are unsafe against future enums. Unknown reasons default to
   // RETRY. Set re-pinned by the validateOnly smoke / first live failures.
-  const hasPermanent = reasons.some((r) => PERMANENT_REASONS.has(r.toUpperCase()));
+  const hasPermanent = reasons.some((r) => PERMANENT_REASONS.has(canonicalizeReason(r)));
   if (status === 'SUCCESS') return 'delivered';
   if (status === 'PARTIAL_SUCCESS' || status === 'FAILED') {
     if (hasDuplicate) return 'delivered';
@@ -535,13 +543,13 @@ export async function settleDueOutcomes(deps = {}) {
           Math.round((Date.parse(marker.nextPollAt) - Date.parse(marker.sentAt) || firstPollMs()) * 1.3),
           60 * 60_000
         );
-        await d.setPath(
+        const n = await d.setPath(
           id,
           [GADS, eventKey],
           { ...marker, nextPollAt: new Date(d.now() + nextDelay + Math.floor(Math.random() * 30_000)).toISOString() },
           { cas }
         );
-        summary.stillPending += 1;
+        if (n > 0) summary.stillPending += 1;
       }
     }
   }

--- a/backend/src/services/googleOfflineConversionsService.js
+++ b/backend/src/services/googleOfflineConversionsService.js
@@ -59,13 +59,16 @@ const SENDING_LEASE_MS = 10 * 60_000; // stale-claim reclaim window (crash recov
 // cannot repair. The API namespaces them as PROCESSING_ERROR_REASON_<SUFFIX>
 // (Codex P3-3 #1) — canonicalizeReason strips that prefix so this set holds
 // the documented suffixes. Unknown reasons default to RETRY.
-const PROCESSING_REASON_PREFIX = 'PROCESSING_ERROR_REASON_';
+// Google's enum namespace has an EXCEPTION: most values are
+// PROCESSING_ERROR_REASON_<SUFFIX>, but at least one documented value uses
+// the bare PROCESSING_ERROR_ prefix — strip the longest matching prefix.
+const PROCESSING_REASON_PREFIXES = ['PROCESSING_ERROR_REASON_', 'PROCESSING_ERROR_'];
 const PERMANENT_REASONS = new Set([
   'INVALID_EVENT',
   'INVALID_TIMESTAMP',
   'EVENT_TOO_OLD',
   'DENIED_CONSENT',
-  'MISSING_CONSENT',
+  'NO_CONSENT',
   'DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED',
   'DESTINATION_ACCOUNT_CUSTOMER_MATCH_TERMS_NOT_SIGNED',
   'OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER',
@@ -77,7 +80,10 @@ const PERMANENT_REASONS = new Set([
 /** Strip the ProcessingErrorReason namespace; unknown shapes pass through. */
 export function canonicalizeReason(reason) {
   const up = String(reason || '').toUpperCase();
-  return up.startsWith(PROCESSING_REASON_PREFIX) ? up.slice(PROCESSING_REASON_PREFIX.length) : up;
+  for (const prefix of PROCESSING_REASON_PREFIXES) {
+    if (up.startsWith(prefix)) return up.slice(prefix.length);
+  }
+  return up;
 }
 const EVENT_KEYS = ['confirmed_resident', 'closed_won'];
 const DEFAULT_VALUES = { confirmed_resident: 40, closed_won: 500 };

--- a/backend/src/services/googleOutcomesReconciler.js
+++ b/backend/src/services/googleOutcomesReconciler.js
@@ -1,0 +1,164 @@
+import * as Sentry from '@sentry/node';
+import { Prospect } from '../models/index.js';
+import { mergeFirstWins } from '../utils/prospectJsonPatch.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Lyfe outcome reconciler (plan google-ads-signal-levers §4.3): the
+ * DURABILITY NET for outcome facts. The Lyfe webhook is fire-and-forget at
+ * the source (its pg_net trigger discards the response — nothing upstream
+ * ever retries), so a missed delivery or a fact-write failure would
+ * otherwise lose the outcome forever. This job reads Lyfe's Supabase
+ * directly (same service-role env the agent sync uses) and back-fills any
+ * missing `sourceMetadata.outcomes` facts — which also BACKFILLS the
+ * outcomes that predate this arc entirely.
+ *
+ * Status mapping (rounds 6–7, pinned against lyfe-app):
+ *  - vocabulary: new | contacted | qualified | proposed | won | lost
+ *  - DIRECT evidence: current `qualified` implies confirmed_resident;
+ *    current `won` implies confirmed_resident + closed_won (the one
+ *    implication Lyfe's own semantics commits to). Timestamps approximate
+ *    to the row's updated_at (documented).
+ *  - HISTORY-FILL for every still-missing key regardless of current status
+ *    (Lyfe permits regressions like won → qualified, and `proposed` alone
+ *    does NOT imply qualification — the SC/PR dialog only fires on
+ *    selecting `qualified`): one batched `lead_activities` query,
+ *    `type=eq.status_change`, transitions read from
+ *    `metadata.to_status`, fact timestamp = the activity's created_at.
+ *    A `proposed` lead with no qualifying transition gets NOTHING — no
+ *    false ConfirmedResident ever enters the bidding signal.
+ *
+ * First-wins merges make webhook, admin, and reconciler writes converge;
+ * the reconciler never overwrites. Erased rows are blocked by the atomic
+ * write's guard. Never throws.
+ */
+
+const KEYS = { CR: 'confirmed_resident', CW: 'closed_won' };
+
+const defaultDeps = { Prospect, fetch: globalThis.fetch, mergeFirstWins };
+
+export function reconcilerConfigured() {
+  if (process.env.GOOGLE_ADS_UPLOADS_ENABLED !== 'true') return false;
+  if (!process.env.LYFE_SUPABASE_URL) return false;
+  if (!process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY) return false;
+  return true;
+}
+
+function restHeaders() {
+  const key = process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY;
+  return { apikey: key, Authorization: `Bearer ${key}` };
+}
+
+async function restGet(path, d) {
+  const base = process.env.LYFE_SUPABASE_URL.replace(/\/$/, '');
+  const res = await d.fetch(`${base}/rest/v1/${path}`, { headers: restHeaders() });
+  if (!res.ok) {
+    throw new Error(`lyfe rest ${res.status}`);
+  }
+  return res.json();
+}
+
+/** Facts a lead's CURRENT status directly implies (timestamps approximate). */
+export function directWants(status, updatedAt) {
+  if (status === 'qualified') return { [KEYS.CR]: updatedAt };
+  if (status === 'won') return { [KEYS.CR]: updatedAt, [KEYS.CW]: updatedAt };
+  return {};
+}
+
+/** Facts a lead's status_change HISTORY proves (earliest transition wins). */
+export function historyWants(activities) {
+  const wants = {};
+  for (const a of activities || []) {
+    const to = a?.metadata?.to_status;
+    const at = a?.created_at;
+    if (!to || !at) continue;
+    if (to === 'qualified' && !wants[KEYS.CR]) wants[KEYS.CR] = at;
+    if (to === 'won') {
+      if (!wants[KEYS.CR]) wants[KEYS.CR] = at;
+      if (!wants[KEYS.CW]) wants[KEYS.CW] = at;
+    }
+  }
+  return wants;
+}
+
+export async function reconcileLyfeOutcomes(deps = {}) {
+  const d = { ...defaultDeps, ...deps };
+  if (!reconcilerConfigured()) return { ran: false, reason: 'guarded' };
+  const summary = { ran: true, leads: 0, factsWritten: 0, historyLookups: 0, errors: 0 };
+  try {
+    const leads = await restGet(
+      'leads?source_name=eq.mktr&status=in.(qualified,proposed,won,lost)&select=id,external_id,status,updated_at&limit=1000',
+      d
+    );
+    summary.leads = leads.length;
+    if (!leads.length) return summary;
+
+    const prospects = await d.Prospect.findAll({
+      attributes: ['id', 'sourceMetadata'],
+      where: { id: leads.map((l) => l.external_id).filter(Boolean) },
+      raw: true,
+    });
+    const byId = new Map(prospects.map((p) => [p.id, p]));
+
+    // Pass 1: direct evidence + collect history candidates (any lead still
+    // missing a key after direct evidence — round-7: regressions included).
+    const wantsById = new Map();
+    const historyLeadIds = [];
+    for (const lead of leads) {
+      const prospect = byId.get(lead.external_id);
+      if (!prospect) continue;
+      const facts = prospect.sourceMetadata?.outcomes || {};
+      const wants = {};
+      for (const [k, at] of Object.entries(directWants(lead.status, lead.updated_at))) {
+        if (!facts[k]) wants[k] = at;
+      }
+      const stillMissing = [KEYS.CR, KEYS.CW].filter((k) => !facts[k] && !wants[k]);
+      if (stillMissing.length) historyLeadIds.push(lead.id);
+      if (Object.keys(wants).length) wantsById.set(lead.external_id, { wants, leadId: lead.id });
+      else wantsById.set(lead.external_id, { wants: {}, leadId: lead.id });
+    }
+
+    // Pass 2: one batched activities query for the candidates.
+    if (historyLeadIds.length) {
+      summary.historyLookups = historyLeadIds.length;
+      const inList = historyLeadIds.map((id) => `"${id}"`).join(',');
+      const activities = await restGet(
+        `lead_activities?type=eq.status_change&lead_id=in.(${inList})&select=lead_id,created_at,metadata&order=created_at.asc&limit=2000`,
+        d
+      );
+      const byLead = new Map();
+      for (const a of activities) {
+        if (!byLead.has(a.lead_id)) byLead.set(a.lead_id, []);
+        byLead.get(a.lead_id).push(a);
+      }
+      for (const lead of leads) {
+        const entry = wantsById.get(lead.external_id);
+        if (!entry) continue;
+        const prospect = byId.get(lead.external_id);
+        const facts = prospect?.sourceMetadata?.outcomes || {};
+        const proven = historyWants(byLead.get(lead.id));
+        for (const [k, at] of Object.entries(proven)) {
+          if (!facts[k] && !entry.wants[k]) entry.wants[k] = at;
+        }
+      }
+    }
+
+    // Pass 3: first-wins merges (one call per prospect).
+    for (const [prospectId, { wants }] of wantsById) {
+      const keys = Object.keys(wants);
+      if (!keys.length) continue;
+      const normalized = Object.fromEntries(
+        keys.map((k) => [k, new Date(Date.parse(wants[k]) || Date.now()).toISOString()])
+      );
+      const n = await d.mergeFirstWins(prospectId, ['outcomes'], normalized);
+      if (n > 0) summary.factsWritten += keys.length;
+    }
+    if (summary.factsWritten) logger.info(summary, 'google_outcomes.reconcile.done');
+    return summary;
+  } catch (err) {
+    summary.errors += 1;
+    Sentry.captureException(err, { tags: { source: 'google_outcomes_reconcile' } });
+    logger.error({ err: err.message }, 'google_outcomes.reconcile.failed');
+    return summary;
+  }
+}

--- a/backend/src/services/googleOutcomesReconciler.js
+++ b/backend/src/services/googleOutcomesReconciler.js
@@ -82,17 +82,25 @@ export function historyWants(activities) {
 }
 
 const PAGE = 1000;
-const MAX_PAGES = 20;
+const HARD_PAGE_CEILING = 500; // runaway-loop backstop, loudly logged — never a silent cap
 
-/** Paged stable scan — one PostgREST page loop, ordered by id. */
-async function restGetAll(basePath, d) {
+/**
+ * KEYSET-paginated scan on a unique column (offset restarts would silently
+ * skip rows beyond any fixed cap — Codex P3-2 #5). `keyCol` must be selected
+ * by the query and totally ordered.
+ */
+async function restGetAllKeyset(basePath, keyCol, d) {
   const all = [];
-  for (let page = 0; page < MAX_PAGES; page++) {
+  let lastKey = null;
+  for (let page = 0; page < HARD_PAGE_CEILING; page++) {
     const sep = basePath.includes('?') ? '&' : '?';
-    const rows = await restGet(`${basePath}${sep}limit=${PAGE}&offset=${page * PAGE}`, d);
+    const cursor = lastKey === null ? '' : `&${keyCol}=gt.${encodeURIComponent(lastKey)}`;
+    const rows = await restGet(`${basePath}${sep}order=${keyCol}.asc${cursor}&limit=${PAGE}`, d);
     all.push(...rows);
-    if (rows.length < PAGE) break;
+    if (rows.length < PAGE) return all;
+    lastKey = rows[rows.length - 1][keyCol];
   }
+  logger.warn({ basePath, pages: HARD_PAGE_CEILING }, 'google_outcomes.reconcile.page_ceiling_hit');
   return all;
 }
 
@@ -104,8 +112,9 @@ export async function reconcileLyfeOutcomes(deps = {}) {
     // ALL SIX statuses (M3): the history-fill contract is "every still-
     // missing key regardless of current status" — a missed `won` followed by
     // regression to `new`/`contacted` must still be recoverable.
-    const leads = await restGetAll(
-      'leads?source_name=eq.mktr&select=id,external_id,status,updated_at&order=id.asc',
+    const leads = await restGetAllKeyset(
+      'leads?source_name=eq.mktr&select=id,external_id,status,updated_at',
+      'id',
       d
     );
     summary.leads = leads.length;
@@ -146,12 +155,16 @@ export async function reconcileLyfeOutcomes(deps = {}) {
       for (let i = 0; i < historyLeadIds.length; i += 100) {
         const batch = historyLeadIds.slice(i, i + 100);
         const inList = encodeURIComponent(`(${batch.map((id) => `"${id}"`).join(',')})`);
-        const activities = await restGetAll(
+        // Per-batch keyset on the unique activity id; consumers re-sort by
+        // created_at (historyWants takes the EARLIEST transition per key).
+        const activities = await restGetAllKeyset(
           `lead_activities?type=eq.status_change&lead_id=in.${inList}` +
             `&metadata->>to_status=in.(qualified,won)` +
-            `&select=lead_id,created_at,metadata&order=created_at.asc`,
+            `&select=id,lead_id,created_at,metadata`,
+          'id',
           d
         );
+        activities.sort((a, b) => String(a.created_at).localeCompare(String(b.created_at)));
         for (const a of activities) {
           if (!byLead.has(a.lead_id)) byLead.set(a.lead_id, []);
           byLead.get(a.lead_id).push(a);

--- a/backend/src/services/googleOutcomesReconciler.js
+++ b/backend/src/services/googleOutcomesReconciler.js
@@ -81,13 +81,31 @@ export function historyWants(activities) {
   return wants;
 }
 
+const PAGE = 1000;
+const MAX_PAGES = 20;
+
+/** Paged stable scan — one PostgREST page loop, ordered by id. */
+async function restGetAll(basePath, d) {
+  const all = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const sep = basePath.includes('?') ? '&' : '?';
+    const rows = await restGet(`${basePath}${sep}limit=${PAGE}&offset=${page * PAGE}`, d);
+    all.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return all;
+}
+
 export async function reconcileLyfeOutcomes(deps = {}) {
   const d = { ...defaultDeps, ...deps };
   if (!reconcilerConfigured()) return { ran: false, reason: 'guarded' };
   const summary = { ran: true, leads: 0, factsWritten: 0, historyLookups: 0, errors: 0 };
   try {
-    const leads = await restGet(
-      'leads?source_name=eq.mktr&status=in.(qualified,proposed,won,lost)&select=id,external_id,status,updated_at&limit=1000',
+    // ALL SIX statuses (M3): the history-fill contract is "every still-
+    // missing key regardless of current status" — a missed `won` followed by
+    // regression to `new`/`contacted` must still be recoverable.
+    const leads = await restGetAll(
+      'leads?source_name=eq.mktr&select=id,external_id,status,updated_at&order=id.asc',
       d
     );
     summary.leads = leads.length;
@@ -121,15 +139,23 @@ export async function reconcileLyfeOutcomes(deps = {}) {
     // Pass 2: one batched activities query for the candidates.
     if (historyLeadIds.length) {
       summary.historyLookups = historyLeadIds.length;
-      const inList = historyLeadIds.map((id) => `"${id}"`).join(',');
-      const activities = await restGet(
-        `lead_activities?type=eq.status_change&lead_id=in.(${inList})&select=lead_id,created_at,metadata&order=created_at.asc&limit=2000`,
-        d
-      );
+      // Batched + encoded id filters, the JSON to_status predicate applied
+      // SERVER-SIDE (irrelevant transitions must not consume the page), and
+      // per-batch pagination (M3).
       const byLead = new Map();
-      for (const a of activities) {
-        if (!byLead.has(a.lead_id)) byLead.set(a.lead_id, []);
-        byLead.get(a.lead_id).push(a);
+      for (let i = 0; i < historyLeadIds.length; i += 100) {
+        const batch = historyLeadIds.slice(i, i + 100);
+        const inList = encodeURIComponent(`(${batch.map((id) => `"${id}"`).join(',')})`);
+        const activities = await restGetAll(
+          `lead_activities?type=eq.status_change&lead_id=in.${inList}` +
+            `&metadata->>to_status=in.(qualified,won)` +
+            `&select=lead_id,created_at,metadata&order=created_at.asc`,
+          d
+        );
+        for (const a of activities) {
+          if (!byLead.has(a.lead_id)) byLead.set(a.lead_id, []);
+          byLead.get(a.lead_id).push(a);
+        }
       }
       for (const lead of leads) {
         const entry = wantsById.get(lead.external_id);

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -39,6 +39,7 @@
  */
 
 import { Prospect, Campaign } from '../models/index.js';
+import { setPath as setSourceMetadataPath } from '../utils/prospectJsonPatch.js';
 import { sendConversionEvent as metaSendConversionEvent } from './metaCapiService.js';
 import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
 import { logger } from '../utils/logger.js';
@@ -72,6 +73,7 @@ const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const defaultDeps = {
   models: { Prospect, Campaign },
   sendConversionEvent: metaSendConversionEvent,
+  setSourceMetadataPath,
   canMarketTo: ledgerCanMarketTo,
   logger,
   sleep: realSleep,
@@ -181,10 +183,11 @@ export function makeLeadOutcomeService(overrides = {}) {
       const result = await dispatchWithRetry(prospect, ctx, { eventName });
 
       if (result?.sent) {
-        const capi = { ...(prospect.sourceMetadata?.capi || {}), [markerKey]: new Date().toISOString() };
-        prospect.sourceMetadata = { ...(prospect.sourceMetadata || {}), capi };
-        if (typeof prospect.changed === 'function') prospect.changed('sourceMetadata', true);
-        await prospect.save();
+        // Atomic single-key marker write (prospectJsonPatch) — the old
+        // read-spread-save of the whole object could delete keys any OTHER
+        // writer (google markers, outcome facts, redemption) landed between
+        // this handler's load and save (plan google-ads-signal-levers §4.3).
+        await d.setSourceMetadataPath(prospect.id, ['capi', markerKey], new Date().toISOString());
         dispatched.push(eventName);
       } else {
         // Not marked → reconciliation / next trigger can retry. (`guarded` = CAPI off.)

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -39,7 +39,12 @@
  */
 
 import { Prospect, Campaign } from '../models/index.js';
-import { setPath as setSourceMetadataPath } from '../utils/prospectJsonPatch.js';
+import { setPath as setSourceMetadataPath, mergeFirstWins as mergeSourceMetadataFirstWins } from '../utils/prospectJsonPatch.js';
+import {
+  dispatchOutcome as dispatchGoogleOutcome,
+  uploadsEnabled as googleUploadsEnabled,
+  actionIdFor as googleActionIdFor,
+} from './googleOfflineConversionsService.js';
 import { sendConversionEvent as metaSendConversionEvent } from './metaCapiService.js';
 import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
 import { logger } from '../utils/logger.js';
@@ -74,6 +79,10 @@ const defaultDeps = {
   models: { Prospect, Campaign },
   sendConversionEvent: metaSendConversionEvent,
   setSourceMetadataPath,
+  mergeSourceMetadataFirstWins,
+  dispatchGoogleOutcome,
+  googleUploadsEnabled,
+  googleActionIdFor,
   canMarketTo: ledgerCanMarketTo,
   logger,
   sleep: realSleep,
@@ -110,7 +119,7 @@ export function makeLeadOutcomeService(overrides = {}) {
    * @param {object} payload { external_id, new_status, old_status, lead_id, agent_id, occurred_at }
    * @returns {Promise<{dispatched?: string[], duplicate?: string[], failed?: string[], skipped?: string}>}
    */
-  async function processLeadOutcome(payload = {}) {
+  async function processLeadOutcome(payload = {}, context = {}) {
     const { external_id: externalId, new_status: newStatus, occurred_at: occurredAt } = payload;
 
     const keys = eventKeysForStatus(newStatus);
@@ -119,6 +128,37 @@ export function makeLeadOutcomeService(overrides = {}) {
 
     const prospect = await m.Prospect.findByPk(externalId);
     if (!prospect) return { skipped: 'no_prospect' };
+
+    // Canonical outcome timestamp (plan google-ads-signal-levers §4.3):
+    // validated body value → the AUTHENTICATED webhook timestamp (passed
+    // explicitly by the Lyfe controller) → receipt time. The body field is
+    // caller-supplied and unvalidated upstream.
+    const bodyTs = occurredAt ? Date.parse(occurredAt) : NaN;
+    const canonicalOccurredAt = !Number.isNaN(bodyTs)
+      ? new Date(bodyTs).toISOString()
+      : context.signedWebhookAt && !Number.isNaN(Date.parse(context.signedWebhookAt))
+        ? new Date(Date.parse(context.signedWebhookAt)).toISOString()
+        : new Date().toISOString();
+
+    // DURABLE FACTS FIRST, all keys for this status in ONE first-wins merge —
+    // the Google worker re-sends from these, so a crash after this line can
+    // never lose the outcome, and a later `won` can never rewrite an earlier
+    // qualified timestamp. (The admin path writes the same facts inside its
+    // edit transaction; this merge is idempotent against that.)
+    try {
+      await d.mergeSourceMetadataFirstWins(
+        prospect.id,
+        ['outcomes'],
+        Object.fromEntries(keys.map((k) => [k, canonicalOccurredAt]))
+      );
+    } catch (factErr) {
+      // A fact-write failure is the ONLY unrecoverable branch on the Lyfe
+      // path (pg_net never retries) — the Lyfe reconciler is the durability
+      // net. Loudly logged; dispatch still proceeds with in-memory values.
+      d.logger.error('[lead-outcome] outcome fact write failed (reconciler heals)', {
+        prospectId: prospect.id, error: factErr?.message || String(factErr),
+      });
+    }
 
     // Send-time em/ph gate (3sites, supersedes the PR B clone hack): derived
     // from the consent ledger at dispatch time — canMarketTo requires a
@@ -189,7 +229,27 @@ export function makeLeadOutcomeService(overrides = {}) {
         // this handler's load and save (plan google-ads-signal-levers §4.3).
         await d.setSourceMetadataPath(prospect.id, ['capi', markerKey], new Date().toISOString());
         dispatched.push(eventName);
-      } else {
+      }
+
+      // Google offline outcome — SEQUENTIAL after Meta (both write disjoint
+      // sourceMetadata keys atomically), isolated: a Google failure never
+      // blocks the Meta result, the other key, or the 200 to Lyfe. Inline
+      // dispatch is the low-latency path; the worker re-sends anything this
+      // misses from the durable fact.
+      if (d.googleUploadsEnabled() && d.googleActionIdFor(key)) {
+        const existingGads = prospect.sourceMetadata?.gads?.[key];
+        if (!existingGads) {
+          try {
+            await d.dispatchGoogleOutcome(prospect, key, canonicalOccurredAt, 0);
+          } catch (googleErr) {
+            d.logger.warn('[lead-outcome] google outcome dispatch error (worker heals)', {
+              prospectId: prospect.id, key, error: googleErr?.message || String(googleErr),
+            });
+          }
+        }
+      }
+
+      if (!result?.sent) {
         // Not marked → reconciliation / next trigger can retry. (`guarded` = CAPI off.)
         failed.push(eventName);
         if (result?.reason === 'guarded') {

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -146,11 +146,23 @@ export function makeLeadOutcomeService(overrides = {}) {
     // qualified timestamp. (The admin path writes the same facts inside its
     // edit transaction; this merge is idempotent against that.)
     try {
-      await d.mergeSourceMetadataFirstWins(
+      const factRows = await d.mergeSourceMetadataFirstWins(
         prospect.id,
         ['outcomes'],
         Object.fromEntries(keys.map((k) => [k, canonicalOccurredAt]))
       );
+      if (factRows === 0) {
+        // The erased guard is the only thing that blocks a plain merge — a
+        // concurrent erasure won between our load and this write. Nothing
+        // may dispatch from the stale pre-erasure row (B2).
+        const fresh = await m.Prospect.findByPk(prospect.id, { raw: true });
+        if (!fresh || fresh.sourceMetadata?.erased === true) {
+          d.logger.warn('[lead-outcome] row erased mid-flight — dispatch aborted', {
+            prospectId: prospect.id,
+          });
+          return { skipped: 'erased' };
+        }
+      }
     } catch (factErr) {
       // A fact-write failure is the ONLY unrecoverable branch on the Lyfe
       // path (pg_net never retries) — the Lyfe reconciler is the durability
@@ -205,12 +217,10 @@ export function makeLeadOutcomeService(overrides = {}) {
       const { markerKey } = EVENTS[key];
       const eventName = eventNameFor(key);
 
-      // Permanent first-transition dedup. Marker is written only on success
-      // (below), so a never-sent event stays re-tryable.
-      if (prospect.sourceMetadata?.capi?.[markerKey]) {
-        duplicate.push(eventName);
-        continue;
-      }
+      // Permanent first-transition dedup — for the META send only. Google is
+      // evaluated independently below (its own marker owns its dedup).
+      const metaDuplicate = Boolean(prospect.sourceMetadata?.capi?.[markerKey]);
+      if (metaDuplicate) duplicate.push(eventName);
 
       const ctx = {
         // Stable across qualified/won → Meta dedups any duplicate send.
@@ -220,9 +230,9 @@ export function makeLeadOutcomeService(overrides = {}) {
         ...(pixelIdOverride ? { pixelIdOverride } : {}),
       };
 
-      const result = await dispatchWithRetry(prospect, ctx, { eventName });
+      const result = metaDuplicate ? null : await dispatchWithRetry(prospect, ctx, { eventName });
 
-      if (result?.sent) {
+      if (!metaDuplicate && result?.sent) {
         // Atomic single-key marker write (prospectJsonPatch) — the old
         // read-spread-save of the whole object could delete keys any OTHER
         // writer (google markers, outcome facts, redemption) landed between
@@ -237,19 +247,19 @@ export function makeLeadOutcomeService(overrides = {}) {
       // dispatch is the low-latency path; the worker re-sends anything this
       // misses from the durable fact.
       if (d.googleUploadsEnabled() && d.googleActionIdFor(key)) {
-        const existingGads = prospect.sourceMetadata?.gads?.[key];
-        if (!existingGads) {
-          try {
-            await d.dispatchGoogleOutcome(prospect, key, canonicalOccurredAt, 0);
-          } catch (googleErr) {
-            d.logger.warn('[lead-outcome] google outcome dispatch error (worker heals)', {
-              prospectId: prospect.id, key, error: googleErr?.message || String(googleErr),
-            });
-          }
+        // dispatchOutcome reloads the FRESH row, claims the marker with an
+        // atomic CAS (race-safe against the worker), and never throws — the
+        // try is belt-and-braces for injected seams.
+        try {
+          await d.dispatchGoogleOutcome(prospect.id, key);
+        } catch (googleErr) {
+          d.logger.warn('[lead-outcome] google outcome dispatch error (worker heals)', {
+            prospectId: prospect.id, key, error: googleErr?.message || String(googleErr),
+          });
         }
       }
 
-      if (!result?.sent) {
+      if (!metaDuplicate && !result?.sent) {
         // Not marked → reconciliation / next trigger can retry. (`guarded` = CAPI off.)
         failed.push(eventName);
         if (result?.reason === 'guarded') {

--- a/backend/src/services/prospectHelpers.js
+++ b/backend/src/services/prospectHelpers.js
@@ -24,6 +24,19 @@ export function phoneDigits(v) {
   return String(v ?? '').replace(/\D/g, '');
 }
 
+/**
+ * Destination-safe sourceMetadata projection for OUTBOUND webhook payloads
+ * (Codex P3 M5): Google click ids, delivery-state internals, and outcome
+ * facts are ad-plumbing — Lyfe / MKTR Leads have no use for them and online
+ * identifiers must not fan out to third systems. Only the NEW ad-delivery
+ * keys are stripped; historical exposure of other keys is unchanged.
+ */
+export function webhookSafeSourceMetadata(sm) {
+  if (!sm || typeof sm !== 'object') return sm;
+  const { gcl: _gcl, gads: _gads, outcomes: _outcomes, ...rest } = sm;
+  return rest;
+}
+
 export function normalizePhone(phone) {
   if (!phone) return phone;
   let p = String(phone).replace(/\s+/g, '');
@@ -137,7 +150,7 @@ export function buildLeadCreatedPayload(prospect, routingMode, agentForWebhook, 
         location: prospect.location,
         tags: prospect.tags,
         notes: prospect.notes,
-        sourceMetadata: prospect.sourceMetadata,
+        sourceMetadata: webhookSafeSourceMetadata(prospect.sourceMetadata),
         recordingUrl: prospect.sourceMetadata?.recordingUrl || null,
         transcript: prospect.sourceMetadata?.retellCallId ? prospect.notes : null,
         dnc: dncPayloadBlock(prospect),
@@ -200,7 +213,7 @@ export function buildLeadAssignedPayload(prospect, agent, prospectWithCampaign, 
         location: prospect.location,
         tags: prospect.tags,
         notes: prospect.notes,
-        sourceMetadata: meta,
+        sourceMetadata: webhookSafeSourceMetadata(meta),
         recordingUrl: meta.recordingUrl || null,
         transcript: meta.retellCallId ? prospect.notes : null,
         dnc: dncPayloadBlock(prospect),
@@ -240,7 +253,7 @@ export function buildLeadUnassignedPayload(prospect, previousAgentLyfeId, opts =
         phone: prospect.phone,
         email: prospect.email,
         leadSource: prospect.leadSource,
-        sourceMetadata: prospect.sourceMetadata
+        sourceMetadata: webhookSafeSourceMetadata(prospect.sourceMetadata)
       },
       previousAgentId: previousAgentLyfeId,
       // Admin pull-back to the held queue: signals the mktr-leads receiver to SOFT-DELETE

--- a/backend/src/services/prospectMutationService.js
+++ b/backend/src/services/prospectMutationService.js
@@ -140,7 +140,11 @@ export function makeProspectMutationOps({ d, m }) {
     // check above races a concurrent erasure, and a stale phone edit must
     // never re-attach a number to a freshly scrubbed row (410, same as the
     // pre-check).
-    const needsTxn = editingDemographics || phoneChanged || mappedStatusTransition;
+    // EVERY non-empty edit takes the managed transaction (B1): the erased
+    // pre-check above races a concurrent erasure, and ANY field write to the
+    // stale instance (email, name, unmapped status) would re-attach data to
+    // a scrubbed skeleton. The lock-reload + 410 inside is the real gate.
+    const needsTxn = Object.keys(safeUpdates).length > 0;
     try {
       if (needsTxn) {
         await d.sequelize.transaction(async (t) => {

--- a/backend/src/services/prospectMutationService.js
+++ b/backend/src/services/prospectMutationService.js
@@ -56,12 +56,11 @@ export function makeProspectMutationOps({ d, m }) {
     }
     const phoneChanged = safeUpdates.phone !== undefined && safeUpdates.phone !== oldPhone;
     const emailChanged = safeUpdates.email !== undefined && safeUpdates.email !== prospect.email;
-    if (phoneChanged && prospect.sourceMetadata?.phoneVerifiedAt) {
-      const sm = { ...(prospect.sourceMetadata || {}) };
-      delete sm.phoneVerifiedAt;
-      delete sm.phoneVerifiedFor;
-      safeUpdates.sourceMetadata = sm;
-    }
+    // The strip itself happens ATOMICALLY inside the managed transaction via
+    // prospectJsonPatch.removePaths — the old whole-object spread-save could
+    // delete marker/fact keys landed by other writers between this read and
+    // the save (plan google-ads-signal-levers §4.3).
+    const strippingVerification = Boolean(phoneChanged && prospect.sourceMetadata?.phoneVerifiedAt);
     if (phoneChanged && !safeUpdates.phone) {
       // Phone cleared entirely: no number, no person link (recompute below
       // only handles E.164 values; the reconciler's empty-phone step is the
@@ -96,6 +95,9 @@ export function makeProspectMutationOps({ d, m }) {
     // outbox write now rolls the edit back (all-or-nothing) instead of
     // committing fields the enrichment pipeline never hears about.
     const editingDemographics = safeUpdates.demographics !== undefined;
+    const mappedStatusTransition =
+      ['qualified', 'won'].includes(safeUpdates.leadStatus) && safeUpdates.leadStatus !== oldStatus;
+    const adminOccurredAt = new Date().toISOString();
     const updatePayload = becomingWon ? { ...safeUpdates, conversionDate: new Date() } : safeUpdates;
 
     // H4: a won-transition is enforced AT MUTATION TIME — the UPDATE's WHERE
@@ -130,10 +132,55 @@ export function makeProspectMutationOps({ d, m }) {
       await prospect.reload(opts);
     };
 
+    // ONE managed transaction for the edits that must be atomic with their
+    // side-writes: demographics (enrichment outbox, H3), phone changes
+    // (verification-stamp strip), and mapped status transitions (durable
+    // outcome facts — plan google-ads-signal-levers §4.3). Inside it the row
+    // is LOCK-RELOADED and the erased flag RE-CHECKED: the pre-transaction
+    // check above races a concurrent erasure, and a stale phone edit must
+    // never re-attach a number to a freshly scrubbed row (410, same as the
+    // pre-check).
+    const needsTxn = editingDemographics || phoneChanged || mappedStatusTransition;
     try {
-      if (editingDemographics) {
+      if (needsTxn) {
         await d.sequelize.transaction(async (t) => {
+          // Lock via a fresh minimal fetch — reloading `prospect` would carry
+          // its eager assignedAgent include, and FOR UPDATE cannot lock the
+          // nullable side of an outer join.
+          const locked = await m.Prospect.findByPk(prospect.id, {
+            transaction: t,
+            lock: t.LOCK.UPDATE,
+          });
+          if (!locked) {
+            throw new d.AppError('Prospect not found or access denied', 404);
+          }
+          if (locked.sourceMetadata?.erased === true) {
+            throw new d.AppError('This lead was erased (PDPA) and can no longer be edited', 410);
+          }
           await applyProspectWrite(t);
+          if (strippingVerification) {
+            await d.removeSourceMetadataPaths(
+              prospect.id,
+              [['phoneVerifiedAt'], ['phoneVerifiedFor']],
+              { transaction: t }
+            );
+          }
+          if (mappedStatusTransition) {
+            // Durable outcome facts land IN the status transaction (write-once,
+            // first-wins; a `won` records both keys with one timestamp) — the
+            // worker re-sends from these, so a crash after commit can never
+            // lose the outcome (plan §4.3).
+            const factKeys = d.eventKeysForStatus(safeUpdates.leadStatus);
+            if (factKeys.length) {
+              await d.mergeSourceMetadataFirstWins(
+                prospect.id,
+                ['outcomes'],
+                Object.fromEntries(factKeys.map((k) => [k, adminOccurredAt])),
+                { transaction: t }
+              );
+            }
+          }
+          if (!editingDemographics) return;
           const [rows] = await d.sequelize.query(
             `UPDATE prospects
                 SET "enrichmentRevision" = COALESCE("enrichmentRevision", 1) + 1
@@ -206,7 +253,7 @@ export function makeProspectMutationOps({ d, m }) {
         const hook = d.processLeadOutcome({
           external_id: prospect.id,
           new_status: safeUpdates.leadStatus,
-          occurred_at: new Date().toISOString(),
+          occurred_at: adminOccurredAt,
         });
         if (hook && typeof hook.catch === 'function') {
           hook.catch((err) =>

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -188,6 +188,13 @@ export function makeProspectService(overrides = {}) {
     const registrationEventId = meta?.registrationEventId ?? safeBody.registrationEventId;
     const ttclid = meta?.ttclid ?? safeBody.ttclid;
     const ttp = meta?.ttp ?? safeBody.ttp;
+    // Google click ids + capture time (plan google-ads-signal-levers §4.1) —
+    // persisted for the Phase 3 offline-conversion upload; the browser tag
+    // handles its own attribution, so these serve ONLY the server-side path.
+    const gclid = meta?.gclid ?? safeBody.gclid;
+    const gbraid = meta?.gbraid ?? safeBody.gbraid;
+    const wbraid = meta?.wbraid ?? safeBody.wbraid;
+    const gclCapturedAt = meta?.gclCapturedAt ?? safeBody.gclCapturedAt;
     // Consent flags: preserve explicit `false` (user opted out) via !== undefined check.
     const consentContact = safeBody.consent_contact;
     const consentTerms = safeBody.consent_terms;
@@ -224,6 +231,7 @@ export function makeProspectService(overrides = {}) {
     const {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
       registrationEventId: _re, ttclid: _tc, ttp: _tp,
+      gclid: _gc, gbraid: _gb, wbraid: _wb, gclCapturedAt: _gca,
       consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp, consent_dnc: _cd,
       consent_copy_version: _ccv,
       // consentMetadata is SERVER-authoritative — the third-party-consent evidence is
@@ -268,6 +276,9 @@ export function makeProspectService(overrides = {}) {
       ...(registrationEventId ? { registrationEventId } : {}),
       ...(ttclid ? { ttclid } : {}),
       ...(ttp ? { ttp } : {}),
+      ...(gclid || gbraid || wbraid
+        ? { gcl: { ...(gclid ? { gclid } : {}), ...(gbraid ? { gbraid } : {}), ...(wbraid ? { wbraid } : {}), ...(gclCapturedAt ? { capturedAt: gclCapturedAt } : {}) } }
+        : {}),
       ...(consentContact !== undefined ? { consent_contact: consentContact } : {}),
       ...(consentTerms !== undefined ? { consent_terms: consentTerms } : {}),
       ...(consentCopyVersion !== undefined ? { consent_copy_version: consentCopyVersion } : {}),

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -43,7 +43,11 @@ import {
 } from './tiktokEventsService.js';
 // Cycle-safe + graph-neutral: leadOutcomeService imports only models,
 // metaCapiService and consentService — all already in this module's graph.
-import { processLeadOutcome } from './leadOutcomeService.js';
+import { processLeadOutcome, eventKeysForStatus } from './leadOutcomeService.js';
+import {
+  mergeFirstWins as mergeSourceMetadataFirstWins,
+  removePaths as removeSourceMetadataPaths,
+} from '../utils/prospectJsonPatch.js';
 import { getOrCreateProspectShareLink } from './shortlinkService.js';
 import { isPhoneVerifiedDurable } from './verifiedPhoneStore.js';
 import {
@@ -120,6 +124,9 @@ const defaultDeps = {
   sendTikTokLeadEvent,
   sendTikTokCompleteRegistrationEvent,
   processLeadOutcome,
+  eventKeysForStatus,
+  mergeSourceMetadataFirstWins,
+  removeSourceMetadataPaths,
   getOrCreateProspectShareLink,
   isPhoneVerifiedDurable,
   resolveConsumerForCaptureTx,

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -201,7 +201,15 @@ export function makeProspectService(overrides = {}) {
     const gclid = meta?.gclid ?? safeBody.gclid;
     const gbraid = meta?.gbraid ?? safeBody.gbraid;
     const wbraid = meta?.wbraid ?? safeBody.wbraid;
-    const gclCapturedAt = meta?.gclCapturedAt ?? safeBody.gclCapturedAt;
+    // CLAMP to now: the capture timestamp is client-supplied and anchors the
+    // offline-conversion age guard — a forged future value must not extend
+    // eligibility (Codex P3 M4). Unparseable → dropped (server falls back to
+    // the signup timestamp).
+    const rawGclCapturedAt = meta?.gclCapturedAt ?? safeBody.gclCapturedAt;
+    const gclCapturedMs = rawGclCapturedAt ? Date.parse(rawGclCapturedAt) : NaN;
+    const gclCapturedAt = Number.isNaN(gclCapturedMs)
+      ? undefined
+      : new Date(Math.min(gclCapturedMs, Date.now())).toISOString();
     // Consent flags: preserve explicit `false` (user opted out) via !== undefined check.
     const consentContact = safeBody.consent_contact;
     const consentTerms = safeBody.consent_terms;

--- a/backend/src/services/redemptionOutcomeService.js
+++ b/backend/src/services/redemptionOutcomeService.js
@@ -35,6 +35,7 @@
 
 import { Prospect, Campaign, Activation, RewardEntitlement } from '../models/index.js';
 import { sendConversionEvent as metaSendConversionEvent } from './metaCapiService.js';
+import { mergeFirstWins as mergeSourceMetadataFirstWins } from '../utils/prospectJsonPatch.js';
 import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
 import { logger } from '../utils/logger.js';
 
@@ -47,6 +48,7 @@ const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const defaultDeps = {
   models: { Prospect, Campaign, Activation, RewardEntitlement },
   sendConversionEvent: metaSendConversionEvent,
+  mergeSourceMetadataFirstWins,
   canMarketTo: ledgerCanMarketTo,
   logger,
   sleep: realSleep,
@@ -139,11 +141,12 @@ export function makeRedemptionOutcomeService(overrides = {}) {
       const result = await dispatchWithRetry(prospect, ctx, { eventName });
 
       if (result?.sent) {
-        const capi = { ...(prospect.sourceMetadata?.capi || {}) };
-        capi.voucherRedeemed = { ...(capi.voucherRedeemed || {}), [entitlement.id]: new Date().toISOString() };
-        prospect.sourceMetadata = { ...(prospect.sourceMetadata || {}), capi };
-        if (typeof prospect.changed === 'function') prospect.changed('sourceMetadata', true);
-        await prospect.save();
+        // Atomic deep merge into capi.voucherRedeemed (prospectJsonPatch):
+        // preserves sibling entitlement markers AND capi siblings without the
+        // stale-instance whole-object save (plan google-ads-signal-levers §4.3).
+        await d.mergeSourceMetadataFirstWins(prospect.id, ['capi', 'voucherRedeemed'], {
+          [entitlement.id]: new Date().toISOString(),
+        });
         d.logger.info(
           { entitlement_id: entitlement.id, prospect_id: prospect.id, event_name: eventName },
           '[redemption-capi] dispatched'

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -8,6 +8,7 @@ import { dispatchEvent } from './webhookService.js';
 import { sendLeadAssignmentEmail } from './mailer.js';
 import { AppError } from '../middleware/appError.js';
 import { logger } from '../utils/logger.js';
+import { setPath as setSourceMetadataPath } from '../utils/prospectJsonPatch.js';
 import { CircuitBreaker } from '../utils/circuitBreaker.js';
 import { destinationForAgent, externalIdForDestination, buildLeadHeldPayload, buildLeadCreatedPayload } from './prospectHelpers.js';
 import { buildProspectWhere } from './prospectScope.js';
@@ -532,11 +533,12 @@ export function makeRetellService(overrides = {}) {
 
     const recordingUrl = call.recording_url || null;
 
-    // Cache it in sourceMetadata for next time
+    // Cache it in sourceMetadata for next time — atomic single-key write
+    // (prospectJsonPatch): the old whole-object update could delete marker/
+    // fact keys other writers landed after `meta` was read
+    // (plan google-ads-signal-levers §4.3).
     if (recordingUrl) {
-      await prospect.update({
-        sourceMetadata: { ...meta, recordingUrl }
-      });
+      await setSourceMetadataPath(prospect.id, ['recordingUrl'], recordingUrl);
     }
 
     return { recordingUrl };

--- a/backend/src/utils/prospectJsonPatch.js
+++ b/backend/src/utils/prospectJsonPatch.js
@@ -33,8 +33,8 @@ import { QueryTypes } from 'sequelize';
 
 const SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
 
-function assertPath(path) {
-  if (!Array.isArray(path) || path.length === 0) {
+function assertPath(path, { allowRoot = false } = {}) {
+  if (!Array.isArray(path) || (!allowRoot && path.length === 0)) {
     throw new Error('prospectJsonPatch: path must be a non-empty array');
   }
   for (const seg of path) {
@@ -50,14 +50,27 @@ function pgPath(path) {
 
 const BASE = `COALESCE("sourceMetadata"::jsonb, '{}'::jsonb)`;
 
-/** Ancestor-ensured expression: every prefix of `path` becomes '{}' if absent. */
+/**
+ * Ancestor-ensured expression: every prefix of `path` becomes '{}' unless it
+ * is ALREADY an object — jsonb_typeof guards convert JSON null / scalar
+ * ancestors too (COALESCE alone passes a JSON null through, and jsonb_set
+ * into a scalar no-ops).
+ */
 function ensuredExpr(path) {
   let expr = BASE;
   for (let i = 1; i < path.length; i++) {
     const prefix = path.slice(0, i);
-    expr = `jsonb_set(${expr}, '${pgPath(prefix)}', COALESCE(${BASE}#>'${pgPath(prefix)}', '{}'::jsonb))`;
+    const at = `${BASE}#>'${pgPath(prefix)}'`;
+    expr = `jsonb_set(${expr}, '${pgPath(prefix)}', CASE WHEN jsonb_typeof(${at}) = 'object' THEN ${at} ELSE '{}'::jsonb END)`;
   }
   return expr;
+}
+
+/** Target-existing expression with the same object-or-'{}' semantics. */
+function objectAt(path) {
+  if (path.length === 0) return BASE;
+  const at = `${BASE}#>'${pgPath(path)}'`;
+  return `CASE WHEN jsonb_typeof(${at}) = 'object' THEN ${at} ELSE '{}'::jsonb END`;
 }
 
 /**
@@ -93,9 +106,13 @@ function whereSql(extra) {
  * @param {CasPredicate} [cas]
  */
 export function buildMergeFirstWinsSql(path, cas) {
-  assertPath(path);
+  assertPath(path, { allowRoot: true });
   const { sql: casClause } = casSql(cas, 'cas');
-  const merged = `$patch::jsonb || COALESCE(${BASE}#>'${pgPath(path)}', '{}'::jsonb)`;
+  const merged = `$patch::jsonb || ${objectAt(path)}`;
+  if (path.length === 0) {
+    // Root merge (contracted `path: []`): first-wins against the whole doc.
+    return `UPDATE prospects SET "sourceMetadata" = (${merged})::json ${whereSql(casClause)}`;
+  }
   return `UPDATE prospects SET "sourceMetadata" = (jsonb_set(${ensuredExpr(path)}, '${pgPath(path)}', ${merged}))::json ${whereSql(casClause)}`;
 }
 

--- a/backend/src/utils/prospectJsonPatch.js
+++ b/backend/src/utils/prospectJsonPatch.js
@@ -1,0 +1,178 @@
+import { sequelize } from '../models/index.js';
+import { QueryTypes } from 'sequelize';
+
+/**
+ * Atomic, path-based writes into prospects."sourceMetadata" — the ONE way any
+ * marker/fact writer may touch that column outside the erasure rebuild
+ * (plan google-ads-signal-levers §4.3).
+ *
+ * Why this exists: sourceMetadata is a NULLABLE JSON (not jsonb) column whose
+ * historical writers read-spread-save whole objects from possibly-stale
+ * loaded instances — a pattern that silently deletes keys written by anyone
+ * else between load and save. Every operation here is ONE SQL statement:
+ *   - the column is COALESCEd ('{}' when NULL) and cast ::jsonb → ::json
+ *     (cast precedent: migration 097),
+ *   - ancestors are ENSURED level by level (naive nested jsonb_set silently
+ *     no-ops when an intermediate key is missing — Postgres semantics),
+ *   - every write carries the erased guard (a delayed webhook or worker must
+ *     never re-populate a scrubbed row),
+ *   - optional CAS predicates make marker state transitions lose cleanly to
+ *     fresher writers instead of clobbering them.
+ * Callers receive the affected-row count and MUST treat 0 as "blocked
+ * (erased or CAS-lost)" — reload and classify, never assume success.
+ *
+ * Path segments are CODE-OWNED constants, but are still validated against a
+ * conservative identifier charset — a path is interpolated into SQL text
+ * (values always travel as binds).
+ */
+
+/**
+ * @typedef {{ path: string[], absent?: true, equals?: unknown, contains?: unknown }} CasPredicate
+ * @typedef {{ transaction?: import('sequelize').Transaction, cas?: CasPredicate }} PatchOpts
+ */
+
+const SEGMENT_RE = /^[A-Za-z0-9_-]+$/;
+
+function assertPath(path) {
+  if (!Array.isArray(path) || path.length === 0) {
+    throw new Error('prospectJsonPatch: path must be a non-empty array');
+  }
+  for (const seg of path) {
+    if (typeof seg !== 'string' || !SEGMENT_RE.test(seg)) {
+      throw new Error(`prospectJsonPatch: unsafe path segment ${String(seg)}`);
+    }
+  }
+}
+
+function pgPath(path) {
+  return `{${path.join(',')}}`;
+}
+
+const BASE = `COALESCE("sourceMetadata"::jsonb, '{}'::jsonb)`;
+
+/** Ancestor-ensured expression: every prefix of `path` becomes '{}' if absent. */
+function ensuredExpr(path) {
+  let expr = BASE;
+  for (let i = 1; i < path.length; i++) {
+    const prefix = path.slice(0, i);
+    expr = `jsonb_set(${expr}, '${pgPath(prefix)}', COALESCE(${BASE}#>'${pgPath(prefix)}', '{}'::jsonb))`;
+  }
+  return expr;
+}
+
+/**
+ * CAS predicate SQL for `{ path, absent: true }` / `{ path, equals }` /
+ * `{ path, contains }` (jsonb containment/subset match — the state/requestId
+ * guard). Exported for testing.
+ * @param {CasPredicate | undefined} cas
+ * @param {string} bindName
+ */
+export function casSql(cas, bindName) {
+  if (!cas) return { sql: '', bind: undefined };
+  assertPath(cas.path);
+  const target = `${BASE}#>'${pgPath(cas.path)}'`;
+  if (cas.absent === true) return { sql: ` AND ${target} IS NULL`, bind: undefined };
+  if ('equals' in cas) return { sql: ` AND ${target} = $${bindName}::jsonb`, bind: JSON.stringify(cas.equals) };
+  if ('contains' in cas) return { sql: ` AND ${target} @> $${bindName}::jsonb`, bind: JSON.stringify(cas.contains) };
+  throw new Error('prospectJsonPatch: unknown CAS shape');
+}
+
+/** Shared statement tail: target row + never touch an erased skeleton. */
+function whereSql(extra) {
+  return `WHERE id = $id AND COALESCE("sourceMetadata"::jsonb->>'erased', 'false') <> 'true'${extra}`;
+}
+
+/**
+ * FIRST-WINS merge of `patch` into the object at `path`. Existing keys keep
+ * their values (`:patch || existing` — existing on the RIGHT wins); absent
+ * keys insert together, so a multi-key fact write (a `won` carrying both
+ * confirmed_resident and closed_won) lands atomically and a replay never
+ * rewrites history. "All keys already present" is idempotent success.
+ * Exported SQL builder for unit tests.
+ * @param {string[]} path
+ * @param {CasPredicate} [cas]
+ */
+export function buildMergeFirstWinsSql(path, cas) {
+  assertPath(path);
+  const { sql: casClause } = casSql(cas, 'cas');
+  const merged = `$patch::jsonb || COALESCE(${BASE}#>'${pgPath(path)}', '{}'::jsonb)`;
+  return `UPDATE prospects SET "sourceMetadata" = (jsonb_set(${ensuredExpr(path)}, '${pgPath(path)}', ${merged}))::json ${whereSql(casClause)}`;
+}
+
+/**
+ * @param {string} id
+ * @param {string[]} path
+ * @param {Record<string, unknown>} patch
+ * @param {PatchOpts} [opts]
+ * @returns {Promise<number>} affected rows — 0 = blocked (erased or CAS-lost)
+ */
+export async function mergeFirstWins(id, path, patch, { transaction, cas } = {}) {
+  const sql = buildMergeFirstWinsSql(path, cas);
+  /** @type {Record<string, string>} */
+  const bind = { id, patch: JSON.stringify(patch) };
+  const { bind: casBind } = casSql(cas, 'cas');
+  if (casBind !== undefined) bind.cas = casBind;
+  const [, meta] = await sequelize.query(sql, { bind, transaction, type: QueryTypes.RAW });
+  return /** @type {{ rowCount?: number } | undefined} */ (meta)?.rowCount ?? 0;
+}
+
+/**
+ * REPLACE the value at `path` (marker state transitions, the Retell
+ * recording-url cache). CAS makes stale transitions lose: a late pending
+ * write cannot regress `delivered`, an old poll cannot clear a newer request.
+ * Exported SQL builder for unit tests.
+ * @param {string[]} path
+ * @param {CasPredicate} [cas]
+ */
+export function buildSetPathSql(path, cas) {
+  assertPath(path);
+  const { sql: casClause } = casSql(cas, 'cas');
+  return `UPDATE prospects SET "sourceMetadata" = (jsonb_set(${ensuredExpr(path)}, '${pgPath(path)}', $value::jsonb))::json ${whereSql(casClause)}`;
+}
+
+/**
+ * @param {string} id
+ * @param {string[]} path
+ * @param {unknown} value
+ * @param {PatchOpts} [opts]
+ * @returns {Promise<number>} affected rows — 0 = blocked (erased or CAS-lost)
+ */
+export async function setPath(id, path, value, { transaction, cas } = {}) {
+  const sql = buildSetPathSql(path, cas);
+  /** @type {Record<string, string>} */
+  const bind = { id, value: JSON.stringify(value) };
+  const { bind: casBind } = casSql(cas, 'cas');
+  if (casBind !== undefined) bind.cas = casBind;
+  const [, meta] = await sequelize.query(sql, { bind, transaction, type: QueryTypes.RAW });
+  return /** @type {{ rowCount?: number } | undefined} */ (meta)?.rowCount ?? 0;
+}
+
+/**
+ * REMOVE keys via `#-` (JSON null is NOT key-absence for existence
+ * predicates — the admin phone-edit verification-stamp removal needs the
+ * keys gone). Exported SQL builder for unit tests.
+ * @param {string[][]} paths
+ */
+export function buildRemovePathsSql(paths) {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error('prospectJsonPatch: paths must be a non-empty array');
+  }
+  let expr = BASE;
+  for (const path of paths) {
+    assertPath(path);
+    expr = `(${expr} #- '${pgPath(path)}')`;
+  }
+  return `UPDATE prospects SET "sourceMetadata" = (${expr})::json ${whereSql('')}`;
+}
+
+/**
+ * @param {string} id
+ * @param {string[][]} paths
+ * @param {{ transaction?: import('sequelize').Transaction }} [opts]
+ * @returns {Promise<number>} affected rows — 0 = blocked (erased)
+ */
+export async function removePaths(id, paths, { transaction } = {}) {
+  const sql = buildRemovePathsSql(paths);
+  const [, meta] = await sequelize.query(sql, { bind: { id }, transaction, type: QueryTypes.RAW });
+  return /** @type {{ rowCount?: number } | undefined} */ (meta)?.rowCount ?? 0;
+}

--- a/backend/test/integration/prospectJsonPatch.test.js
+++ b/backend/test/integration/prospectJsonPatch.test.js
@@ -133,3 +133,57 @@ describe('concurrency: atomic single-key writers cannot clobber each other', () 
     expect(sm.recordingUrl).toBe('https://r.example/x');
   });
 });
+
+describe('ancestor edge cases (Codex P3 minor)', () => {
+  test('a JSON-null or scalar ancestor is converted to an object, not silently no-opped', async () => {
+    const p = await seed({ capi: null });
+    expect(await mergeFirstWins(p.id, ['capi', 'voucherRedeemed'], { e1: 'T1' })).toBe(1);
+    expect((await smOf(p.id)).capi.voucherRedeemed).toEqual({ e1: 'T1' });
+
+    const p2 = await seed({ gads: 'scalar-garbage' });
+    expect(await setPath(p2.id, ['gads', 'k'], { state: 'pending' })).toBe(1);
+    expect((await smOf(p2.id)).gads.k.state).toBe('pending');
+  });
+
+  test('root merge (path []) is first-wins against the whole document', async () => {
+    const p = await seed({ keep: 'original' });
+    expect(await mergeFirstWins(p.id, [], { keep: 'MUST-LOSE', added: 'new' })).toBe(1);
+    const sm = await smOf(p.id);
+    expect(sm.keep).toBe('original');
+    expect(sm.added).toBe('new');
+  });
+});
+
+describe('REAL converted writers interleave safely (Codex P3 M7)', () => {
+  test('concurrent lead-outcome capi marker, redemption deep merge, retell cache, and an outcomes fact all land on one row', async () => {
+    const p = await seed({});
+    const { setPath: sp, mergeFirstWins: mf } = await import('../../src/utils/prospectJsonPatch.js');
+    // The four converted writers' exact write shapes, fired concurrently:
+    await Promise.all([
+      sp(p.id, ['capi', 'confirmedResidentAt'], '2026-08-18T01:00:00Z'), // leadOutcomeService
+      mf(p.id, ['capi', 'voucherRedeemed'], { 'ent-1': '2026-08-18T01:00:01Z' }), // redemptionOutcomeService
+      sp(p.id, ['recordingUrl'], 'https://r.example/rec'), // retellService
+      mf(p.id, ['outcomes'], { confirmed_resident: '2026-08-18T01:00:02Z' }), // processLeadOutcome facts
+      sp(p.id, ['gads', 'confirmed_resident'], { state: 'pending', requestId: 'r1' }), // dispatch marker
+    ]);
+    const sm = await smOf(p.id);
+    expect(sm.capi.confirmedResidentAt).toBe('2026-08-18T01:00:00Z');
+    expect(sm.capi.voucherRedeemed).toEqual({ 'ent-1': '2026-08-18T01:00:01Z' });
+    expect(sm.recordingUrl).toBe('https://r.example/rec');
+    expect(sm.outcomes.confirmed_resident).toBe('2026-08-18T01:00:02Z');
+    expect(sm.gads.confirmed_resident).toEqual({ state: 'pending', requestId: 'r1' });
+  });
+
+  test('the admin removePaths strip in a transaction cannot clobber a concurrent marker write', async () => {
+    const p = await seed({ phoneVerifiedAt: 'T', phoneVerifiedFor: 'H' });
+    const { sequelize } = await import('../../src/models/index.js');
+    const { setPath: sp, removePaths: rp } = await import('../../src/utils/prospectJsonPatch.js');
+    await Promise.all([
+      sequelize.transaction(async (t) => rp(p.id, [['phoneVerifiedAt'], ['phoneVerifiedFor']], { transaction: t })),
+      sp(p.id, ['capi', 'confirmedResidentAt'], 'K'),
+    ]);
+    const sm = await smOf(p.id);
+    expect('phoneVerifiedAt' in sm).toBe(false);
+    expect(sm.capi.confirmedResidentAt).toBe('K');
+  });
+});

--- a/backend/test/integration/prospectJsonPatch.test.js
+++ b/backend/test/integration/prospectJsonPatch.test.js
@@ -1,0 +1,135 @@
+/**
+ * prospectJsonPatch — REAL-POSTGRES semantics proof. The whole point of the
+ * helper is behavior mocks cannot certify: jsonb_set no-ops on missing
+ * parents, NULL-column COALESCE, first-wins merge direction, CAS races,
+ * `#-` true key removal, and the erased guard (plan google-ads-signal-levers
+ * §4.3).
+ */
+import crypto from 'crypto';
+import {
+  getApp, closeDb, createTestUser, createTestCampaign,
+} from '../helpers.js';
+import { Prospect } from '../../src/models/index.js';
+import {
+  mergeFirstWins, setPath, removePaths,
+} from '../../src/utils/prospectJsonPatch.js';
+
+let campaign;
+
+beforeAll(async () => {
+  await getApp();
+  const admin = await createTestUser({ role: 'admin' });
+  campaign = await createTestCampaign(admin.user.id);
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+async function seed(sourceMetadata) {
+  return Prospect.create({
+    firstName: 'Patch', lastName: 'Case',
+    email: `patch-${crypto.randomUUID().slice(0, 8)}@test.com`,
+    phone: `+659${String(Math.floor(1000000 + Math.random() * 8999999))}`,
+    campaignId: campaign.id, leadSource: 'website',
+    ...(sourceMetadata !== undefined ? { sourceMetadata } : {}),
+  });
+}
+
+async function smOf(id) {
+  const row = await Prospect.findByPk(id, { raw: true });
+  return row.sourceMetadata;
+}
+
+describe('mergeFirstWins', () => {
+  test('creates parents on a NULL column and merges multi-key atomically', async () => {
+    const p = await seed(null);
+    const n = await mergeFirstWins(p.id, ['outcomes'], {
+      confirmed_resident: '2026-08-18T01:00:00Z',
+      closed_won: '2026-08-18T01:00:00Z',
+    });
+    expect(n).toBe(1);
+    expect((await smOf(p.id)).outcomes).toEqual({
+      confirmed_resident: '2026-08-18T01:00:00Z',
+      closed_won: '2026-08-18T01:00:00Z',
+    });
+  });
+
+  test('FIRST WINS: an existing key survives a replay; absent keys still insert', async () => {
+    const p = await seed({ outcomes: { confirmed_resident: 'EARLIER' } });
+    await mergeFirstWins(p.id, ['outcomes'], {
+      confirmed_resident: 'LATER-MUST-LOSE',
+      closed_won: 'NEW',
+    });
+    expect((await smOf(p.id)).outcomes).toEqual({
+      confirmed_resident: 'EARLIER',
+      closed_won: 'NEW',
+    });
+  });
+
+  test('deep path preserves siblings at every level (redemption map shape)', async () => {
+    const p = await seed({ capi: { confirmedResidentAt: 'K', voucherRedeemed: { e1: 'T1' } }, utm: { utm_source: 'g' } });
+    await mergeFirstWins(p.id, ['capi', 'voucherRedeemed'], { e2: 'T2' });
+    const sm = await smOf(p.id);
+    expect(sm.capi.voucherRedeemed).toEqual({ e1: 'T1', e2: 'T2' });
+    expect(sm.capi.confirmedResidentAt).toBe('K'); // sibling intact
+    expect(sm.utm).toEqual({ utm_source: 'g' }); // top-level sibling intact
+  });
+
+  test('never touches an erased skeleton (returns 0)', async () => {
+    const p = await seed({ erased: true });
+    expect(await mergeFirstWins(p.id, ['outcomes'], { confirmed_resident: 'X' })).toBe(0);
+    expect((await smOf(p.id)).outcomes).toBeUndefined();
+  });
+});
+
+describe('setPath with CAS', () => {
+  test('replace + parent-ensure; absent-CAS blocks a second writer', async () => {
+    const p = await seed({});
+    const first = await setPath(p.id, ['gads', 'confirmed_resident'], { state: 'pending', requestId: 'r1' }, { cas: { path: ['gads', 'confirmed_resident'], absent: true } });
+    expect(first).toBe(1);
+    const second = await setPath(p.id, ['gads', 'confirmed_resident'], { state: 'pending', requestId: 'r2' }, { cas: { path: ['gads', 'confirmed_resident'], absent: true } });
+    expect(second).toBe(0); // CAS lost — no clobber
+    expect((await smOf(p.id)).gads.confirmed_resident.requestId).toBe('r1');
+  });
+
+  test('contains-CAS: a stale poll for an old requestId cannot regress delivered', async () => {
+    const p = await seed({ gads: { k: { state: 'delivered', requestId: 'new' } } });
+    const n = await setPath(p.id, ['gads', 'k'], { state: 'failedPermanent' }, { cas: { path: ['gads', 'k'], contains: { requestId: 'old' } } });
+    expect(n).toBe(0);
+    expect((await smOf(p.id)).gads.k.state).toBe('delivered');
+    const ok = await setPath(p.id, ['gads', 'k'], { state: 'retryWait', requestId: 'new' }, { cas: { path: ['gads', 'k'], contains: { requestId: 'new', state: 'delivered' } } });
+    expect(ok).toBe(1);
+  });
+});
+
+describe('removePaths', () => {
+  test('truly removes keys (existence predicates see absence), preserves siblings', async () => {
+    const p = await seed({ phoneVerifiedAt: 'T', phoneVerifiedFor: 'H', utm: { utm_source: 'g' } });
+    expect(await removePaths(p.id, [['phoneVerifiedAt'], ['phoneVerifiedFor']])).toBe(1);
+    const sm = await smOf(p.id);
+    expect('phoneVerifiedAt' in sm).toBe(false);
+    expect('phoneVerifiedFor' in sm).toBe(false);
+    expect(sm.utm).toEqual({ utm_source: 'g' });
+  });
+
+  test('erased guard holds for removals too', async () => {
+    const p = await seed({ erased: true, phoneVerifiedAt: 'T' });
+    expect(await removePaths(p.id, [['phoneVerifiedAt']])).toBe(0);
+  });
+});
+
+describe('concurrency: atomic single-key writers cannot clobber each other', () => {
+  test('interleaved merges to sibling parents both land', async () => {
+    const p = await seed(null);
+    await Promise.all([
+      mergeFirstWins(p.id, ['outcomes'], { confirmed_resident: 'A' }),
+      setPath(p.id, ['capi', 'confirmedResidentAt'], 'B'),
+      setPath(p.id, ['recordingUrl'], 'https://r.example/x'),
+    ]);
+    const sm = await smOf(p.id);
+    expect(sm.outcomes.confirmed_resident).toBe('A');
+    expect(sm.capi.confirmedResidentAt).toBe('B');
+    expect(sm.recordingUrl).toBe('https://r.example/x');
+  });
+});

--- a/backend/test/leadOutcomeService.test.js
+++ b/backend/test/leadOutcomeService.test.js
@@ -368,15 +368,17 @@ describe('leadOutcomeService — durable outcome facts + Google dispatch (plan �
     expect(dispatchGoogleOutcome.mock.calls.map((c) => c[1])).toEqual(['confirmed_resident', 'closed_won']);
   });
 
-  it('an existing gads marker suppresses the inline Google dispatch (worker owns retries)', async () => {
+  it('delegates marker dedup to the claim flow — dispatch is CALLED and owns the race (id-based)', async () => {
     const prospect = makeProspect({
       sourceMetadata: { consent_contact: true, gads: { confirmed_resident: { state: 'pending', requestId: 'r' } } },
     });
-    const dispatchGoogleOutcome = jest.fn();
+    const dispatchGoogleOutcome = jest.fn().mockResolvedValue({ sent: false, reason: 'marker_present' });
     const googleUploadsEnabled = jest.fn().mockReturnValue(true);
     const { deps } = buildDeps({ prospect, dispatchGoogleOutcome, googleUploadsEnabled });
     const svc = makeLeadOutcomeService(deps);
     await svc.processLeadOutcome(QUALIFIED);
-    expect(dispatchGoogleOutcome).not.toHaveBeenCalled();
-  });
-});
+    // claim-flow contract: the service delegates with the PROSPECT ID (the
+    // dispatcher reloads fresh state and CAS-claims — suppression of existing
+    // markers is proven in googleOfflineConversionsService.test.js).
+    expect(dispatchGoogleOutcome).toHaveBeenCalledWith(prospect.id, 'confirmed_resident');
+  });});

--- a/backend/test/leadOutcomeService.test.js
+++ b/backend/test/leadOutcomeService.test.js
@@ -33,13 +33,29 @@ function buildDeps(overrides = {}) {
   // verified grant" (the fixtures' old consent_contact:true, ledger-shaped).
   const canMarketTo = overrides.canMarketTo ?? jest.fn().mockResolvedValue(true);
   const sleep = jest.fn().mockResolvedValue(undefined);
+  // Marker writes go through the atomic prospectJsonPatch seam now (plan
+  // google-ads-signal-levers §4.3). The spy EMULATES the write on the
+  // in-memory fixture so existing assertions keep reading the result.
+  const setSourceMetadataPath =
+    overrides.setSourceMetadataPath ??
+    jest.fn(async (id, path, value) => {
+      if (!prospect.sourceMetadata) prospect.sourceMetadata = {};
+      let target = prospect.sourceMetadata;
+      for (const k of path.slice(0, -1)) {
+        if (!target[k]) target[k] = {};
+        target = target[k];
+      }
+      target[path[path.length - 1]] = value;
+      return 1;
+    });
   return {
-    deps: { models: { Prospect, Campaign }, sendConversionEvent, canMarketTo, logger: silentLogger, sleep, ...overrides.deps },
+    deps: { models: { Prospect, Campaign }, sendConversionEvent, canMarketTo, setSourceMetadataPath, logger: silentLogger, sleep, ...overrides.deps },
     prospect,
     Prospect,
     Campaign,
     sendConversionEvent,
     canMarketTo,
+    setSourceMetadataPath,
     sleep,
   };
 }
@@ -55,7 +71,7 @@ const QUALIFIED = {
 
 describe('leadOutcomeService.processLeadOutcome', () => {
   it('dispatches ConfirmedResident with deterministic event_id, back-dated event_time, and pixel override', async () => {
-    const { deps, sendConversionEvent } = buildDeps();
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps();
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -70,7 +86,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
   });
 
   it('won emits BOTH ConfirmedResident and ClosedWon (won implies SC/PR)', async () => {
-    const { deps, prospect, sendConversionEvent } = buildDeps();
+    const { deps, prospect, sendConversionEvent, setSourceMetadataPath } = buildDeps();
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'won', old_status: 'proposed' });
@@ -83,14 +99,18 @@ describe('leadOutcomeService.processLeadOutcome', () => {
     expect(sendConversionEvent.mock.calls[1][2].eventName).toBe('ClosedWon');
     expect(prospect.sourceMetadata.capi.confirmedResidentAt).toEqual(expect.any(String));
     expect(prospect.sourceMetadata.capi.closedWonAt).toEqual(expect.any(String));
-    expect(prospect.save).toHaveBeenCalledTimes(2);
+    expect(setSourceMetadataPath).toHaveBeenCalledTimes(2);
+    expect(setSourceMetadataPath.mock.calls.map((c) => c[1])).toEqual([
+      ['capi', 'confirmedResidentAt'],
+      ['capi', 'closedWonAt'],
+    ]);
   });
 
   it('won skips ConfirmedResident if already sent, still emits ClosedWon', async () => {
     const prospect = makeProspect({
       sourceMetadata: { consent_contact: true, capi: { confirmedResidentAt: '2026-06-08T00:00:00Z' } },
     });
-    const { deps, sendConversionEvent } = buildDeps({ prospect });
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps({ prospect });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'won' });
@@ -101,14 +121,14 @@ describe('leadOutcomeService.processLeadOutcome', () => {
   });
 
   it('writes the dedup marker ONLY after a successful send', async () => {
-    const { deps, prospect } = buildDeps();
+    const { deps, prospect, setSourceMetadataPath } = buildDeps();
     const svc = makeLeadOutcomeService(deps);
 
     await svc.processLeadOutcome(QUALIFIED);
 
     expect(prospect.sourceMetadata.capi.confirmedResidentAt).toEqual(expect.any(String));
-    expect(prospect.changed).toHaveBeenCalledWith('sourceMetadata', true);
-    expect(prospect.save).toHaveBeenCalledTimes(1);
+    expect(setSourceMetadataPath).toHaveBeenCalledTimes(1);
+    expect(setSourceMetadataPath.mock.calls[0][1]).toEqual(['capi', 'confirmedResidentAt']);
     // existing sourceMetadata preserved, not clobbered
     expect(prospect.sourceMetadata.consent_contact).toBe(true);
     expect(prospect.sourceMetadata.fbp).toBe('fb.1.1.x');
@@ -116,14 +136,14 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
   it('does NOT mark (leaves re-tryable) when the send fails', async () => {
     const sendConversionEvent = jest.fn().mockResolvedValue({ sent: false, status: 500 });
-    const { deps, prospect } = buildDeps({ sendConversionEvent });
+    const { deps, prospect, setSourceMetadataPath } = buildDeps({ sendConversionEvent });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
 
     expect(result).toMatchObject({ dispatched: [], duplicate: [], failed: ['ConfirmedResident'] });
     expect(prospect.sourceMetadata.capi).toBeUndefined();
-    expect(prospect.save).not.toHaveBeenCalled();
+    expect(setSourceMetadataPath).not.toHaveBeenCalled();
   });
 
   it('retries a transient failure then succeeds', async () => {
@@ -131,7 +151,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
       .fn()
       .mockResolvedValueOnce({ sent: false, status: 503 })
       .mockResolvedValueOnce({ sent: true });
-    const { deps, prospect, sleep } = buildDeps({ sendConversionEvent });
+    const { deps, prospect, sleep, setSourceMetadataPath } = buildDeps({ sendConversionEvent });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -139,12 +159,12 @@ describe('leadOutcomeService.processLeadOutcome', () => {
     expect(result.dispatched).toEqual(['ConfirmedResident']);
     expect(sendConversionEvent).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledTimes(1);
-    expect(prospect.save).toHaveBeenCalledTimes(1);
+    expect(setSourceMetadataPath).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT retry a guarded (CAPI disabled / ineligible) result', async () => {
     const sendConversionEvent = jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' });
-    const { deps, sleep } = buildDeps({ sendConversionEvent });
+    const { deps, sleep, setSourceMetadataPath } = buildDeps({ sendConversionEvent });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -156,7 +176,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 
   it('does NOT retry a 4xx (non-transient) result', async () => {
     const sendConversionEvent = jest.fn().mockResolvedValue({ sent: false, status: 400 });
-    const { deps, sleep } = buildDeps({ sendConversionEvent });
+    const { deps, sleep, setSourceMetadataPath } = buildDeps({ sendConversionEvent });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -170,18 +190,18 @@ describe('leadOutcomeService.processLeadOutcome', () => {
     const prospect = makeProspect({
       sourceMetadata: { consent_contact: true, capi: { confirmedResidentAt: '2026-06-08T00:00:00Z' } },
     });
-    const { deps, sendConversionEvent } = buildDeps({ prospect });
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps({ prospect });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
 
     expect(result).toMatchObject({ dispatched: [], duplicate: ['ConfirmedResident'], failed: [] });
     expect(sendConversionEvent).not.toHaveBeenCalled();
-    expect(prospect.save).not.toHaveBeenCalled();
+    expect(setSourceMetadataPath).not.toHaveBeenCalled();
   });
 
   it('skips cleanly when the prospect is not found', async () => {
-    const { deps, Prospect, sendConversionEvent } = buildDeps();
+    const { deps, Prospect, sendConversionEvent, setSourceMetadataPath } = buildDeps();
     Prospect.findByPk.mockResolvedValueOnce(null);
     const svc = makeLeadOutcomeService(deps);
 
@@ -192,7 +212,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
   });
 
   it('skips unmapped statuses without touching the DB', async () => {
-    const { deps, Prospect } = buildDeps();
+    const { deps, Prospect, setSourceMetadataPath } = buildDeps();
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'contacted' });
@@ -202,7 +222,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
   });
 
   it('omits eventTime when occurred_at is missing/invalid (falls back to now in payload)', async () => {
-    const { deps, sendConversionEvent } = buildDeps();
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps();
     const svc = makeLeadOutcomeService(deps);
 
     await svc.processLeadOutcome({ ...QUALIFIED, occurred_at: 'not-a-date' });
@@ -215,7 +235,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
     process.env.META_EVENT_QUALIFIED = 'Lead';
     process.env.META_EVENT_WON = 'Purchase';
     try {
-      const { deps, sendConversionEvent } = buildDeps();
+      const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps();
       const svc = makeLeadOutcomeService(deps);
       await svc.processLeadOutcome(QUALIFIED);
       expect(sendConversionEvent.mock.calls[0][2].eventName).toBe('Lead');
@@ -231,7 +251,7 @@ describe('leadOutcomeService.processLeadOutcome', () => {
 describe('leadOutcomeService — ledger-derived em/ph gate (3sites)', () => {
   it('computes canMarketTo from the prospect identity + campaign scope and threads it into ctx', async () => {
     const prospect = makeProspect({ consumerId: 'consumer-uuid-1', phone: '+6581234567' });
-    const { deps, canMarketTo, sendConversionEvent } = buildDeps({ prospect });
+    const { deps, canMarketTo, sendConversionEvent, setSourceMetadataPath } = buildDeps({ prospect });
     const svc = makeLeadOutcomeService(deps);
 
     await svc.processLeadOutcome(QUALIFIED);
@@ -247,7 +267,7 @@ describe('leadOutcomeService — ledger-derived em/ph gate (3sites)', () => {
   });
 
   it('threads marketingConsent:false when the ledger denies (withdrawal/unverified)', async () => {
-    const { deps, sendConversionEvent } = buildDeps({ canMarketTo: jest.fn().mockResolvedValue(false) });
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps({ canMarketTo: jest.fn().mockResolvedValue(false) });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -257,7 +277,7 @@ describe('leadOutcomeService — ledger-derived em/ph gate (3sites)', () => {
   });
 
   it('fails CLOSED when the ledger lookup rejects — event fires without em/ph consent', async () => {
-    const { deps, sendConversionEvent } = buildDeps({ canMarketTo: jest.fn().mockRejectedValue(new Error('ledger down')) });
+    const { deps, sendConversionEvent, setSourceMetadataPath } = buildDeps({ canMarketTo: jest.fn().mockRejectedValue(new Error('ledger down')) });
     const svc = makeLeadOutcomeService(deps);
 
     const result = await svc.processLeadOutcome(QUALIFIED);
@@ -267,7 +287,7 @@ describe('leadOutcomeService — ledger-derived em/ph gate (3sites)', () => {
   });
 
   it('dispatches the ORIGINAL prospect instance — the PR B clone hack is gone', async () => {
-    const { deps, prospect, sendConversionEvent } = buildDeps({ canMarketTo: jest.fn().mockResolvedValue(false) });
+    const { deps, prospect, sendConversionEvent, setSourceMetadataPath } = buildDeps({ canMarketTo: jest.fn().mockResolvedValue(false) });
     const svc = makeLeadOutcomeService(deps);
 
     await svc.processLeadOutcome(QUALIFIED);

--- a/backend/test/leadOutcomeService.test.js
+++ b/backend/test/leadOutcomeService.test.js
@@ -48,8 +48,19 @@ function buildDeps(overrides = {}) {
       target[path[path.length - 1]] = value;
       return 1;
     });
+  const mergeSourceMetadataFirstWins = overrides.mergeSourceMetadataFirstWins ?? jest.fn().mockResolvedValue(1);
+  const dispatchGoogleOutcome = overrides.dispatchGoogleOutcome ?? jest.fn().mockResolvedValue({ sent: true });
+  const googleUploadsEnabled = overrides.googleUploadsEnabled ?? jest.fn().mockReturnValue(false);
+  const googleActionIdFor = overrides.googleActionIdFor ?? jest.fn().mockReturnValue('act-1');
   return {
-    deps: { models: { Prospect, Campaign }, sendConversionEvent, canMarketTo, setSourceMetadataPath, logger: silentLogger, sleep, ...overrides.deps },
+    deps: {
+      models: { Prospect, Campaign }, sendConversionEvent, canMarketTo, setSourceMetadataPath,
+      mergeSourceMetadataFirstWins, dispatchGoogleOutcome, googleUploadsEnabled, googleActionIdFor,
+      logger: silentLogger, sleep, ...overrides.deps,
+    },
+    mergeSourceMetadataFirstWins,
+    dispatchGoogleOutcome,
+    googleUploadsEnabled,
     prospect,
     Prospect,
     Campaign,
@@ -295,5 +306,77 @@ describe('leadOutcomeService — ledger-derived em/ph gate (3sites)', () => {
     expect(sendConversionEvent.mock.calls[0][0]).toBe(prospect);
     // stored evidence untouched (no consent_contact:false overwrite)
     expect(prospect.sourceMetadata.consent_contact).toBe(true);
+  });
+});
+
+
+describe('leadOutcomeService — durable outcome facts + Google dispatch (plan §4.3)', () => {
+  it('writes ALL facts for the status FIRST (one first-wins merge), before any dispatch', async () => {
+    const calls = [];
+    const mergeSourceMetadataFirstWins = jest.fn(async () => { calls.push('facts'); return 1; });
+    const sendConversionEvent = jest.fn(async () => { calls.push('meta'); return { sent: true }; });
+    const { deps } = buildDeps({ mergeSourceMetadataFirstWins, sendConversionEvent });
+    const svc = makeLeadOutcomeService(deps);
+    await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'won' });
+    expect(calls[0]).toBe('facts');
+    expect(mergeSourceMetadataFirstWins).toHaveBeenCalledTimes(1);
+    const [, path, patch] = mergeSourceMetadataFirstWins.mock.calls[0];
+    expect(path).toEqual(['outcomes']);
+    expect(patch).toEqual({
+      confirmed_resident: '2026-06-09T10:00:00.000Z',
+      closed_won: '2026-06-09T10:00:00.000Z',
+    });
+  });
+
+  it('canonical timestamp chain: invalid body occurred_at → signedWebhookAt → receipt time', async () => {
+    const { deps, mergeSourceMetadataFirstWins } = buildDeps();
+    const svc = makeLeadOutcomeService(deps);
+    await svc.processLeadOutcome(
+      { ...QUALIFIED, occurred_at: 'not-a-date' },
+      { signedWebhookAt: '2026-06-09T09:00:00.000Z' }
+    );
+    expect(mergeSourceMetadataFirstWins.mock.calls[0][2]).toEqual({
+      confirmed_resident: '2026-06-09T09:00:00.000Z',
+    });
+
+    const { deps: d2, mergeSourceMetadataFirstWins: m2 } = buildDeps();
+    const svc2 = makeLeadOutcomeService(d2);
+    const before = Date.now();
+    await svc2.processLeadOutcome({ ...QUALIFIED, occurred_at: undefined });
+    const written = Date.parse(m2.mock.calls[0][2].confirmed_resident);
+    expect(written).toBeGreaterThanOrEqual(before - 1000);
+  });
+
+  it('a fact-write failure is loud but never blocks the Meta dispatch', async () => {
+    const mergeSourceMetadataFirstWins = jest.fn().mockRejectedValue(new Error('db down'));
+    const { deps, sendConversionEvent } = buildDeps({ mergeSourceMetadataFirstWins });
+    const svc = makeLeadOutcomeService(deps);
+    const result = await svc.processLeadOutcome(QUALIFIED);
+    expect(result.dispatched).toEqual(['ConfirmedResident']);
+    expect(sendConversionEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('Google dispatch runs per key when enabled (fresh markers only) and its failure never touches the Meta result', async () => {
+    const dispatchGoogleOutcome = jest.fn().mockRejectedValue(new Error('google down'));
+    const googleUploadsEnabled = jest.fn().mockReturnValue(true);
+    const { deps, sendConversionEvent } = buildDeps({ dispatchGoogleOutcome, googleUploadsEnabled });
+    const svc = makeLeadOutcomeService(deps);
+    const result = await svc.processLeadOutcome({ ...QUALIFIED, new_status: 'won' });
+    expect(result.dispatched).toEqual(['ConfirmedResident', 'ClosedWon']);
+    expect(sendConversionEvent).toHaveBeenCalledTimes(2);
+    expect(dispatchGoogleOutcome).toHaveBeenCalledTimes(2);
+    expect(dispatchGoogleOutcome.mock.calls.map((c) => c[1])).toEqual(['confirmed_resident', 'closed_won']);
+  });
+
+  it('an existing gads marker suppresses the inline Google dispatch (worker owns retries)', async () => {
+    const prospect = makeProspect({
+      sourceMetadata: { consent_contact: true, gads: { confirmed_resident: { state: 'pending', requestId: 'r' } } },
+    });
+    const dispatchGoogleOutcome = jest.fn();
+    const googleUploadsEnabled = jest.fn().mockReturnValue(true);
+    const { deps } = buildDeps({ prospect, dispatchGoogleOutcome, googleUploadsEnabled });
+    const svc = makeLeadOutcomeService(deps);
+    await svc.processLeadOutcome(QUALIFIED);
+    expect(dispatchGoogleOutcome).not.toHaveBeenCalled();
   });
 });

--- a/backend/test/lyfeLeadOutcomeController.test.js
+++ b/backend/test/lyfeLeadOutcomeController.test.js
@@ -159,7 +159,13 @@ describe('handleLyfeLeadOutcome', () => {
     await handleLyfeLeadOutcome(makeReq(validBody), res);
     expect(res.statusCode).toBe(200);
     expect(res.body).toMatchObject({ success: true, dispatched: ['ConfirmedResident'] });
-    expect(processLeadOutcomeMock).toHaveBeenCalledWith(validBody);
+    expect(processLeadOutcomeMock).toHaveBeenCalledWith(validBody, {
+      signedWebhookAt: expect.any(String),
+    });
+    // the trusted fallback comes from the SIGNED header timestamp
+    expect(
+      Number.isNaN(Date.parse(processLeadOutcomeMock.mock.calls[0][1].signedWebhookAt))
+    ).toBe(false);
   });
 
   it('still returns 200 (not 5xx) if the service throws — no pg_net retry storm', async () => {

--- a/backend/test/redemptionOutcomeService.test.js
+++ b/backend/test/redemptionOutcomeService.test.js
@@ -47,13 +47,30 @@ function buildDeps(overrides = {}) {
   const sendConversionEvent = overrides.sendConversionEvent ?? jest.fn().mockResolvedValue({ sent: true });
   const canMarketTo = overrides.canMarketTo ?? jest.fn().mockResolvedValue(true);
   const sleep = jest.fn().mockResolvedValue(undefined);
+  // Marker writes go through the atomic prospectJsonPatch seam (plan
+  // google-ads-signal-levers §4.3) — the spy EMULATES the first-wins deep
+  // merge on the fixture so existing assertions keep reading the result.
+  const mergeSourceMetadataFirstWins =
+    overrides.mergeSourceMetadataFirstWins ??
+    jest.fn(async (id, path, patch) => {
+      if (!prospect.sourceMetadata) prospect.sourceMetadata = {};
+      let target = prospect.sourceMetadata;
+      for (const k of path) {
+        if (!target[k]) target[k] = {};
+        target = target[k];
+      }
+      for (const [k, v] of Object.entries(patch)) {
+        if (!(k in target)) target[k] = v;
+      }
+      return 1;
+    });
   return {
     deps: {
       models: { Prospect, Campaign, Activation, RewardEntitlement },
-      sendConversionEvent, canMarketTo, logger: silentLogger, sleep,
+      sendConversionEvent, canMarketTo, mergeSourceMetadataFirstWins, logger: silentLogger, sleep,
       ...overrides.deps,
     },
-    prospect, Prospect, Campaign, Activation, RewardEntitlement, sendConversionEvent, canMarketTo, sleep,
+    prospect, Prospect, Campaign, Activation, RewardEntitlement, sendConversionEvent, canMarketTo, mergeSourceMetadataFirstWins, sleep,
   };
 }
 
@@ -63,7 +80,7 @@ afterEach(() => {
 
 describe('processRedemption — guards', () => {
   test('no entitlement → skipped, nothing sent', async () => {
-    const { deps, sendConversionEvent } = buildDeps();
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     expect(await svc.processRedemption({})).toEqual({ skipped: 'no_entitlement' });
     expect(await svc.processRedemption()).toEqual({ skipped: 'no_entitlement' });
@@ -71,7 +88,7 @@ describe('processRedemption — guards', () => {
   });
 
   test('prospect-less entitlement → skipped (nullable prospectId is real)', async () => {
-    const { deps, sendConversionEvent } = buildDeps();
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement({ prospectId: null }) });
     expect(r).toEqual({ skipped: 'no_prospect' });
@@ -79,7 +96,7 @@ describe('processRedemption — guards', () => {
   });
 
   test('prospect row gone → skipped', async () => {
-    const { deps, Prospect, sendConversionEvent } = buildDeps();
+    const { deps, Prospect, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps();
     Prospect.findByPk.mockResolvedValue(null);
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
@@ -91,7 +108,7 @@ describe('processRedemption — guards', () => {
     const prospect = makeProspect({
       sourceMetadata: { capi: { voucherRedeemed: { 'ent-uuid-1': '2026-07-01T00:00:00Z' } } },
     });
-    const { deps, sendConversionEvent } = buildDeps({ prospect });
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps({ prospect });
     const svc = makeRedemptionOutcomeService(deps);
     expect(await svc.processRedemption({ entitlement: makeEntitlement() })).toEqual({ duplicate: true });
     expect(sendConversionEvent).not.toHaveBeenCalled();
@@ -101,7 +118,7 @@ describe('processRedemption — guards', () => {
     const prospect = makeProspect({
       sourceMetadata: { capi: { voucherRedeemed: { 'other-ent': '2026-07-01T00:00:00Z' } } },
     });
-    const { deps, sendConversionEvent } = buildDeps({ prospect });
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps({ prospect });
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
     expect(r).toEqual({ dispatched: 'VoucherRedeemed' });
@@ -111,7 +128,7 @@ describe('processRedemption — guards', () => {
 
 describe('processRedemption — dispatch shape', () => {
   test('happy path: deterministic event_id, physical_store, activation-campaign scope, pixel override, marker on success', async () => {
-    const { deps, prospect, sendConversionEvent, canMarketTo, Campaign } = buildDeps();
+    const { deps, prospect, sendConversionEvent, canMarketTo, Campaign, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
 
@@ -134,12 +151,15 @@ describe('processRedemption — dispatch shape', () => {
 
     // Marker written only after the confirmed send.
     expect(prospect.sourceMetadata.capi.voucherRedeemed['ent-uuid-1']).toEqual(expect.any(String));
-    expect(prospect.changed).toHaveBeenCalledWith('sourceMetadata', true);
-    expect(prospect.save).toHaveBeenCalled();
+    expect(mergeSourceMetadataFirstWins).toHaveBeenCalledWith(
+      prospect.id,
+      ['capi', 'voucherRedeemed'],
+      { 'ent-uuid-1': expect.any(String) }
+    );
   });
 
   test('activation.campaignId undefined (association loaded without the column) → reloads the Activation', async () => {
-    const { deps, Activation, sendConversionEvent, canMarketTo } = buildDeps();
+    const { deps, Activation, sendConversionEvent, canMarketTo, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     const entitlement = makeEntitlement({ activation: { id: 'act-uuid-1' } }); // campaignId missing entirely
     await svc.processRedemption({ entitlement });
@@ -149,7 +169,7 @@ describe('processRedemption — dispatch shape', () => {
   });
 
   test('explicit null campaignId (campaign deleted) → no override, consent falls to global scope (fail-closed)', async () => {
-    const { deps, Activation, Campaign, sendConversionEvent, canMarketTo } = buildDeps();
+    const { deps, Activation, Campaign, sendConversionEvent, canMarketTo, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     const entitlement = makeEntitlement({ activation: { id: 'act-uuid-1', campaignId: null } });
     await svc.processRedemption({ entitlement });
@@ -162,7 +182,7 @@ describe('processRedemption — dispatch shape', () => {
   });
 
   test('canMarketTo throws → marketingConsent false, event still fires (fail-closed PII, not a lost event)', async () => {
-    const { deps, sendConversionEvent } = buildDeps({
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps({
       canMarketTo: jest.fn().mockRejectedValue(new Error('ledger down')),
     });
     const svc = makeRedemptionOutcomeService(deps);
@@ -173,7 +193,7 @@ describe('processRedemption — dispatch shape', () => {
 
   test('META_EVENT_REDEEMED renames the event', async () => {
     process.env.META_EVENT_REDEEMED = 'Purchase';
-    const { deps, sendConversionEvent } = buildDeps();
+    const { deps, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps();
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
     expect(r).toEqual({ dispatched: 'Purchase' });
@@ -185,7 +205,7 @@ describe('processRedemption — dispatch shape', () => {
 describe('processRedemption — reliability', () => {
   test('guarded (CAPI off / ineligible origin) → no retry, no marker, benign failure', async () => {
     const send = jest.fn().mockResolvedValue({ sent: false, reason: 'guarded' });
-    const { deps, prospect } = buildDeps({ sendConversionEvent: send });
+    const { deps, prospect, mergeSourceMetadataFirstWins } = buildDeps({ sendConversionEvent: send });
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
     expect(r).toEqual({ failed: 'VoucherRedeemed', reason: 'guarded' });
@@ -197,18 +217,18 @@ describe('processRedemption — reliability', () => {
     const send = jest.fn()
       .mockResolvedValueOnce({ sent: false, status: 500 })
       .mockResolvedValueOnce({ sent: true });
-    const { deps, prospect, sleep } = buildDeps({ sendConversionEvent: send });
+    const { deps, prospect, sleep, mergeSourceMetadataFirstWins } = buildDeps({ sendConversionEvent: send });
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
     expect(r).toEqual({ dispatched: 'VoucherRedeemed' });
     expect(send).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledTimes(1);
-    expect(prospect.save).toHaveBeenCalled();
+    expect(mergeSourceMetadataFirstWins).toHaveBeenCalled();
   });
 
   test('4xx does not retry and leaves the marker unwritten (replay/sweep can retry later)', async () => {
     const send = jest.fn().mockResolvedValue({ sent: false, status: 400 });
-    const { deps, prospect } = buildDeps({ sendConversionEvent: send });
+    const { deps, prospect, mergeSourceMetadataFirstWins } = buildDeps({ sendConversionEvent: send });
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
     expect(r.failed).toBe('VoucherRedeemed');
@@ -217,7 +237,7 @@ describe('processRedemption — reliability', () => {
   });
 
   test('never throws — an exploding model resolves to a failed result', async () => {
-    const { deps, Prospect } = buildDeps();
+    const { deps, Prospect, mergeSourceMetadataFirstWins } = buildDeps();
     Prospect.findByPk.mockRejectedValue(new Error('db down'));
     const svc = makeRedemptionOutcomeService(deps);
     const r = await svc.processRedemption({ entitlement: makeEntitlement() });
@@ -233,7 +253,7 @@ describe('sweepUnmarkedRedemptions', () => {
       sourceMetadata: { capi: { voucherRedeemed: { 'ent-marked': 'ts' } } },
     });
     const fresh = makeProspect({ id: 'p-fresh' });
-    const { deps, RewardEntitlement, Prospect, sendConversionEvent } = buildDeps();
+    const { deps, RewardEntitlement, Prospect, sendConversionEvent, mergeSourceMetadataFirstWins } = buildDeps();
     RewardEntitlement.findAll.mockResolvedValue([
       { id: 'ent-nopros', prospectId: null, activationId: 'act-1' },
       { id: 'ent-marked', prospectId: 'p-marked', activationId: 'act-1', activation: undefined },

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -1,0 +1,337 @@
+import { jest } from '@jest/globals';
+import crypto from 'crypto';
+
+const sentryMocks = { captureException: jest.fn(), captureMessage: jest.fn(), init: jest.fn(), setTag: jest.fn() };
+jest.unstable_mockModule('@sentry/node', () => sentryMocks);
+const loggerMock = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({ logger: loggerMock }));
+const MODEL_NAMES = `Activation ActivationIssuanceSkip AgentGroup AgentGroupMember AiSettings Attribution
+Campaign CampaignAgentAssignment CampaignPreview Cohort ConsentEvent Consumer ConsumerObservation
+ConsumerProfile ConsumerSuppression DiscoveryCandidate DiscoveryDailyUsage DiscoveryPlaceMemory
+DiscoveryRun Draw DrawAttempt DrawBoostReview DrawEntry DrawTermsVersion EmailBroadcast
+EmailBroadcastRecipient EnrichmentJob EnrichmentScoringConfig EnrichmentSweepRun ExternalAgent
+ExternalCampaignAgent IdempotencyKey LeadPackage LeadPackageAssignment MetaAgentConnection
+MetaFormMapping MetaLeadgenEvent MetaPage OutreachAccount OutreachActivity OutreachCadence
+OutreachCadenceEnrollment OutreachCadenceStep OutreachCadenceTransition OutreachEmail
+OutreachPersona OutreachSuppression OutreachTask PartnerAssignmentEvent PartnerContact
+PartnerLocation PartnerOnboardingItem PartnerOrganisation PartnerStageEvent Payment
+PhoneVerificationMarker Prospect ProspectActivity ProspectingPool ProspectingPoolMember QrScan
+QrTag RedeemOpsAuditEvent RedeemOpsCategory Redemption RedemptionEvent RewardEntitlement
+RewardInventoryEvent RewardOffer RewardOfferLocation RewardTermsVersion RoundRobinCursor
+SessionVisit ShortLink ShortLinkClick SuppressionPropagation TimelineHiddenEntry User Verification
+WaitlistSignup WalletLedger WaMessageSend WaMessageStatus WebhookDelivery WebhookSubscriber`
+  .split(/\s+/)
+  .filter(Boolean);
+jest.unstable_mockModule('../../src/models/index.js', () => {
+  const models = Object.fromEntries(MODEL_NAMES.map((n) => [n, {}]));
+  models.Prospect = { findAll: jest.fn(), findByPk: jest.fn() };
+  const sequelize = { transaction: jest.fn(), query: jest.fn() };
+  return { ...models, sequelize, default: { ...models, sequelize } };
+});
+const consentMocks = { getSuppressedPhoneSet: jest.fn(), getMarketableGrantMap: jest.fn(), canMarketTo: jest.fn() };
+jest.unstable_mockModule('../../src/services/consentService.js', () => consentMocks);
+
+let svc;
+let recon;
+beforeAll(async () => {
+  svc = await import('../../src/services/googleOfflineConversionsService.js');
+  recon = await import('../../src/services/googleOutcomesReconciler.js');
+});
+
+const ENV_KEYS = [
+  'GOOGLE_ADS_UPLOADS_ENABLED', 'GOOGLE_DM_OAUTH_CLIENT_ID', 'GOOGLE_DM_OAUTH_CLIENT_SECRET',
+  'GOOGLE_DM_REFRESH_TOKEN', 'GOOGLE_ADS_CUSTOMER_ID', 'GOOGLE_CONV_ACTION_QUALIFIED',
+  'GOOGLE_CONV_ACTION_WON', 'GOOGLE_VALUE_QUALIFIED', 'GOOGLE_VALUE_WON',
+  'GOOGLE_CONV_MAX_AGE_DAYS', 'GOOGLE_PENDING_MAX_DAYS', 'GOOGLE_SEND_MAX_RETRIES',
+  'LYFE_SUPABASE_URL', 'LYFE_SUPABASE_SERVICE_ROLE_KEY',
+];
+const saved = {};
+const T0 = 1_700_000_000_000;
+beforeEach(() => {
+  for (const k of ENV_KEYS) saved[k] = process.env[k];
+  process.env.GOOGLE_ADS_UPLOADS_ENABLED = 'true';
+  process.env.GOOGLE_DM_OAUTH_CLIENT_ID = 'cid';
+  process.env.GOOGLE_DM_OAUTH_CLIENT_SECRET = 'sec';
+  process.env.GOOGLE_DM_REFRESH_TOKEN = 'rt';
+  process.env.GOOGLE_ADS_CUSTOMER_ID = '1829163947';
+  process.env.GOOGLE_CONV_ACTION_QUALIFIED = 'act-cr';
+  process.env.GOOGLE_CONV_ACTION_WON = 'act-cw';
+  process.env.GOOGLE_VALUE_QUALIFIED = '40';
+  process.env.GOOGLE_VALUE_WON = '500';
+  process.env.LYFE_SUPABASE_URL = 'https://lyfe.example';
+  process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY = 'srk';
+  consentMocks.canMarketTo.mockReset().mockResolvedValue(true);
+  sentryMocks.captureException.mockClear();
+  sentryMocks.captureMessage.mockClear();
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+const sha = (v) => crypto.createHash('sha256').update(v).digest('hex');
+const nowAt = (ms) => () => ms;
+
+function prospectFx(overrides = {}) {
+  return {
+    id: 'p-1',
+    email: 'jane@mktr.sg',
+    phone: '+6591234567',
+    consumerId: 'c-1',
+    campaignId: 'camp-1',
+    leadSource: 'website',
+    createdAt: new Date(T0 - 10 * 24 * 60 * 60 * 1000).toISOString(),
+    sourceMetadata: { gcl: { gclid: 'g1', capturedAt: new Date(T0 - 10 * 24 * 60 * 60 * 1000).toISOString() } },
+    ...overrides,
+  };
+}
+
+describe('factEligibility', () => {
+  it('skips call_bot and no-identifier permanently; passes a normal row', () => {
+    expect(svc.factEligibility(prospectFx({ leadSource: 'call_bot' }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'call_bot' });
+    expect(svc.factEligibility(prospectFx({ email: null, phone: null, sourceMetadata: {} }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'no_identifier' });
+    expect(svc.factEligibility(prospectFx(), { now: nowAt(T0) })).toEqual({ ok: true });
+  });
+
+  it('age-guards from the CLICK capture (or signup for PII-only), never the outcome', () => {
+    const oldClick = prospectFx({ sourceMetadata: { gcl: { gclid: 'g', capturedAt: new Date(T0 - 61 * 24 * 60 * 60 * 1000).toISOString() } } });
+    expect(svc.factEligibility(oldClick, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired' });
+    const piiOnlyOld = prospectFx({ sourceMetadata: {}, createdAt: new Date(T0 - 61 * 24 * 60 * 60 * 1000).toISOString() });
+    expect(svc.factEligibility(piiOnlyOld, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired' });
+    const piiOnlyFresh = prospectFx({ sourceMetadata: {}, createdAt: new Date(T0 - 5 * 24 * 60 * 60 * 1000).toISOString() });
+    expect(svc.factEligibility(piiOnlyFresh, { now: nowAt(T0) })).toEqual({ ok: true });
+  });
+
+  it('Meta-Lead-Ads-origin rows are NOT skipped (upload-all guidance)', () => {
+    const metaLead = prospectFx({ sourceMetadata: { metaLeadgenId: 'ml-1', gcl: { gclid: 'g', capturedAt: new Date(T0 - 1000).toISOString() } } });
+    expect(svc.factEligibility(metaLead, { now: nowAt(T0) })).toEqual({ ok: true });
+  });
+});
+
+describe('buildOutcomeEnvelope', () => {
+  it('pins the consented envelope: OTHER, RFC3339, transactionId, ALL identifiers, HEX + consent WITH userData', () => {
+    const env = svc.buildOutcomeEnvelope(
+      prospectFx({ sourceMetadata: { gcl: { gclid: 'g1', gbraid: 'b1', wbraid: 'w1' } } }),
+      'confirmed_resident',
+      '2026-08-18T01:02:03.000Z',
+      { marketingConsent: true }
+    );
+    expect(env).toEqual({
+      destinations: [{ operatingAccount: { product: 'GOOGLE_ADS', accountId: '1829163947' }, productDestinationId: 'act-cr' }],
+      events: [{
+        eventSource: 'OTHER',
+        eventTimestamp: '2026-08-18T01:02:03.000Z',
+        transactionId: 'confirmed_resident:p-1',
+        conversionValue: 40,
+        currency: 'SGD',
+        adIdentifiers: { gclid: 'g1', gbraid: 'b1', wbraid: 'w1' },
+        userData: { userIdentifiers: [{ emailAddress: sha('jane@mktr.sg') }, { phoneNumber: sha('+6591234567') }] },
+      }],
+      encoding: 'HEX',
+      consent: { adUserData: 'CONSENT_GRANTED', adPersonalization: 'CONSENT_GRANTED' },
+    });
+  });
+
+  it('click-only (no consent) omits userData, encoding, AND the consent block — never a false CONSENT_GRANTED', () => {
+    const env = svc.buildOutcomeEnvelope(prospectFx(), 'closed_won', '2026-08-18T01:02:03.000Z', { marketingConsent: false });
+    expect(env.events[0].userData).toBeUndefined();
+    expect(env.encoding).toBeUndefined();
+    expect(env.consent).toBeUndefined();
+    expect(env.events[0].adIdentifiers).toEqual({ gclid: 'g1' });
+    expect(env.events[0].conversionValue).toBe(500);
+    expect(env.destinations[0].productDestinationId).toBe('act-cw');
+  });
+});
+
+describe('dispatchOutcome', () => {
+  it('accept → pending marker carrying retryCount, ~30min first poll', async () => {
+    const setPath = jest.fn().mockResolvedValue(1);
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
+    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 2, {
+      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(res).toEqual({ sent: true, requestId: 'req-1' });
+    const [, path, marker] = setPath.mock.calls[0];
+    expect(path).toEqual(['gads', 'confirmed_resident']);
+    expect(marker).toMatchObject({ state: 'pending', requestId: 'req-1', retryCount: 2 });
+    expect(Date.parse(marker.nextPollAt) - T0).toBe(30 * 60_000);
+  });
+
+  it('permanently ineligible facts get skippedPermanent (no send)', async () => {
+    const setPath = jest.fn().mockResolvedValue(1);
+    const dmRequest = jest.fn();
+    const res = await svc.dispatchOutcome(prospectFx({ leadSource: 'call_bot' }), 'confirmed_resident', new Date(T0).toISOString(), 0, {
+      setPath, dmRequest, now: nowAt(T0),
+    });
+    expect(res.reason).toBe('call_bot');
+    expect(dmRequest).not.toHaveBeenCalled();
+    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'skippedPermanent', reason: 'call_bot' });
+  });
+
+  it('retry cap is checked BEFORE dispatch → failedPermanent', async () => {
+    const setPath = jest.fn().mockResolvedValue(1);
+    const dmRequest = jest.fn();
+    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 5, {
+      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(res.reason).toBe('retry_cap');
+    expect(dmRequest).not.toHaveBeenCalled();
+    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'retry_cap' });
+  });
+
+  it('ledger failure fails CLOSED for PII but the click-only event still sends', async () => {
+    consentMocks.canMarketTo.mockRejectedValue(new Error('ledger down'));
+    const setPath = jest.fn().mockResolvedValue(1);
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
+    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
+      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(res.sent).toBe(true);
+    const envelope = dmRequest.mock.calls[0][1];
+    expect(envelope.events[0].userData).toBeUndefined();
+    expect(envelope.consent).toBeUndefined();
+    expect(envelope.events[0].adIdentifiers.gclid).toBe('g1');
+  });
+
+  it('missing requestId and transient errors → retryWait with retryCount+1; 4xx → failedPermanent', async () => {
+    const setPath = jest.fn().mockResolvedValue(1);
+    const noId = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 1, {
+      setPath, dmRequest: jest.fn().mockResolvedValue({}), canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(noId.reason).toBe('missing_request_id');
+    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 2, lastReason: 'missing_request_id' });
+
+    setPath.mockClear();
+    const transient = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
+      setPath, dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('boom'), { status: 503 })),
+      canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(transient.reason).toBe('transient');
+    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 1 });
+
+    setPath.mockClear();
+    const permanent = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
+      setPath, dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('bad'), { status: 400 })),
+      canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
+    });
+    expect(permanent.reason).toBe('permanent');
+    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'http_400' });
+  });
+});
+
+describe('workers', () => {
+  it('resend: missing action id aborts the key pass with NO row mutation or query', async () => {
+    delete process.env.GOOGLE_CONV_ACTION_QUALIFIED;
+    delete process.env.GOOGLE_CONV_ACTION_WON;
+    const sequelize = { query: jest.fn() };
+    const res = await svc.resendDueOutcomes({ sequelize, now: nowAt(T0) });
+    expect(res.ran).toBe(true);
+    expect(sequelize.query).not.toHaveBeenCalled();
+  });
+
+  it('settle: SUCCESS delivers with a requestId CAS; FAILED re-queues with Sentry; PROCESSING advances nextPollAt', async () => {
+    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 40 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
+    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const setPath = jest.fn().mockResolvedValue(1);
+    const dmRequestGet = jest.fn().mockResolvedValue({ requestStatus: 'SUCCESS' });
+    const res = await svc.settleDueOutcomes({ sequelize, setPath, dmRequestGet, now: nowAt(T0) });
+    expect(res.delivered).toBe(1);
+    const [, path, value, opts] = setPath.mock.calls[0];
+    expect(path).toEqual(['gads', 'confirmed_resident']);
+    expect(value).toMatchObject({ state: 'delivered', requestId: 'req-1' });
+    expect(opts.cas).toEqual({ path: ['gads', 'confirmed_resident'], contains: { state: 'pending', requestId: 'req-1' } });
+
+    const seq2 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const set2 = jest.fn().mockResolvedValue(1);
+    const failed = await svc.settleDueOutcomes({ sequelize: seq2, setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED' }), now: nowAt(T0) });
+    expect(failed.retried).toBe(1);
+    expect(set2.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 1, lastReason: 'ingest_failed' });
+    expect(sentryMocks.captureMessage).toHaveBeenCalled();
+
+    const seq3 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const set3 = jest.fn().mockResolvedValue(1);
+    const processing = await svc.settleDueOutcomes({ sequelize: seq3, setPath: set3, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
+    expect(processing.stillPending).toBe(1);
+    expect(Date.parse(set3.mock.calls[0][2].nextPollAt)).toBeGreaterThan(T0);
+  });
+
+  it('settle: duplicate-transaction evidence counts as delivered; pending past the horizon fails permanently', async () => {
+    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 8 * 24 * 60 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
+    const seq = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const set = jest.fn().mockResolvedValue(1);
+    const dup = await svc.settleDueOutcomes({ sequelize: seq, setPath: set, dmRequestGet: jest.fn().mockRejectedValue(new Error('HTTP 409 duplicate transaction id')), now: nowAt(T0) });
+    expect(dup.delivered).toBe(1);
+    expect(set.mock.calls[0][2]).toMatchObject({ state: 'delivered' });
+
+    const seq2 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const set2 = jest.fn().mockResolvedValue(1);
+    const timedOut = await svc.settleDueOutcomes({ sequelize: seq2, setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
+    expect(timedOut.failedPermanent).toBe(1);
+    expect(set2.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'pending_timeout' });
+  });
+});
+
+describe('reconcileLyfeOutcomes', () => {
+  function jsonRes(body) {
+    return { ok: true, json: async () => body };
+  }
+
+  it('direct statuses write first-wins facts; proposed WITHOUT history gets nothing (no false CR)', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce(jsonRes([
+        { id: 'L1', external_id: 'p-q', status: 'qualified', updated_at: '2026-08-01T00:00:00Z' },
+        { id: 'L2', external_id: 'p-prop', status: 'proposed', updated_at: '2026-08-02T00:00:00Z' },
+      ]))
+      .mockResolvedValueOnce(jsonRes([])); // no qualifying history
+    const Prospect = { findAll: jest.fn().mockResolvedValue([
+      { id: 'p-q', sourceMetadata: {} },
+      { id: 'p-prop', sourceMetadata: {} },
+    ]) };
+    const mergeFirstWins = jest.fn().mockResolvedValue(1);
+    const res = await recon.reconcileLyfeOutcomes({ fetch, Prospect, mergeFirstWins });
+    expect(res.factsWritten).toBe(1);
+    expect(mergeFirstWins).toHaveBeenCalledTimes(1);
+    expect(mergeFirstWins.mock.calls[0][0]).toBe('p-q');
+    expect(mergeFirstWins.mock.calls[0][2]).toEqual({ confirmed_resident: '2026-08-01T00:00:00.000Z' });
+  });
+
+  it('a won → qualified regression recovers closed_won from the status_change history', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce(jsonRes([
+        { id: 'L1', external_id: 'p-1', status: 'qualified', updated_at: '2026-08-10T00:00:00Z' },
+      ]))
+      .mockResolvedValueOnce(jsonRes([
+        { lead_id: 'L1', created_at: '2026-08-05T00:00:00Z', metadata: { from_status: 'qualified', to_status: 'won' } },
+      ]));
+    const Prospect = { findAll: jest.fn().mockResolvedValue([{ id: 'p-1', sourceMetadata: {} }]) };
+    const mergeFirstWins = jest.fn().mockResolvedValue(1);
+    const res = await recon.reconcileLyfeOutcomes({ fetch, Prospect, mergeFirstWins });
+    expect(res.factsWritten).toBe(2);
+    const patch = mergeFirstWins.mock.calls[0][2];
+    expect(patch.confirmed_resident).toBe('2026-08-10T00:00:00.000Z'); // direct evidence
+    expect(patch.closed_won).toBe('2026-08-05T00:00:00.000Z'); // history-proven
+    // the exact PostgREST shapes are pinned (column `type`, metadata to_status)
+    expect(fetch.mock.calls[1][0]).toContain('lead_activities?type=eq.status_change');
+    expect(fetch.mock.calls[1][0]).toContain('select=lead_id,created_at,metadata');
+  });
+
+  it('existing facts are never re-written; guarded without config', async () => {
+    const fetch = jest.fn().mockResolvedValueOnce(jsonRes([
+      { id: 'L1', external_id: 'p-1', status: 'won', updated_at: '2026-08-10T00:00:00Z' },
+    ])).mockResolvedValueOnce(jsonRes([]));
+    const Prospect = { findAll: jest.fn().mockResolvedValue([
+      { id: 'p-1', sourceMetadata: { outcomes: { confirmed_resident: 'X', closed_won: 'Y' } } },
+    ]) };
+    const mergeFirstWins = jest.fn();
+    const res = await recon.reconcileLyfeOutcomes({ fetch, Prospect, mergeFirstWins });
+    expect(res.factsWritten).toBe(0);
+    expect(mergeFirstWins).not.toHaveBeenCalled();
+
+    delete process.env.LYFE_SUPABASE_URL;
+    expect(await recon.reconcileLyfeOutcomes({ fetch, Prospect, mergeFirstWins })).toEqual({ ran: false, reason: 'guarded' });
+  });
+});

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -345,7 +345,9 @@ describe('classifyStatusBody (M2 reason taxonomy)', () => {
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_EVENT_TOO_OLD' }] } })).toBe('permanent');
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_DENIED_CONSENT' }] } })).toBe('permanent');
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED' }] } })).toBe('permanent');
-    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER' }] } })).toBe('permanent');
+    // the EXCEPTIONAL bare PROCESSING_ERROR_ prefix (documented as-is)
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_NO_CONSENT' }] } })).toBe('permanent');
     // bare suffixes still classify (defensive against shape drift)
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'EVENT_TOO_OLD' }] } })).toBe('permanent');
     // unknown enum → retry, even when it CONTAINS a scary substring

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -88,35 +88,43 @@ function prospectFx(overrides = {}) {
   };
 }
 
-describe('factEligibility', () => {
-  it('skips call_bot and no-identifier permanently; passes a normal row', () => {
-    expect(svc.factEligibility(prospectFx({ leadSource: 'call_bot' }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'call_bot' });
-    expect(svc.factEligibility(prospectFx({ email: null, phone: null, sourceMetadata: {} }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'no_identifier' });
-    expect(svc.factEligibility(prospectFx(), { now: nowAt(T0) })).toEqual({ ok: true });
+describe('factScreen', () => {
+  it('terminally screens call_bot and expired click windows; erased is non-terminal (guards block writes)', () => {
+    expect(svc.factScreen(prospectFx({ leadSource: 'call_bot' }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'call_bot', terminal: true });
+    expect(svc.factScreen(prospectFx({ sourceMetadata: { erased: true } }), { now: nowAt(T0) })).toEqual({ ok: false, reason: 'erased', terminal: false });
+    expect(svc.factScreen(prospectFx(), { now: nowAt(T0) })).toEqual({ ok: true });
   });
 
-  it('age-guards from the CLICK capture (or signup for PII-only), never the outcome', () => {
+  it('age-guards from the CLICK capture (or signup for click-less rows) and a FUTURE anchor cannot extend the window', () => {
     const oldClick = prospectFx({ sourceMetadata: { gcl: { gclid: 'g', capturedAt: new Date(T0 - 61 * 24 * 60 * 60 * 1000).toISOString() } } });
-    expect(svc.factEligibility(oldClick, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired' });
+    expect(svc.factScreen(oldClick, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired', terminal: true });
+    const futureForged = prospectFx({
+      createdAt: new Date(T0 - 61 * 24 * 60 * 60 * 1000).toISOString(),
+      sourceMetadata: { gcl: { gclid: 'g', capturedAt: new Date(T0 + 90 * 24 * 60 * 60 * 1000).toISOString() } },
+    });
+    // clamped to now → within window is TRUE only because the click anchor is
+    // clamped, not extended — a future stamp cannot push eligibility out
+    expect(svc.factScreen(futureForged, { now: nowAt(T0) })).toEqual({ ok: true });
     const piiOnlyOld = prospectFx({ sourceMetadata: {}, createdAt: new Date(T0 - 61 * 24 * 60 * 60 * 1000).toISOString() });
-    expect(svc.factEligibility(piiOnlyOld, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired' });
-    const piiOnlyFresh = prospectFx({ sourceMetadata: {}, createdAt: new Date(T0 - 5 * 24 * 60 * 60 * 1000).toISOString() });
-    expect(svc.factEligibility(piiOnlyFresh, { now: nowAt(T0) })).toEqual({ ok: true });
+    expect(svc.factScreen(piiOnlyOld, { now: nowAt(T0) })).toEqual({ ok: false, reason: 'age_window_expired', terminal: true });
   });
 
   it('Meta-Lead-Ads-origin rows are NOT skipped (upload-all guidance)', () => {
     const metaLead = prospectFx({ sourceMetadata: { metaLeadgenId: 'ml-1', gcl: { gclid: 'g', capturedAt: new Date(T0 - 1000).toISOString() } } });
-    expect(svc.factEligibility(metaLead, { now: nowAt(T0) })).toEqual({ ok: true });
+    expect(svc.factScreen(metaLead, { now: nowAt(T0) })).toEqual({ ok: true });
   });
 });
 
 describe('buildOutcomeEnvelope', () => {
   it('pins the consented envelope: OTHER, RFC3339, transactionId, ALL identifiers, HEX + consent WITH userData', () => {
     const env = svc.buildOutcomeEnvelope(
-      prospectFx({ sourceMetadata: { gcl: { gclid: 'g1', gbraid: 'b1', wbraid: 'w1' } } }),
+      prospectFx(),
       'confirmed_resident',
       '2026-08-18T01:02:03.000Z',
-      { marketingConsent: true }
+      {
+        adIdentifiers: { gclid: 'g1', gbraid: 'b1', wbraid: 'w1' },
+        userIdentifiers: [{ emailAddress: sha('jane@mktr.sg') }, { phoneNumber: sha('+6591234567') }],
+      }
     );
     expect(env).toEqual({
       destinations: [{ operatingAccount: { product: 'GOOGLE_ADS', accountId: '1829163947' }, productDestinationId: 'act-cr' }],
@@ -135,7 +143,10 @@ describe('buildOutcomeEnvelope', () => {
   });
 
   it('click-only (no consent) omits userData, encoding, AND the consent block — never a false CONSENT_GRANTED', () => {
-    const env = svc.buildOutcomeEnvelope(prospectFx(), 'closed_won', '2026-08-18T01:02:03.000Z', { marketingConsent: false });
+    const env = svc.buildOutcomeEnvelope(prospectFx(), 'closed_won', '2026-08-18T01:02:03.000Z', {
+      adIdentifiers: { gclid: 'g1' },
+      userIdentifiers: [],
+    });
     expect(env.events[0].userData).toBeUndefined();
     expect(env.encoding).toBeUndefined();
     expect(env.consent).toBeUndefined();
@@ -145,79 +156,162 @@ describe('buildOutcomeEnvelope', () => {
   });
 });
 
-describe('dispatchOutcome', () => {
-  it('accept → pending marker carrying retryCount, ~30min first poll', async () => {
-    const setPath = jest.fn().mockResolvedValue(1);
-    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
-    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 2, {
-      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
+describe('dispatchOutcome (claim-flow)', () => {
+  function freshDeps(row, over = {}) {
+    return {
+      Prospect: { findByPk: jest.fn().mockResolvedValue(row) },
+      setPath: jest.fn().mockResolvedValue(1),
+      dmRequest: jest.fn().mockResolvedValue({ requestId: 'req-1' }),
+      canMarketTo: consentMocks.canMarketTo,
+      now: nowAt(T0),
+      randomUUID: () => 'claim-1',
+      ...over,
+    };
+  }
+  function rowWithFact(overrides = {}) {
+    const base = prospectFx(overrides);
+    base.sourceMetadata = { ...base.sourceMetadata, outcomes: { confirmed_resident: '2026-08-18T01:00:00.000Z' }, ...(overrides.sourceMetadata || {}) };
+    return base;
+  }
+
+  it('claims (CAS absent), sends, and CASes pending against the claim token', async () => {
+    const d = freshDeps(rowWithFact());
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
     expect(res).toEqual({ sent: true, requestId: 'req-1' });
-    const [, path, marker] = setPath.mock.calls[0];
-    expect(path).toEqual(['gads', 'confirmed_resident']);
-    expect(marker).toMatchObject({ state: 'pending', requestId: 'req-1', retryCount: 2 });
-    expect(Date.parse(marker.nextPollAt) - T0).toBe(30 * 60_000);
+    const claim = d.setPath.mock.calls[0];
+    expect(claim[2]).toMatchObject({ state: 'sending', claimToken: 'claim-1', retryCount: 0 });
+    expect(claim[3].cas).toEqual({ path: ['gads', 'confirmed_resident'], absent: true });
+    const pending = d.setPath.mock.calls[1];
+    expect(pending[2]).toMatchObject({ state: 'pending', requestId: 'req-1', retryCount: 0 });
+    expect(Date.parse(pending[2].nextPollAt) - T0).toBe(30 * 60_000);
+    expect(pending[3].cas).toEqual({ path: ['gads', 'confirmed_resident'], contains: { state: 'sending', claimToken: 'claim-1' } });
   });
 
-  it('permanently ineligible facts get skippedPermanent (no send)', async () => {
-    const setPath = jest.fn().mockResolvedValue(1);
-    const dmRequest = jest.fn();
-    const res = await svc.dispatchOutcome(prospectFx({ leadSource: 'call_bot' }), 'confirmed_resident', new Date(T0).toISOString(), 0, {
-      setPath, dmRequest, now: nowAt(T0),
-    });
-    expect(res.reason).toBe('call_bot');
-    expect(dmRequest).not.toHaveBeenCalled();
-    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'skippedPermanent', reason: 'call_bot' });
+  it('a lost claim walks away without sending (worker/inline race)', async () => {
+    const d = freshDeps(rowWithFact(), { setPath: jest.fn().mockResolvedValue(0) });
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res).toEqual({ sent: false, reason: 'claim_lost' });
+    expect(d.dmRequest).not.toHaveBeenCalled();
   });
 
-  it('retry cap is checked BEFORE dispatch → failedPermanent', async () => {
-    const setPath = jest.fn().mockResolvedValue(1);
-    const dmRequest = jest.fn();
-    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 5, {
-      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
-    expect(res.reason).toBe('retry_cap');
-    expect(dmRequest).not.toHaveBeenCalled();
-    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'retry_cap' });
-  });
-
-  it('ledger failure fails CLOSED for PII but the click-only event still sends', async () => {
-    consentMocks.canMarketTo.mockRejectedValue(new Error('ledger down'));
-    const setPath = jest.fn().mockResolvedValue(1);
-    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
-    const res = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
-      setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
+  it('claims a DUE retryWait with its retryCount and refuses one that is not due', async () => {
+    const due = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'retryWait', retryCount: 2, nextSendAt: new Date(T0 - 1000).toISOString() } } } });
+    const d = freshDeps(due);
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
     expect(res.sent).toBe(true);
-    const envelope = dmRequest.mock.calls[0][1];
+    expect(d.setPath.mock.calls[0][3].cas).toEqual({
+      path: ['gads', 'confirmed_resident'],
+      contains: { state: 'retryWait', retryCount: 2 },
+    });
+    expect(d.setPath.mock.calls[1][2].retryCount).toBe(2); // rides through pending
+
+    const notDue = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'retryWait', retryCount: 1, nextSendAt: new Date(T0 + 60_000).toISOString() } } } });
+    const d2 = freshDeps(notDue);
+    expect(await svc.dispatchOutcome('p-1', 'confirmed_resident', d2)).toEqual({ sent: false, reason: 'not_due' });
+  });
+
+  it('existing pending/delivered markers are never re-dispatched; missing fact/row abort', async () => {
+    const pendingRow = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'pending', requestId: 'r' } } } });
+    expect(await svc.dispatchOutcome('p-1', 'confirmed_resident', freshDeps(pendingRow))).toEqual({ sent: false, reason: 'marker_present' });
+    expect(await svc.dispatchOutcome('p-1', 'confirmed_resident', freshDeps(prospectFx()))).toEqual({ sent: false, reason: 'no_fact' });
+    expect(await svc.dispatchOutcome('p-1', 'confirmed_resident', freshDeps(null))).toEqual({ sent: false, reason: 'missing_row' });
+  });
+
+  it('erased rows never send and never get a marker written', async () => {
+    const erased = rowWithFact({ sourceMetadata: { erased: true } });
+    const d = freshDeps(erased);
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res).toEqual({ sent: false, reason: 'erased' });
+    expect(d.dmRequest).not.toHaveBeenCalled();
+    expect(d.setPath).not.toHaveBeenCalled();
+  });
+
+  it('terminal screens write skippedPermanent THROUGH the claim CAS', async () => {
+    const bot = rowWithFact({ leadSource: 'call_bot' });
+    const d = freshDeps(bot);
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res.reason).toBe('call_bot');
+    expect(d.dmRequest).not.toHaveBeenCalled();
+    expect(d.setPath.mock.calls[0][2]).toMatchObject({ state: 'skippedPermanent', reason: 'call_bot' });
+    expect(d.setPath.mock.calls[0][3].cas).toEqual({ path: ['gads', 'confirmed_resident'], absent: true });
+  });
+
+  it('retry cap is enforced BEFORE dispatch', async () => {
+    const capped = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'retryWait', retryCount: 5, nextSendAt: new Date(T0 - 1000).toISOString() } } } });
+    const d = freshDeps(capped);
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res.reason).toBe('retry_cap');
+    expect(d.dmRequest).not.toHaveBeenCalled();
+    expect(d.setPath.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'retry_cap' });
+  });
+
+  it('identifier decision is POST-ledger: PII-only + ledger outage → retryWait; PII-only + denial → skippedPermanent; click-only sends without consent block', async () => {
+    const piiOnly = rowWithFact({ sourceMetadata: { outcomes: { confirmed_resident: 'X' } } });
+    piiOnly.sourceMetadata.gcl = undefined;
+    consentMocks.canMarketTo.mockRejectedValueOnce(new Error('ledger down'));
+    const d = freshDeps(piiOnly);
+    const outage = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(outage.reason).toBe('ledger_outage');
+    expect(d.setPath.mock.calls[1][2]).toMatchObject({ state: 'retryWait', retryCount: 1, lastReason: 'ledger_outage' });
+    expect(d.dmRequest).not.toHaveBeenCalled();
+
+    consentMocks.canMarketTo.mockResolvedValueOnce(false);
+    const d2 = freshDeps(structuredClone(piiOnly));
+    const denied = await svc.dispatchOutcome('p-1', 'confirmed_resident', d2);
+    expect(denied.reason).toBe('no_identifier');
+    expect(d2.setPath.mock.calls[1][2]).toMatchObject({ state: 'skippedPermanent', reason: 'no_identifier' });
+    expect(d2.dmRequest).not.toHaveBeenCalled();
+
+    consentMocks.canMarketTo.mockRejectedValueOnce(new Error('ledger down'));
+    const clickOnly = freshDeps(rowWithFact());
+    const sent = await svc.dispatchOutcome('p-1', 'confirmed_resident', clickOnly);
+    expect(sent.sent).toBe(true);
+    const envelope = clickOnly.dmRequest.mock.calls[0][1];
     expect(envelope.events[0].userData).toBeUndefined();
     expect(envelope.consent).toBeUndefined();
     expect(envelope.events[0].adIdentifiers.gclid).toBe('g1');
   });
 
-  it('missing requestId and transient errors → retryWait with retryCount+1; 4xx → failedPermanent', async () => {
-    const setPath = jest.fn().mockResolvedValue(1);
-    const noId = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 1, {
-      setPath, dmRequest: jest.fn().mockResolvedValue({}), canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
+  it('missing requestId / transient / 4xx transitions all CAS against the claim', async () => {
+    const d = freshDeps(rowWithFact(), { dmRequest: jest.fn().mockResolvedValue({}) });
+    const noId = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
     expect(noId.reason).toBe('missing_request_id');
-    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 2, lastReason: 'missing_request_id' });
+    expect(d.setPath.mock.calls[1][2]).toMatchObject({ state: 'retryWait', retryCount: 1 });
+    expect(d.setPath.mock.calls[1][3].cas.contains).toEqual({ state: 'sending', claimToken: 'claim-1' });
 
-    setPath.mockClear();
-    const transient = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
-      setPath, dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('boom'), { status: 503 })),
-      canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
-    expect(transient.reason).toBe('transient');
-    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 1 });
+    const d2 = freshDeps(rowWithFact(), { dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('x'), { status: 400 })) });
+    const perm = await svc.dispatchOutcome('p-1', 'confirmed_resident', d2);
+    expect(perm.reason).toBe('permanent');
+    expect(d2.setPath.mock.calls[1][2]).toMatchObject({ state: 'failedPermanent', reason: 'http_400' });
 
-    setPath.mockClear();
-    const permanent = await svc.dispatchOutcome(prospectFx(), 'confirmed_resident', new Date(T0).toISOString(), 0, {
-      setPath, dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('bad'), { status: 400 })),
-      canMarketTo: consentMocks.canMarketTo, now: nowAt(T0),
-    });
-    expect(permanent.reason).toBe('permanent');
-    expect(setPath.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'http_400' });
+    const d3 = freshDeps(rowWithFact(), { dmRequest: jest.fn().mockRejectedValue(Object.assign(new Error('x'), { status: 503 })) });
+    const trans = await svc.dispatchOutcome('p-1', 'confirmed_resident', d3);
+    expect(trans.reason).toBe('transient');
+    expect(d3.setPath.mock.calls[1][2]).toMatchObject({ state: 'retryWait', retryCount: 1 });
+  });
+
+  it('default values survive missing env (plan-contracted S$40/S$500)', async () => {
+    delete process.env.GOOGLE_VALUE_QUALIFIED;
+    delete process.env.GOOGLE_VALUE_WON;
+    expect(svc.valueFor('confirmed_resident')).toBe(40);
+    expect(svc.valueFor('closed_won')).toBe(500);
+    process.env.GOOGLE_VALUE_QUALIFIED = 'garbage';
+    expect(svc.valueFor('confirmed_resident')).toBe(40);
+  });
+});
+
+describe('classifyStatusBody (M2 reason taxonomy)', () => {
+  it('duplicate evidence in errorCounts = delivered even on FAILED/PARTIAL', () => {
+    expect(svc.classifyStatusBody({ requestStatusPerDestination: [{ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'DUPLICATE_TRANSACTION_ID', count: 1 }] } }] })).toBe('delivered');
+    expect(svc.classifyStatusBody({ requestStatus: 'PARTIAL_SUCCESS', errorInfo: { errorCounts: [{ errorReason: 'duplicate' }] } })).toBe('delivered');
+  });
+
+  it('permanent validation/consent/age reasons never retry; unexplained failures do', () => {
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'INVALID_ARGUMENT' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'EVENT_TOO_OLD' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED' })).toBe('transient');
+    expect(svc.classifyStatusBody({ requestStatus: 'SUCCESS' })).toBe('delivered');
+    expect(svc.classifyStatusBody({ requestStatus: 'PROCESSING' })).toBe('processing');
   });
 });
 
@@ -231,45 +325,60 @@ describe('workers', () => {
     expect(sequelize.query).not.toHaveBeenCalled();
   });
 
-  it('settle: SUCCESS delivers with a requestId CAS; FAILED re-queues with Sentry; PROCESSING advances nextPollAt', async () => {
-    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 40 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
-    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+  it('resend: dispatches each due row through the claim flow (fresh reload inside)', async () => {
+    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1' }]).mockResolvedValue([]) };
+    const row = prospectFx();
+    row.sourceMetadata = { ...row.sourceMetadata, outcomes: { confirmed_resident: '2026-08-18T01:00:00.000Z' } };
+    const Prospect = { findByPk: jest.fn().mockResolvedValue(row) };
     const setPath = jest.fn().mockResolvedValue(1);
-    const dmRequestGet = jest.fn().mockResolvedValue({ requestStatus: 'SUCCESS' });
-    const res = await svc.settleDueOutcomes({ sequelize, setPath, dmRequestGet, now: nowAt(T0) });
-    expect(res.delivered).toBe(1);
-    const [, path, value, opts] = setPath.mock.calls[0];
-    expect(path).toEqual(['gads', 'confirmed_resident']);
-    expect(value).toMatchObject({ state: 'delivered', requestId: 'req-1' });
-    expect(opts.cas).toEqual({ path: ['gads', 'confirmed_resident'], contains: { state: 'pending', requestId: 'req-1' } });
-
-    const seq2 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
-    const set2 = jest.fn().mockResolvedValue(1);
-    const failed = await svc.settleDueOutcomes({ sequelize: seq2, setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED' }), now: nowAt(T0) });
-    expect(failed.retried).toBe(1);
-    expect(set2.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 1, lastReason: 'ingest_failed' });
-    expect(sentryMocks.captureMessage).toHaveBeenCalled();
-
-    const seq3 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
-    const set3 = jest.fn().mockResolvedValue(1);
-    const processing = await svc.settleDueOutcomes({ sequelize: seq3, setPath: set3, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
-    expect(processing.stillPending).toBe(1);
-    expect(Date.parse(set3.mock.calls[0][2].nextPollAt)).toBeGreaterThan(T0);
+    const dmRequest = jest.fn().mockResolvedValue({ requestId: 'req-1' });
+    const res = await svc.resendDueOutcomes({ sequelize, Prospect, setPath, dmRequest, canMarketTo: consentMocks.canMarketTo, now: nowAt(T0), randomUUID: () => 'c' });
+    expect(res.sent).toBe(1);
+    expect(Prospect.findByPk).toHaveBeenCalledWith('p-1', { raw: true });
+    expect(sequelize.query.mock.calls[0][0]).toContain("-> 'outcomes'");
   });
 
-  it('settle: duplicate-transaction evidence counts as delivered; pending past the horizon fails permanently', async () => {
-    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 8 * 24 * 60 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
-    const seq = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
-    const set = jest.fn().mockResolvedValue(1);
-    const dup = await svc.settleDueOutcomes({ sequelize: seq, setPath: set, dmRequestGet: jest.fn().mockRejectedValue(new Error('HTTP 409 duplicate transaction id')), now: nowAt(T0) });
-    expect(dup.delivered).toBe(1);
-    expect(set.mock.calls[0][2]).toMatchObject({ state: 'delivered' });
+  it('settle: delivered/permanent/transient via the taxonomy, all CAS on the exact pending marker', async () => {
+    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 40 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
+    const mk = () => ({ query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) });
 
-    const seq2 = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const set1 = jest.fn().mockResolvedValue(1);
+    const ok = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set1, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'SUCCESS' }), now: nowAt(T0) });
+    expect(ok.delivered).toBe(1);
+    expect(set1.mock.calls[0][3].cas).toEqual({ path: ['gads', 'confirmed_resident'], contains: { state: 'pending', requestId: 'req-1' } });
+
     const set2 = jest.fn().mockResolvedValue(1);
-    const timedOut = await svc.settleDueOutcomes({ sequelize: seq2, setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
+    const rejected = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'INVALID_ARGUMENT' }] } }), now: nowAt(T0) });
+    expect(rejected.failedPermanent).toBe(1);
+    expect(set2.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'ingest_rejected' });
+
+    const set3 = jest.fn().mockResolvedValue(1);
+    const transient = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set3, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED' }), now: nowAt(T0) });
+    expect(transient.retried).toBe(1);
+    expect(set3.mock.calls[0][2]).toMatchObject({ state: 'retryWait', retryCount: 1, lastReason: 'ingest_failed' });
+
+    const set4 = jest.fn().mockResolvedValue(1);
+    const processing = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set4, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
+    expect(processing.stillPending).toBe(1);
+    expect(Date.parse(set4.mock.calls[0][2].nextPollAt)).toBeGreaterThan(T0);
+  });
+
+  it('settle: duplicate evidence (body OR thrown) = delivered; pending past the horizon fails permanently', async () => {
+    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 8 * 24 * 60 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
+    const mk = () => ({ query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) });
+
+    const set1 = jest.fn().mockResolvedValue(1);
+    const viaBody = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set1, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'duplicate_transaction' }] } }), now: nowAt(T0) });
+    expect(viaBody.delivered).toBe(1);
+
+    const set2 = jest.fn().mockResolvedValue(1);
+    const viaThrow = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set2, dmRequestGet: jest.fn().mockRejectedValue(new Error('HTTP 409 duplicate transaction id')), now: nowAt(T0) });
+    expect(viaThrow.delivered).toBe(1);
+
+    const set3 = jest.fn().mockResolvedValue(1);
+    const timedOut = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set3, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
     expect(timedOut.failedPermanent).toBe(1);
-    expect(set2.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'pending_timeout' });
+    expect(set3.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'pending_timeout' });
   });
 });
 

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -160,6 +160,8 @@ describe('dispatchOutcome (claim-flow)', () => {
   function freshDeps(row, over = {}) {
     return {
       Prospect: { findByPk: jest.fn().mockResolvedValue(row) },
+      // pre-send erased re-check (round 2 #1)
+      sequelize: { query: jest.fn().mockResolvedValue([{ erased: 'false' }]) },
       setPath: jest.fn().mockResolvedValue(1),
       dmRequest: jest.fn().mockResolvedValue({ requestId: 'req-1' }),
       canMarketTo: consentMocks.canMarketTo,
@@ -290,6 +292,37 @@ describe('dispatchOutcome (claim-flow)', () => {
     expect(d3.setPath.mock.calls[1][2]).toMatchObject({ state: 'retryWait', retryCount: 1 });
   });
 
+  it('a live sending claim is respected; a STALE one is reclaimed as a lease carrying retryCount', async () => {
+    const live = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'sending', claimToken: 'other', retryCount: 3, claimedAt: new Date(T0 - 60_000).toISOString() } } } });
+    expect(await svc.dispatchOutcome('p-1', 'confirmed_resident', freshDeps(live))).toEqual({ sent: false, reason: 'claim_held' });
+
+    const stale = rowWithFact({ sourceMetadata: { gads: { confirmed_resident: { state: 'sending', claimToken: 'dead', retryCount: 3, claimedAt: new Date(T0 - 11 * 60_000).toISOString() } } } });
+    const d = freshDeps(stale);
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res.sent).toBe(true);
+    expect(d.setPath.mock.calls[0][3].cas).toEqual({
+      path: ['gads', 'confirmed_resident'],
+      contains: { state: 'sending', claimToken: 'dead' },
+    });
+    expect(d.setPath.mock.calls[1][2].retryCount).toBe(3); // lease reclaim preserves history
+  });
+
+  it('the pre-send erased re-check aborts the wire call (ms-window fence)', async () => {
+    const d = freshDeps(rowWithFact(), { sequelize: { query: jest.fn().mockResolvedValue([{ erased: 'true' }]) } });
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res).toEqual({ sent: false, reason: 'erased' });
+    expect(d.dmRequest).not.toHaveBeenCalled();
+  });
+
+  it('a zero-row pending transition after a real upload reports claimLost, never plain success', async () => {
+    const d = freshDeps(rowWithFact());
+    d.setPath = jest.fn()
+      .mockResolvedValueOnce(1) // claim
+      .mockResolvedValueOnce(0); // pending write lost (erasure/lease reclaim)
+    const res = await svc.dispatchOutcome('p-1', 'confirmed_resident', d);
+    expect(res).toEqual({ sent: true, requestId: 'req-1', claimLost: true });
+  });
+
   it('default values survive missing env (plan-contracted S$40/S$500)', async () => {
     delete process.env.GOOGLE_VALUE_QUALIFIED;
     delete process.env.GOOGLE_VALUE_WON;
@@ -306,9 +339,13 @@ describe('classifyStatusBody (M2 reason taxonomy)', () => {
     expect(svc.classifyStatusBody({ requestStatus: 'PARTIAL_SUCCESS', errorInfo: { errorCounts: [{ errorReason: 'duplicate' }] } })).toBe('delivered');
   });
 
-  it('permanent validation/consent/age reasons never retry; unexplained failures do', () => {
+  it('EXACT permanent enums never retry; UNKNOWN reasons default to retry (never substring guesses)', () => {
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'INVALID_ARGUMENT' }] } })).toBe('permanent');
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'EVENT_TOO_OLD' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER' }] } })).toBe('permanent');
+    // unknown enum → retry, even if it CONTAINS a scary substring
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'SOME_FUTURE_AGE_RELATED_ENUM' }] } })).toBe('transient');
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED' })).toBe('transient');
     expect(svc.classifyStatusBody({ requestStatus: 'SUCCESS' })).toBe('delivered');
     expect(svc.classifyStatusBody({ requestStatus: 'PROCESSING' })).toBe('processing');
@@ -326,7 +363,9 @@ describe('workers', () => {
   });
 
   it('resend: dispatches each due row through the claim flow (fresh reload inside)', async () => {
-    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1' }]).mockResolvedValue([]) };
+    // first call = the worker's due-row scan; later calls = the dispatch
+    // pre-send erased re-check
+    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1' }]).mockResolvedValue([{ erased: 'false' }]) };
     const row = prospectFx();
     row.sourceMetadata = { ...row.sourceMetadata, outcomes: { confirmed_resident: '2026-08-18T01:00:00.000Z' } };
     const Prospect = { findByPk: jest.fn().mockResolvedValue(row) };
@@ -425,7 +464,9 @@ describe('reconcileLyfeOutcomes', () => {
     expect(patch.closed_won).toBe('2026-08-05T00:00:00.000Z'); // history-proven
     // the exact PostgREST shapes are pinned (column `type`, metadata to_status)
     expect(fetch.mock.calls[1][0]).toContain('lead_activities?type=eq.status_change');
-    expect(fetch.mock.calls[1][0]).toContain('select=lead_id,created_at,metadata');
+    expect(fetch.mock.calls[1][0]).toContain('metadata->>to_status=in.(qualified,won)');
+    expect(fetch.mock.calls[1][0]).toContain('select=id,lead_id,created_at,metadata');
+    expect(fetch.mock.calls[1][0]).toContain('order=id.asc');
   });
 
   it('existing facts are never re-written; guarded without config', async () => {

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -399,7 +399,7 @@ describe('workers', () => {
     expect(set1.mock.calls[0][3].cas).toEqual({ path: ['gads', 'confirmed_resident'], contains: { state: 'pending', requestId: 'req-1' } });
 
     const set2 = jest.fn().mockResolvedValue(1);
-    const rejected = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'INVALID_ARGUMENT' }] } }), now: nowAt(T0) });
+    const rejected = await svc.settleDueOutcomes({ sequelize: mk(), setPath: set2, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_INVALID_EVENT' }] } }), now: nowAt(T0) });
     expect(rejected.failedPermanent).toBe(1);
     expect(set2.mock.calls[0][2]).toMatchObject({ state: 'failedPermanent', reason: 'ingest_rejected' });
 

--- a/backend/test/unit/googleOfflineConversionsService.test.js
+++ b/backend/test/unit/googleOfflineConversionsService.test.js
@@ -339,16 +339,28 @@ describe('classifyStatusBody (M2 reason taxonomy)', () => {
     expect(svc.classifyStatusBody({ requestStatus: 'PARTIAL_SUCCESS', errorInfo: { errorCounts: [{ errorReason: 'duplicate' }] } })).toBe('delivered');
   });
 
-  it('EXACT permanent enums never retry; UNKNOWN reasons default to retry (never substring guesses)', () => {
-    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'INVALID_ARGUMENT' }] } })).toBe('permanent');
+  it('EXACT ProcessingErrorReason enums (namespaced) never retry; UNKNOWN reasons default to retry', () => {
+    // The API namespaces reasons as PROCESSING_ERROR_REASON_<SUFFIX> —
+    // fixtures use the REAL response shapes (Codex P3-3 #1).
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_EVENT_TOO_OLD' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_DENIED_CONSENT' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED' }] } })).toBe('permanent');
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER' }] } })).toBe('permanent');
+    // bare suffixes still classify (defensive against shape drift)
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'EVENT_TOO_OLD' }] } })).toBe('permanent');
-    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'DESTINATION_ACCOUNT_ENHANCED_CONVERSIONS_TERMS_NOT_SIGNED' }] } })).toBe('permanent');
-    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'OPERATING_ACCOUNT_MISMATCH_FOR_AD_IDENTIFIER' }] } })).toBe('permanent');
-    // unknown enum → retry, even if it CONTAINS a scary substring
-    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'SOME_FUTURE_AGE_RELATED_ENUM' }] } })).toBe('transient');
+    // unknown enum → retry, even when it CONTAINS a scary substring
+    expect(svc.classifyStatusBody({ requestStatus: 'FAILED', errorInfo: { errorCounts: [{ reason: 'PROCESSING_ERROR_REASON_SOME_FUTURE_AGE_ENUM' }] } })).toBe('transient');
     expect(svc.classifyStatusBody({ requestStatus: 'FAILED' })).toBe('transient');
     expect(svc.classifyStatusBody({ requestStatus: 'SUCCESS' })).toBe('delivered');
     expect(svc.classifyStatusBody({ requestStatus: 'PROCESSING' })).toBe('processing');
+  });
+
+  it('a zero-row CAS in the PROCESSING branch is not counted (erasure mid-settle)', async () => {
+    const marker = { state: 'pending', requestId: 'req-1', retryCount: 0, sentAt: new Date(T0 - 40 * 60_000).toISOString(), nextPollAt: new Date(T0 - 60_000).toISOString() };
+    const sequelize = { query: jest.fn().mockResolvedValueOnce([{ id: 'p-1', marker }]).mockResolvedValue([]) };
+    const setPath = jest.fn().mockResolvedValue(0);
+    const res = await svc.settleDueOutcomes({ sequelize, setPath, dmRequestGet: jest.fn().mockResolvedValue({ requestStatus: 'PROCESSING' }), now: nowAt(T0) });
+    expect(res.stillPending).toBe(0);
   });
 });
 

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -109,6 +109,9 @@ function buildMocks() {
   const mockTransaction = {
     commit: jest.fn().mockResolvedValue(undefined),
     rollback: jest.fn().mockResolvedValue(undefined),
+    // The managed-transaction edit path lock-reloads the row (plan
+    // google-ads-signal-levers §4.3).
+    LOCK: { UPDATE: 'UPDATE' },
   };
 
   const sequelize = {
@@ -160,6 +163,13 @@ function buildMocks() {
     logger,
     processLeadOutcome: jest.fn().mockResolvedValue({ dispatched: [] }),
     cancelLiveEntitlementsForProspectTx: jest.fn().mockResolvedValue({ cancelled: 0 }),
+    eventKeysForStatus: jest.fn((status) => {
+      if (status === 'qualified') return ['confirmed_resident'];
+      if (status === 'won') return ['confirmed_resident', 'closed_won'];
+      return [];
+    }),
+    mergeSourceMetadataFirstWins: jest.fn().mockResolvedValue(1),
+    removeSourceMetadataPaths: jest.fn().mockResolvedValue(1),
   };
 }
 
@@ -176,6 +186,11 @@ function makeService(mocks, extra = {}) {
     AppError: mocks.AppError,
     logger: mocks.logger,
     processLeadOutcome: mocks.processLeadOutcome,
+    // Atomic sourceMetadata seams (plan google-ads-signal-levers §4.3) —
+    // stubbed: the real ones run raw SQL against the live DB.
+    eventKeysForStatus: mocks.eventKeysForStatus,
+    mergeSourceMetadataFirstWins: mocks.mergeSourceMetadataFirstWins,
+    removeSourceMetadataPaths: mocks.removeSourceMetadataPaths,
     // PR-2 (CX13): stub the lazy default — the real one reaches the live DB.
     cancelLiveEntitlementsForProspectTx: mocks.cancelLiveEntitlementsForProspectTx,
     ...extra,
@@ -884,7 +899,16 @@ describe('prospectService (unit)', () => {
       expect(updateArg.leadStatus).toBe('won');
       expect(updateArg.conversionDate).toBeInstanceOf(Date);
       expect(updateOpts.where.id).toBe('prospect-1');
-      expect(updateOpts.transaction).toBeUndefined(); // still no tx for a plain status edit
+      // Mapped status transitions now run IN the managed transaction — the
+      // durable outcome facts must be atomic with the status write (plan
+      // google-ads-signal-levers §4.3).
+      expect(updateOpts.transaction).toBe(mocks.mockTransaction);
+      expect(mocks.mergeSourceMetadataFirstWins).toHaveBeenCalledWith(
+        'prospect-1',
+        ['outcomes'],
+        { confirmed_resident: expect.any(String), closed_won: expect.any(String) },
+        { transaction: mocks.mockTransaction }
+      );
       expect(prospect.update).not.toHaveBeenCalled();
       expect(prospect.reload).toHaveBeenCalled();
       expect(mocks.models.Commission.create).not.toHaveBeenCalled();

--- a/src/lib/__tests__/googleAds.test.js
+++ b/src/lib/__tests__/googleAds.test.js
@@ -7,6 +7,8 @@ import {
   toE164Sg,
   setGoogleUserData,
   clearGoogleUserData,
+  captureGclFromUrl,
+  readGcl,
   __resetGoogleAdsStateForTests,
 } from '../googleAds.js';
 
@@ -118,15 +120,19 @@ describe('initGoogleAds', () => {
   it('is idempotent per id — a repeat call neither reconfigures nor re-injects', () => {
     initGoogleAds(CONVERSION_ID);
     initGoogleAds(CONVERSION_ID);
-    expect(gtag).toHaveBeenCalledTimes(1);
+    const configCalls = gtag.mock.calls.filter((c) => c[0] === 'config');
+    expect(configCalls).toHaveLength(1);
+    // each NEW config also fires exactly one gclid-recovery 'get'
+    expect(gtag.mock.calls.filter((c) => c[0] === 'get')).toHaveLength(1);
     expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(1);
   });
 
   it('configures a second id but injects the script only once', () => {
     initGoogleAds(CONVERSION_ID);
     initGoogleAds(OTHER_ID);
-    expect(gtag).toHaveBeenCalledTimes(2);
-    expect(gtag).toHaveBeenLastCalledWith('config', OTHER_ID);
+    const configCalls = gtag.mock.calls.filter((c) => c[0] === 'config');
+    expect(configCalls).toHaveLength(2);
+    expect(configCalls[1]).toEqual(['config', OTHER_ID]);
     expect(document.querySelectorAll(GTAG_SELECTOR)).toHaveLength(1);
   });
 
@@ -341,5 +347,87 @@ describe('setGoogleUserData / clearGoogleUserData', () => {
     expect(
       afterClear.some((c) => c[0] === 'set' && c[1] === 'user_data' && c[2] !== null)
     ).toBe(false);
+  });
+});
+
+describe('captureGclFromUrl / readGcl', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('captures gclid/gbraid/wbraid with a load-bearing capturedAt', () => {
+    const stored = captureGclFromUrl('?gclid=g1&gbraid=b1&utm_source=google');
+    expect(stored.gclid).toBe('g1');
+    expect(stored.gbraid).toBe('b1');
+    expect(stored.wbraid).toBeUndefined();
+    expect(new Date(stored.capturedAt).getTime()).not.toBeNaN();
+    expect(readGcl()).toEqual({ gclid: 'g1', gbraid: 'b1', gclCapturedAt: stored.capturedAt });
+  });
+
+  it('is a no-op without any click id, and last-touch overwrites on a new landing', () => {
+    expect(captureGclFromUrl('?utm_source=google')).toBeNull();
+    expect(readGcl()).toBeNull();
+    captureGclFromUrl('?gclid=old');
+    captureGclFromUrl('?gclid=new');
+    expect(readGcl().gclid).toBe('new');
+  });
+
+  it('shapes keys for direct payload spread (gclCapturedAt, not capturedAt)', () => {
+    captureGclFromUrl('?wbraid=w1');
+    const read = readGcl();
+    expect(read.wbraid).toBe('w1');
+    expect(read.capturedAt).toBeUndefined();
+    expect(read.gclCapturedAt).toBeTruthy();
+  });
+});
+
+describe('initGoogleAds gclid recovery via gtag("get")', () => {
+  let gtag;
+  let getCallback;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    __resetGoogleAdsStateForTests();
+    document.querySelectorAll(GTAG_SELECTOR).forEach((s) => s.remove());
+    getCallback = undefined;
+    gtag = jest_fn_with_get();
+    window.gtag = gtag;
+  });
+
+  afterEach(() => {
+    delete window.gtag;
+    document.querySelectorAll(GTAG_SELECTOR).forEach((s) => s.remove());
+  });
+
+  function jest_fn_with_get() {
+    const fn = vi.fn((...args) => {
+      if (args[0] === 'get') getCallback = args[3];
+    });
+    return fn;
+  }
+
+  it('fills gclid from recovery only when storage has none', () => {
+    initGoogleAds(CONVERSION_ID);
+    expect(typeof getCallback).toBe('function');
+    getCallback('recovered-gclid');
+    expect(readGcl().gclid).toBe('recovered-gclid');
+  });
+
+  it('a stale recovery never overwrites a fresher URL capture', () => {
+    captureGclFromUrl('?gclid=fresh-from-url');
+    initGoogleAds(CONVERSION_ID);
+    getCallback('stale-recovered');
+    expect(readGcl().gclid).toBe('fresh-from-url');
+  });
+
+  it('recovery preserves URL-captured gbraid/wbraid when filling gclid', () => {
+    captureGclFromUrl('?gbraid=b-url');
+    initGoogleAds(CONVERSION_ID);
+    getCallback('recovered');
+    expect(readGcl()).toMatchObject({ gclid: 'recovered', gbraid: 'b-url' });
+  });
+
+  it('an empty recovery result writes nothing', () => {
+    initGoogleAds(CONVERSION_ID);
+    getCallback(undefined);
+    expect(readGcl()).toBeNull();
   });
 });

--- a/src/lib/googleAds.js
+++ b/src/lib/googleAds.js
@@ -111,10 +111,12 @@ export function initGoogleAds(conversionId) {
         const existing = sessionStorage.getItem(GCL_STORAGE_KEY);
         if (existing && JSON.parse(existing)?.gclid) return;
         const prior = existing ? JSON.parse(existing) : {};
-        sessionStorage.setItem(
-          GCL_STORAGE_KEY,
-          JSON.stringify({ ...prior, gclid: recovered, capturedAt: new Date().toISOString() })
-        );
+        // NO capturedAt for a recovered id: the tag saw this click on an
+        // EARLIER landing whose time we don't know — stamping "now" would
+        // reset the offline-conversion age window (the server falls back to
+        // the signup timestamp instead, which is strictly older-or-equal).
+        const { capturedAt: _prior, ...rest } = prior;
+        sessionStorage.setItem(GCL_STORAGE_KEY, JSON.stringify({ ...rest, gclid: recovered }));
       } catch {
         /* storage unavailable — recovery is best-effort */
       }

--- a/src/lib/googleAds.js
+++ b/src/lib/googleAds.js
@@ -47,6 +47,7 @@ import { isTrackableLeadCapture } from './pixelSuppression';
 
 const configuredIds = new Set();
 let sdkInjected = false;
+const GCL_STORAGE_KEY = '_mktr_gcl';
 
 /**
  * `conversionId` is the CALLER-RESOLVED id for this campaign (see lib/pixelIds.js)
@@ -95,6 +96,32 @@ export function initGoogleAds(conversionId) {
 
   window.gtag('config', conversionId);
   configuredIds.add(conversionId);
+
+  // Click-id recovery (plan google-ads-signal-levers §4.1): the documented
+  // gtag('get') API can surface a gclid the tag saw on an EARLIER landing
+  // (its own first-party state) when the current URL carries no param. Runs
+  // here because gtag('get') is an async callback API and only answers after
+  // config. The callback RE-CHECKS storage before writing: a stale recovery
+  // must never overwrite a fresher URL capture. gclid only — gbraid/wbraid
+  // are URL-param capture only.
+  try {
+    window.gtag('get', conversionId, 'gclid', (recovered) => {
+      if (!recovered) return;
+      try {
+        const existing = sessionStorage.getItem(GCL_STORAGE_KEY);
+        if (existing && JSON.parse(existing)?.gclid) return;
+        const prior = existing ? JSON.parse(existing) : {};
+        sessionStorage.setItem(
+          GCL_STORAGE_KEY,
+          JSON.stringify({ ...prior, gclid: recovered, capturedAt: new Date().toISOString() })
+        );
+      } catch {
+        /* storage unavailable — recovery is best-effort */
+      }
+    });
+  } catch {
+    /* older gtag without 'get' — recovery is best-effort */
+  }
 }
 
 /**
@@ -183,6 +210,52 @@ export function clearGoogleUserData() {
   if (import.meta.env.VITE_GOOGLE_ADS_EC_ENABLED !== 'true') return;
   if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
   window.gtag('set', 'user_data', null);
+}
+
+/**
+ * Capture Google click ids (gclid / gbraid / wbraid) from the landing URL
+ * into sessionStorage, mirroring the `_mktr_fbc` pattern. capturedAt is
+ * LOAD-BEARING: the backend's offline-conversion age guard measures from the
+ * click (capture happens on the landing that carried it), not from the
+ * outcome. Last-touch: any landing carrying at least one id overwrites the
+ * stored set. Called from the SAME unconditional early capture effects as
+ * captureFbcFromUrl — independent of the firedGoogle view guard, which may
+ * already be set on a later reload.
+ */
+export function captureGclFromUrl(search) {
+  if (!search || typeof sessionStorage === 'undefined') return null;
+  try {
+    const params = new URLSearchParams(search);
+    const ids = {};
+    for (const key of ['gclid', 'gbraid', 'wbraid']) {
+      const value = params.get(key);
+      if (value) ids[key] = value;
+    }
+    if (Object.keys(ids).length === 0) return null;
+    const stored = { ...ids, capturedAt: new Date().toISOString() };
+    sessionStorage.setItem(GCL_STORAGE_KEY, JSON.stringify(stored));
+    return stored;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the captured click ids for the submit payload. Returns
+ * `{ gclid?, gbraid?, wbraid?, gclCapturedAt }` or null — keys shaped for
+ * spreading straight into the /prospects body beside ttclid.
+ */
+export function readGcl() {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(GCL_STORAGE_KEY);
+    if (!raw) return null;
+    const { capturedAt, ...ids } = JSON.parse(raw);
+    if (Object.keys(ids).length === 0) return null;
+    return { ...ids, ...(capturedAt ? { gclCapturedAt: capturedAt } : {}) };
+  } catch {
+    return null;
+  }
 }
 
 /** Test seam — resets the module-level idempotency state. */

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -438,10 +438,15 @@ export default function LeadCapture() {
           // marketplace flow passes the 8-digit local number — toE164Sg
           // inside setGoogleUserData normalizes both.
           setGoogleUserData({ email: formData.email, phone: formData.phone });
-          trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
-            transactionId: leadEventIdRef.current,
-          });
-          clearGoogleUserData();
+          try {
+            trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
+              transactionId: leadEventIdRef.current,
+            });
+          } finally {
+            // finally: a throwing tag call must never leave page-global PII
+            // attached to later SPA events.
+            clearGoogleUserData();
+          }
         }
         setSubmitted(true);
         setShareOpen(true);

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -48,6 +48,7 @@ import {
 import {
   shouldTrackGoogle, initGoogleAds, trackGoogleLead,
   setGoogleUserData, clearGoogleUserData,
+  captureGclFromUrl, readGcl,
 } from '../lib/googleAds';
 import { trackFunnelEvent } from '../lib/pixelCustom';
 
@@ -99,6 +100,7 @@ export default function LeadCapture() {
     if (!registrationEventIdRef.current) registrationEventIdRef.current = generateEventId();
     captureFbcFromUrl(location.search);
     captureTtclidFromUrl(location.search);
+    captureGclFromUrl(location.search);
     // Capture UTM params from the landing URL into sessionStorage (last-touch,
     // mirrors the _mktr_fbc pattern) — forwarded into the prospect submit and
     // stored server-side in sourceMetadata.utm.
@@ -375,6 +377,7 @@ export default function LeadCapture() {
         // TikTok attribution identifiers (server-side Events API consumes these in
         // Phase 6). Captured from the landing URL / pixel cookie.
         ttclid: readTtclid() || undefined,
+        ...(readGcl() || {}),
         ttp: readTtp() || undefined,
       };
 

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -423,10 +423,15 @@ export default function MarketplaceFlow() {
           // page-global, so clear right after the conversion queues — later
           // SPA tag events must not inherit the submitter's PII.
           setGoogleUserData({ email: form.email, phone: form.phone });
-          trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
-            transactionId: leadEventIdRef.current,
-          });
-          clearGoogleUserData();
+          try {
+            trackGoogleLead(googleId, resolveGoogleAdsLeadLabel(campaign), {
+              transactionId: leadEventIdRef.current,
+            });
+          } finally {
+            // finally: a throwing tag call must never leave page-global PII
+            // attached to later SPA events.
+            clearGoogleUserData();
+          }
         }
         if (isDraw) trackCustom('draw_entry_confirmed');
         setResult({

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -23,6 +23,7 @@ import {
 import {
   shouldTrackGoogle, initGoogleAds, trackGoogleLead,
   setGoogleUserData, clearGoogleUserData,
+  captureGclFromUrl, readGcl,
 } from '@/lib/googleAds';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 import {
@@ -134,6 +135,7 @@ export default function MarketplaceFlow() {
     if (!leadEventIdRef.current) leadEventIdRef.current = generateEventId();
     captureFbcFromUrl(window.location.search);
     captureTtclidFromUrl(window.location.search);
+    captureGclFromUrl(window.location.search);
     captureUtmsFromUrl(window.location.search);
   }, []);
 
@@ -387,6 +389,7 @@ export default function MarketplaceFlow() {
         ...(readUtms() || {}),
         ttclid: readTtclid() || undefined,
         ttp: readTtp() || undefined,
+        ...(readGcl() || {}),
         ...(Object.keys(marketplaceMeta).length ? { marketplace: marketplaceMeta } : {}),
       };
       const payload = Object.fromEntries(

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -10,7 +10,7 @@ import { shouldTrack, initPixel, ensureFbp, trackEvent, captureFbcFromUrl, captu
 import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtclidFromUrl } from '@/lib/tiktokPixel';
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
 import { resolveMetaPixelId, resolveTikTokPixelId, resolveGoogleAdsConversionId } from '@/lib/pixelIds';
-import { shouldTrackGoogle, initGoogleAds } from '@/lib/googleAds';
+import { shouldTrackGoogle, initGoogleAds, captureGclFromUrl } from '@/lib/googleAds';
 
 /**
  * Offer detail (/offers/:slug) — the FIRST public content surface for
@@ -45,6 +45,7 @@ export default function MarketplaceOffer() {
   useEffect(() => {
     captureFbcFromUrl(window.location.search);
     captureTtclidFromUrl(window.location.search);
+    captureGclFromUrl(window.location.search);
     captureUtmsFromUrl(window.location.search);
   }, [slug]);
 


### PR DESCRIPTION
## Why

Phase 3 of `docs/plans/google-ads-signal-levers.md` (v8, 8-round Codex-passed plan) — the "CAPI parity" arc. Google currently optimizes on phone-verified leads only; this teaches it which leads become **ConfirmedResident** and **ClosedWon**, via Data Manager `events:ingest`.

## What

**Frontend (capture, §4.1):** `captureGclFromUrl`/`readGcl` (`_mktr_gcl`, `capturedAt` load-bearing) in the three surfaces' unconditional early capture effects; async-correct `gtag('get')` gclid recovery inside `initGoogleAds` (re-checks storage — stale recovery never overwrites a fresh URL capture); payload spread beside `ttclid`; Joi whitelist; persisted as `sourceMetadata.gcl`.

**`prospectJsonPatch` (§4.3):** one-statement, ancestor-ensured, erased-guarded, CAS-capable writes on the nullable JSON column (`mergeFirstWins` = `patch || existing` so history never rewrites; `setPath`; `removePaths` via `#-`). Semantics **proven on real Postgres** (9 integration tests: NULL COALESCE, missing parents, first-wins direction, CAS races, sibling preservation, concurrent writers). **All four legacy whole-object writers converted** (Meta lead-outcome markers, redemption's nested entitlement map, admin phone-edit verification strip, Retell recording cache) — any surviving read-spread-save site could silently delete the new keys.

**Admin edits:** one managed transaction for demographics/phone/mapped-status edits with **lock-reload via minimal `findByPk`** (reloading the eager instance trips `FOR UPDATE … nullable side of an outer join`) + in-txn erased re-check (410), atomic verification strip, and **in-txn write-once outcome facts**.

**`processLeadOutcome` (all three inbound paths):** canonical `occurred_at` (validated body → **signed webhook timestamp** passed explicitly by the controller → receipt), durable facts written FIRST (one first-wins merge for all keys — a `won` lands both with one timestamp; a replay never rewrites), then sequential isolated Google dispatch per key (fresh markers only).

**`googleOfflineConversionsService`:** Google-specific gate (call_bot = data-quality skip; **Meta-Lead-Ads NOT skipped** — upload-all; missing action id = per-key preflight, no row mutation), click-anchored age guard, single-event envelopes (`eventSource: OTHER`, RFC3339, `transactionId` dedup, values, ALL captured ad identifiers, `userData`+`HEX`+`CONSENT_GRANTED` strictly consent-conditional — click-only events omit the consent block), and the full `gads` marker state machine (pending/delivered/retryWait/failedPermanent/skippedPermanent, retryCount through pending, CAS transitions, duplicate-transaction = delivered, pending timeout).

**Workers (bootstrap, 10m, single-flight):** re-send from facts + settle due pendings on Google's real 30min→24h diagnostics window. **Lyfe outcome reconciler (6h):** pg_net discards responses, so durability comes from reading Lyfe's Supabase directly (agent-sync env) — direct evidence for `qualified`/`won`, `status_change`-history fill for every still-missing key (won→qualified regressions recover `closed_won`; `proposed` without a qualifying transition gets **nothing** — no false CR), and pre-arc outcomes backfill.

## Safe to merge now

**Ships dark**: `GOOGLE_ADS_UPLOADS_ENABLED` unset everywhere; workers/reconciler don't register; capture+facts writes are inert additions. The four writer conversions are behavior-preserving (proven by their existing suites + new interleaving tests).

## Tested

- 2423 backend unit (146 suites; 38 new across the outcomes service, reconciler, patch-SQL, capture)
- 605 green across the affected DB-backed suites on real Postgres (erasure 29, jsonPatch 9, lead/redemption/prospect/retell/external)
- 1995 frontend green; typecheck (checkJs) + eslint clean; **no migrations**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcFxTJ4vuWC5XJ8mavUTk