### PR TITLE
fix(funnel): profile-questions block drops its header when any question is required

### DIFF
--- a/src/components/campaigns/CampaignSignupForm.jsx
+++ b/src/components/campaigns/CampaignSignupForm.jsx
@@ -1006,14 +1006,18 @@ export default function CampaignSignupForm({
             Studio click-to-edit jump target; inert on live pages. */}
         {Array.isArray(profileQuestions?.questionIds) && profileQuestions.questionIds.length > 0 && (
           <div data-se="profileQuestions" style={{ marginTop: 18 }}>
-            <div style={{
-              fontSize: 12, color: TOKENS.muted, marginBottom: 10,
-              fontFamily: 'Albert Sans, system-ui, sans-serif',
-            }}>
-              {(profileQuestions.requiredIds || []).length === 0
-                ? 'Optional — helps us serve you better'
-                : 'Helps us serve you better'}
-            </div>
+            {/* The reassurance header renders ONLY when every question is
+                optional (its original design intent). With any required
+                question the block opens straight on the first prompt —
+                owner call, 2026-08-18. */}
+            {(profileQuestions.requiredIds || []).length === 0 && (
+              <div style={{
+                fontSize: 12, color: TOKENS.muted, marginBottom: 10,
+                fontFamily: 'Albert Sans, system-ui, sans-serif',
+              }}>
+                Optional — helps us serve you better
+              </div>
+            )}
             {profileQuestions.questionIds.map((qid) => {
               const q = resolveQuestion(qid, profileQuestions.custom);
               if (!q) return null;

--- a/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
+++ b/src/components/campaigns/__tests__/CampaignSignupForm.test.jsx
@@ -676,12 +676,12 @@ describe('CampaignSignupForm — profile question controls (required + showZh)',
     expect(document.querySelector('[data-se="profileQuestions"]').textContent).toContain('您偏好哪种语言');
   });
 
-  it('required questions get an asterisk and the header drops "Optional"', () => {
+  it('required questions get an asterisk and NO header at all (owner call, 2026-08-18)', () => {
     renderForm({ profileQuestions: { enabled: true, questionIds: ['language', 'pets'], requiredIds: ['language'], showZh: true } });
     const block = document.querySelector('[data-se="profileQuestions"]');
     expect(block.textContent).toContain('*');
-    expect(block.textContent).toContain('Helps us serve you better');
-    expect(block.textContent).not.toContain('Optional — helps us serve you better');
+    expect(block.textContent).not.toContain('Helps us serve you better');
+    expect(block.textContent).not.toContain('Optional');
   });
 
   it('all-optional keeps the Optional header and no asterisk', () => {


### PR DESCRIPTION
Owner call (2026-08-18, testing the live custom-questions feature): the "Helps us serve you better" line should not render above required questions. The reassurance header now renders ONLY in the all-optional case it was designed for ("Optional — helps us serve you better"); with any required question the block opens straight on the first prompt.

One renderer conditional + the matching test flip (63/63 CampaignSignupForm tests green, eslint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h6CXFYoeyPNmF3EwE9oZN