### PR TITLE
feat(ads): AdRoll retargeting pixel on the customer surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,17 @@ VITE_GOOGLE_ADS_DEV_MODE=
 # on for the conversion action. Any other value ships dark.
 VITE_GOOGLE_ADS_EC_ENABLED=
 
+# AdRoll retargeting pixel — BOTH ids come off the Manual connection screen
+# (AdRoll → Getting Started → Pixel). The loader is gated on both being set,
+# so a build with only one stays dark. Customer brand only: set these on the
+# redeem-frontend service and leave them EMPTY on mktr-platform (operator UI)
+# and redeem-ops-frontend (staff surface).
+VITE_ADROLL_ADV_ID=
+VITE_ADROLL_PIX_ID=
+# AdRoll has no test-event-code equivalent, so dev firing needs an explicit
+# opt-in. Any non-empty value enables it. Staging only; empty in production.
+VITE_ADROLL_DEV_MODE=
+
 # -----------------------------------------------------------------------------
 # Per-build page chrome & SEO (substituted into index.html)
 # -----------------------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -66,6 +66,33 @@
         window.gtag('js', new Date());
       })();
     </script>
+
+    <!-- AdRoll pixel base stub (gated on VITE_ADROLL_ADV_ID + VITE_ADROLL_PIX_ID).
+         Sets the adroll_* globals roundtrip.js reads at load time and defines the
+         `adroll` command queue, but does NOT inject roundtrip.js and does NOT call
+         adroll.track('pageView') — React (adroll.initAdRoll) does both, only on
+         public customer surfaces, so the SDK never loads on admin/ops/preview
+         pages (same contract as the ttq and gtag stubs above). -->
+    <script>
+      (function (w) {
+        var ADV_ID = '%VITE_ADROLL_ADV_ID%';
+        var PIX_ID = '%VITE_ADROLL_PIX_ID%';
+        if (!ADV_ID || ADV_ID.charAt(0) === '%') return;
+        if (!PIX_ID || PIX_ID.charAt(0) === '%') return;
+        w.adroll_adv_id = ADV_ID;
+        w.adroll_pix_id = PIX_ID;
+        w.adroll_version = '2.0';
+        w.adroll_tag_source = 'manual';
+        w.__adroll_loaded = true;
+        w.adroll = w.adroll || [];
+        w.adroll.f = ['setProperties', 'identify', 'track', 'identify_email', 'get_cookie'];
+        for (var a = 0; a < w.adroll.f.length; a++) {
+          w.adroll[w.adroll.f[a]] = w.adroll[w.adroll.f[a]] || (function (n) {
+            return function () { w.adroll.push([n, arguments]) };
+          })(w.adroll.f[a]);
+        }
+      })(window);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/AdRollRouteTracker.jsx
+++ b/src/components/AdRollRouteTracker.jsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import {
+  initAdRoll,
+  isAdRollCampaignSurface,
+  shouldTrackAdRoll,
+  trackAdRollPageView,
+} from '@/lib/adroll';
+
+/**
+ * Fires AdRoll's pageView on the public browse surfaces as the SPA navigates.
+ *
+ * Renders nothing and mounts once inside the router (see pages/index.jsx). The
+ * campaign funnel pages are deliberately skipped here: their gate needs the
+ * loaded `campaign` to apply the test-data exclusion, so each of LeadCapture /
+ * MarketplaceOffer / MarketplaceFlow fires its own pageView alongside the Meta,
+ * TikTok and Google view events.
+ *
+ * Everything not on adroll.js's allow-list — admin, redeem-ops, auth, and the
+ * token-bearing reward/callback links — never reaches initAdRoll at all.
+ */
+export default function AdRollRouteTracker() {
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    if (isAdRollCampaignSurface(pathname)) return;
+    if (!shouldTrackAdRoll({ pathname, search })) return;
+    initAdRoll();
+    trackAdRollPageView();
+  }, [pathname, search]);
+
+  return null;
+}

--- a/src/components/__tests__/AdRollRouteTracker.test.jsx
+++ b/src/components/__tests__/AdRollRouteTracker.test.jsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import AdRollRouteTracker from '../AdRollRouteTracker';
+import { __resetAdRollStateForTests } from '@/lib/adroll';
+
+const ADV_ID = 'XWJKUPH2LRC4LG4ZVFR4MS';
+const PIX_ID = 'Q5WESFHM2JDHPIDHKY3DBT';
+const ROUNDTRIP_SELECTOR = 'script[src*="s.adroll.com/j/"]';
+
+function installStub() {
+  window.adroll_adv_id = ADV_ID;
+  window.adroll_pix_id = PIX_ID;
+  window.adroll = [];
+  window.adroll.track = vi.fn();
+  return window.adroll.track;
+}
+
+/** Navigates once on mount so a client-side route change can be asserted. */
+function NavigateOnMount({ to }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(to);
+  }, [navigate, to]);
+  return null;
+}
+
+function renderAt(initialPath, extra = null) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AdRollRouteTracker />
+      <Routes>
+        <Route path="*" element={extra} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('AdRollRouteTracker', () => {
+  let track;
+
+  beforeEach(() => {
+    __resetAdRollStateForTests();
+    document.querySelectorAll(ROUNDTRIP_SELECTOR).forEach((s) => s.remove());
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_ADROLL_ADV_ID', ADV_ID);
+    vi.stubEnv('VITE_ADROLL_PIX_ID', PIX_ID);
+    vi.stubEnv('PROD', true);
+    vi.stubEnv('DEV', false);
+    track = installStub();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete window.adroll;
+    delete window.adroll_adv_id;
+    delete window.adroll_pix_id;
+    document.querySelectorAll(ROUNDTRIP_SELECTOR).forEach((s) => s.remove());
+  });
+
+  it('injects the SDK and fires a pageView on a browse surface', () => {
+    renderAt('/explore');
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(1);
+    expect(track).toHaveBeenCalledWith('pageView');
+  });
+
+  it('fires again on a client-side route change (the SPA has no full reloads)', () => {
+    renderAt('/explore', <NavigateOnMount to="/how-it-works" />);
+    expect(track).toHaveBeenCalledTimes(2);
+    // Still one script tag — only the pageView repeats.
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(1);
+  });
+
+  it('stays out of the campaign funnel — those pages fire it themselves', () => {
+    renderAt('/offers/tokyo-draw');
+    expect(track).not.toHaveBeenCalled();
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(0);
+  });
+
+  it('never fires on internal or token-bearing routes', () => {
+    for (const path of ['/AdminDashboard', '/redeem-ops/partners', '/r/sometoken', '/callback?t=x']) {
+      renderAt(path);
+    }
+    expect(track).not.toHaveBeenCalled();
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(0);
+  });
+
+  it('stays dark when the build carries no AdRoll ids', () => {
+    vi.stubEnv('VITE_ADROLL_ADV_ID', '');
+    vi.stubEnv('VITE_ADROLL_PIX_ID', '');
+    renderAt('/explore');
+    expect(track).not.toHaveBeenCalled();
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(0);
+  });
+});

--- a/src/lib/__tests__/adroll.test.js
+++ b/src/lib/__tests__/adroll.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  shouldTrackAdRoll,
+  isAdRollSurface,
+  isAdRollCampaignSurface,
+  resolveAdRollIds,
+  initAdRoll,
+  trackAdRollPageView,
+  __resetAdRollStateForTests,
+} from '../adroll.js';
+
+const ADV_ID = 'XWJKUPH2LRC4LG4ZVFR4MS';
+const PIX_ID = 'Q5WESFHM2JDHPIDHKY3DBT';
+
+const ROUNDTRIP_SELECTOR = 'script[src*="s.adroll.com/j/"]';
+
+function stubProdWithIds() {
+  vi.stubEnv('VITE_ADROLL_ADV_ID', ADV_ID);
+  vi.stubEnv('VITE_ADROLL_PIX_ID', PIX_ID);
+  vi.stubEnv('MODE', 'production');
+  vi.stubEnv('PROD', true);
+  vi.stubEnv('DEV', false);
+}
+
+/** Mirrors the index.html stub: queue + globals, no SDK, no pageView. */
+function installStub() {
+  window.adroll_adv_id = ADV_ID;
+  window.adroll_pix_id = PIX_ID;
+  window.adroll = [];
+  window.adroll.track = vi.fn();
+  return window.adroll.track;
+}
+
+function removeStub() {
+  delete window.adroll;
+  delete window.adroll_adv_id;
+  delete window.adroll_pix_id;
+}
+
+describe('shouldTrackAdRoll', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    stubProdWithIds();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true on the campaign funnel surfaces', () => {
+    expect(shouldTrackAdRoll({ pathname: '/LeadCapture', search: '' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/offers/tokyo-draw' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/flow/tokyo-draw' })).toBe(true);
+  });
+
+  it('returns true on the public browse surfaces the other pixels skip', () => {
+    expect(shouldTrackAdRoll({ pathname: '/' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/explore' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/c/travel' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/winners' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/how-it-works' })).toBe(true);
+    expect(shouldTrackAdRoll({ pathname: '/legal/terms' })).toBe(true);
+  });
+
+  it('returns false when either id is missing — both halves are required', () => {
+    vi.stubEnv('VITE_ADROLL_ADV_ID', '');
+    expect(shouldTrackAdRoll({ pathname: '/explore' })).toBe(false);
+    stubProdWithIds();
+    vi.stubEnv('VITE_ADROLL_PIX_ID', '');
+    expect(shouldTrackAdRoll({ pathname: '/explore' })).toBe(false);
+  });
+
+  it('returns false on /preview, /LeadCapture/demo and /p/:slug (shared suppression)', () => {
+    expect(shouldTrackAdRoll({ pathname: '/preview' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/preview/atelier' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/LeadCapture/demo' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/p/some-slug' })).toBe(false);
+  });
+
+  it('returns false when ?preview=true is present', () => {
+    expect(shouldTrackAdRoll({ pathname: '/LeadCapture', search: '?preview=true' })).toBe(false);
+  });
+
+  it('returns false when campaign.is_test_data is true', () => {
+    expect(shouldTrackAdRoll({ pathname: '/offers/x', campaign: { is_test_data: true } })).toBe(false);
+  });
+
+  it('never fires on token-bearing routes — those URLs must not reach AdRoll', () => {
+    expect(shouldTrackAdRoll({ pathname: '/r/abc123token' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/callback', search: '?t=abc123token' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/t/some-slug' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/share/some-slug' })).toBe(false);
+  });
+
+  it('never fires on internal surfaces (allow-list keeps new admin routes dark)', () => {
+    expect(shouldTrackAdRoll({ pathname: '/AdminDashboard' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/admin/campaigns/123/studio' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/redeem-ops/partners' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/CustomerLogin' })).toBe(false);
+    expect(shouldTrackAdRoll({ pathname: '/AdminLogin' })).toBe(false);
+  });
+
+  it('returns false in dev without VITE_ADROLL_DEV_MODE, true with it', () => {
+    vi.stubEnv('PROD', false);
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_ADROLL_DEV_MODE', '');
+    expect(shouldTrackAdRoll({ pathname: '/explore' })).toBe(false);
+    vi.stubEnv('VITE_ADROLL_DEV_MODE', '1');
+    expect(shouldTrackAdRoll({ pathname: '/explore' })).toBe(true);
+  });
+
+  it('handles a missing pathname gracefully', () => {
+    expect(shouldTrackAdRoll({})).toBe(false);
+  });
+
+  it('resolveAdRollIds reads both build ids', () => {
+    expect(resolveAdRollIds()).toEqual({ advId: ADV_ID, pixId: PIX_ID });
+  });
+});
+
+describe('surface classification', () => {
+  it('separates the campaign funnel from the browse pages', () => {
+    expect(isAdRollCampaignSurface('/LeadCapture')).toBe(true);
+    expect(isAdRollCampaignSurface('/offers/tokyo-draw')).toBe(true);
+    expect(isAdRollCampaignSurface('/flow/tokyo-draw')).toBe(true);
+    // Browse pages are on the allow-list but NOT campaign surfaces — the route
+    // tracker owns those, the pages own the funnel.
+    expect(isAdRollCampaignSurface('/explore')).toBe(false);
+    expect(isAdRollSurface('/explore')).toBe(true);
+  });
+
+  it('requires a slug segment on the marketplace patterns', () => {
+    expect(isAdRollSurface('/offers')).toBe(false);
+    expect(isAdRollSurface('/flow')).toBe(false);
+  });
+});
+
+describe('initAdRoll', () => {
+  let track;
+
+  beforeEach(() => {
+    __resetAdRollStateForTests();
+    document.querySelectorAll(ROUNDTRIP_SELECTOR).forEach((s) => s.remove());
+    track = installStub();
+  });
+
+  afterEach(() => {
+    removeStub();
+    document.querySelectorAll(ROUNDTRIP_SELECTOR).forEach((s) => s.remove());
+  });
+
+  it('injects roundtrip.js for the advertisable id', () => {
+    initAdRoll();
+    const scripts = document.querySelectorAll(ROUNDTRIP_SELECTOR);
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0].src).toContain(ADV_ID);
+    expect(scripts[0].async).toBe(true);
+  });
+
+  it('does not fire a pageView on its own', () => {
+    initAdRoll();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — repeat calls inject once', () => {
+    initAdRoll();
+    initAdRoll();
+    initAdRoll();
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(1);
+  });
+
+  it('no-ops when the index.html stub is absent (ids unset at build)', () => {
+    removeStub();
+    expect(() => initAdRoll()).not.toThrow();
+    expect(document.querySelectorAll(ROUNDTRIP_SELECTOR)).toHaveLength(0);
+  });
+});
+
+describe('trackAdRollPageView', () => {
+  let track;
+
+  beforeEach(() => {
+    __resetAdRollStateForTests();
+    track = installStub();
+  });
+
+  afterEach(() => {
+    removeStub();
+    document.querySelectorAll(ROUNDTRIP_SELECTOR).forEach((s) => s.remove());
+  });
+
+  it('pushes a pageView through the queue', () => {
+    trackAdRollPageView();
+    expect(track).toHaveBeenCalledWith('pageView');
+  });
+
+  it('fires once per call — no session guard, unlike ViewContent', () => {
+    trackAdRollPageView();
+    trackAdRollPageView();
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+
+  it('no-ops when the stub is absent', () => {
+    removeStub();
+    expect(() => trackAdRollPageView()).not.toThrow();
+  });
+});

--- a/src/lib/adroll.js
+++ b/src/lib/adroll.js
@@ -1,0 +1,154 @@
+/**
+ * AdRoll pixel client utilities — the fourth network alongside metaPixel.js /
+ * tiktokPixel.js / googleAds.js, and the only one whose job is RETARGETING
+ * rather than conversion measurement. That difference drives every design
+ * decision in this file:
+ *
+ *   1. WIDER SURFACE. Meta/TikTok/Google fire on the campaign funnel only
+ *      (`/LeadCapture`, `/offers/:slug`, `/flow/:slug`) because a conversion is
+ *      attributed to a campaign. AdRoll's asset is the audience pool, so it also
+ *      fires on the customer-brand browse and marketing pages — someone who
+ *      browsed `/explore` and left is exactly who retargeting exists to reach.
+ *   2. NO EVENT-ID DEDUP. There is no server-side counterpart to deduplicate
+ *      against (no CAPI/Events-API equivalent wired), so pageView carries no
+ *      shared event id and takes no once-per-session guard — every qualifying
+ *      view is a legitimate audience touch.
+ *   3. ALLOW-LIST, NOT DENY-LIST. isAdRollSurface enumerates the public
+ *      customer routes instead of excluding the internal ones, so a new admin,
+ *      ops or auth route is untagged by default rather than untagged only if
+ *      somebody remembers to add it.
+ *
+ * DELIBERATELY ABSENT from the allow-list, beyond the usual admin/ops/auth
+ * routes: `/r/:token` (reward claim), `/callback?t=…` (screening opt-in),
+ * `/t/:slug` and `/share/:slug`. Each carries a bearer token in the URL, and
+ * roundtrip.js reports the full location to AdRoll — tagging those pages would
+ * hand a third-party ad network a working credential for a customer's reward.
+ * Do not add them.
+ *
+ * The `adroll` queue + adroll_* globals live in index.html, gated on
+ * VITE_ADROLL_ADV_ID + VITE_ADROLL_PIX_ID, and define the queue ONLY — the stub
+ * neither injects roundtrip.js nor fires a pageView. initAdRoll() does the
+ * injection and is invoked only after shouldTrackAdRoll passes, so the SDK never
+ * loads on admin/ops/preview surfaces (same contract as tiktokPixel's deferred
+ * `ttq.load()` and googleAds' deferred `gtag('config')`).
+ *
+ * Suppression: shares pixelSuppression's exclusion half (isSuppressedSurface) —
+ * preview routes, the demo page, `?preview=true` and test-data campaigns are out
+ * on identical terms to the other three networks.
+ *
+ * All functions are SSR-safe (defensive against missing window/document).
+ */
+import { isSuppressedSurface } from './pixelSuppression';
+
+let sdkInjected = false;
+
+/** Both halves are required — roundtrip.js is addressed by the advertisable id. */
+export function resolveAdRollIds() {
+  return {
+    advId: import.meta.env.VITE_ADROLL_ADV_ID || '',
+    pixId: import.meta.env.VITE_ADROLL_PIX_ID || '',
+  };
+}
+
+/**
+ * The campaign funnel pages. Split out because these are the surfaces whose
+ * `campaign` object decides the test-data exclusion: the route-level tracker
+ * skips them and each page fires its own pageView once the campaign has loaded
+ * and proved itself real. Everywhere else there is no campaign to wait for.
+ */
+export function isAdRollCampaignSurface(pathname) {
+  const path = (pathname || '').toLowerCase();
+  if (path === '/leadcapture') return true;
+  if (/^\/offers\/[a-z0-9-]+$/.test(path)) return true;
+  if (/^\/flow\/[a-z0-9-]+$/.test(path)) return true;
+  return false;
+}
+
+/** Public browse + marketing pages on the customer brand (redeem.sg). */
+const BROWSE_SURFACES = new Set([
+  '/',
+  '/explore',
+  '/dsa',
+  '/winners',
+  '/how-it-works',
+  '/businesses',
+  '/about',
+  '/contact',
+  '/personal-data-policy',
+  '/leads/privacy',
+]);
+
+const BROWSE_PATTERNS = [
+  /^\/c\/[^/]+$/, // category browse
+  /^\/legal\/[^/]+$/, // marketplace legal docs
+];
+
+/** Every route AdRoll is allowed on: campaign funnel ∪ public browse. */
+export function isAdRollSurface(pathname) {
+  const path = (pathname || '').toLowerCase();
+  if (isAdRollCampaignSurface(path)) return true;
+  if (BROWSE_SURFACES.has(path)) return true;
+  return BROWSE_PATTERNS.some((re) => re.test(path));
+}
+
+/**
+ * `campaign` is only meaningful on the funnel surfaces; pass it there so a
+ * test-data campaign stays out of the audience pool. Browse pages call without
+ * one, which is why the gate must tolerate its absence.
+ */
+export function shouldTrackAdRoll({ campaign, pathname, search } = {}) {
+  const { advId, pixId } = resolveAdRollIds();
+  if (!advId || !pixId) return false;
+  // AdRoll has no test-event-code equivalent, so dev firing needs an explicit
+  // opt-in — same shape as VITE_GOOGLE_ADS_DEV_MODE. Keeps localhost traffic
+  // out of the production audience.
+  if (!import.meta.env.PROD && !import.meta.env.VITE_ADROLL_DEV_MODE) return false;
+  if (isSuppressedSurface({ campaign, pathname, search })) return false;
+  return isAdRollSurface(pathname);
+}
+
+/**
+ * Inject roundtrip.js. Idempotent — the script tag goes in at most once per
+ * page, and the queue defined in index.html buffers any track() call made
+ * before it finishes loading.
+ *
+ * Only called after shouldTrackAdRoll passes, so the SDK never loads on
+ * admin/ops/preview pages.
+ */
+export function initAdRoll() {
+  if (sdkInjected) return;
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  // The index.html stub is what defines the queue; if it did not run, the build
+  // has no AdRoll ids and there is nothing to load.
+  if (!window.adroll || typeof window.adroll.track !== 'function') return;
+  const advId = window.adroll_adv_id;
+  if (!advId) return;
+
+  try {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://s.adroll.com/j/${encodeURIComponent(advId)}/roundtrip.js`;
+    const first = document.getElementsByTagName('script')[0];
+    if (first && first.parentNode) first.parentNode.insertBefore(script, first);
+    else document.head.appendChild(script);
+    sdkInjected = true;
+  } catch {
+    /* injection failed — leave sdkInjected false so a later route can retry */
+  }
+}
+
+/**
+ * Fire AdRoll's pageView — the single event that grows the retargeting
+ * audience. Safe to call on every route change; the SPA has no full page loads
+ * for roundtrip.js to pick up on its own.
+ */
+export function trackAdRollPageView() {
+  if (typeof window === 'undefined') return;
+  if (!window.adroll || typeof window.adroll.track !== 'function') return;
+  window.adroll.track('pageView');
+}
+
+/** Test seam — resets the module-level injection state. */
+export function __resetAdRollStateForTests() {
+  sdkInjected = false;
+}

--- a/src/lib/pixelSuppression.js
+++ b/src/lib/pixelSuppression.js
@@ -22,23 +22,34 @@
  * ViewContent fires at the FIRST public content surface for a campaign; every
  * other route stays suppressed). SSR-safe.
  */
-export function isTrackableLeadCapture({ campaign, pathname, search } = {}) {
+/**
+ * The exclusion half of the rule set, factored out so surfaces with a WIDER
+ * allow-list than the campaign funnel (adroll.js — retargeting fires on the
+ * browse pages too) can suppress on exactly the same terms instead of keeping
+ * a second copy of these checks that can drift.
+ */
+export function isSuppressedSurface({ campaign, pathname, search } = {}) {
   const path = (pathname || '').toLowerCase();
-  if (path === '/preview' || path.startsWith('/preview/')) return false;
-  if (path.startsWith('/leadcapture/demo')) return false;
-  if (path.startsWith('/p/')) return false;
+  if (path === '/preview' || path.startsWith('/preview/')) return true;
+  if (path.startsWith('/leadcapture/demo')) return true;
+  if (path.startsWith('/p/')) return true;
 
   if (search) {
     try {
       const params = new URLSearchParams(search);
-      if (params.get('preview') === 'true') return false;
+      if (params.get('preview') === 'true') return true;
     } catch {
       /* malformed query — ignore */
     }
   }
 
-  if (campaign?.is_test_data === true) return false;
+  return campaign?.is_test_data === true;
+}
 
+export function isTrackableLeadCapture({ campaign, pathname, search } = {}) {
+  if (isSuppressedSurface({ campaign, pathname, search })) return false;
+
+  const path = (pathname || '').toLowerCase();
   if (path === '/leadcapture') return true;
   // Marketplace campaign surfaces — a slug segment must be present.
   if (/^\/offers\/[a-z0-9-]+$/.test(path)) return true;

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -50,6 +50,7 @@ import {
   setGoogleUserData, clearGoogleUserData,
   captureGclFromUrl, readGcl,
 } from '../lib/googleAds';
+import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '../lib/adroll';
 import { trackFunnelEvent } from '../lib/pixelCustom';
 
 export default function LeadCapture() {
@@ -164,6 +165,15 @@ export default function LeadCapture() {
         initGoogleAds(googleId);
         markVcFired(campaign.id, 'google');
       }
+    }
+
+    // AdRoll (retargeting): fires here rather than in AdRollRouteTracker because
+    // the gate needs the loaded campaign to apply the test-data exclusion. No
+    // session guard and no shared event id — a retargeting pixel wants every
+    // qualifying view, and it has no server-side twin to dedup against.
+    if (shouldTrackAdRoll(trackCtx)) {
+      initAdRoll();
+      trackAdRollPageView();
     }
   }, [campaign, location.pathname, location.search]);
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,6 +4,7 @@ import RedeemOpsRoute from '@/components/auth/RedeemOpsRoute';
 import DashboardLayout from '@/components/layout/DashboardLayout';
 import RedeemOpsLayout from '@/components/redeemops/RedeemOpsLayout';
 import RouteErrorBoundary from '@/components/RouteErrorBoundary';
+import AdRollRouteTracker from '@/components/AdRollRouteTracker';
 import { BrowserRouter as Router, Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import ErrorBoundary from './ErrorBoundary';
 import { brand } from '@/lib/brand';
@@ -216,6 +217,9 @@ function PagesContent() {
 
  return (
  <ErrorBoundary>
+ {/* AdRoll retargeting pageViews on the public browse surfaces. No-op unless
+     the build carries the AdRoll ids; never mounted on the ops surface. */}
+ {!IS_OPS_SURFACE && <AdRollRouteTracker />}
  <Suspense
  fallback={
  <div className="min-h-screen flex items-center justify-center">

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -25,6 +25,7 @@ import {
   setGoogleUserData, clearGoogleUserData,
   captureGclFromUrl, readGcl,
 } from '@/lib/googleAds';
+import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '@/lib/adroll';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 import {
   shouldTrackTikTok, captureTtclidFromUrl, readTtclid, readTtp,
@@ -194,6 +195,15 @@ export default function MarketplaceFlow() {
         initGoogleAds(googleId);
         markVcFired(campaign.id, 'google');
       }
+    }
+
+    // AdRoll (retargeting): fires here rather than in AdRollRouteTracker because
+    // the gate needs the loaded campaign to apply the test-data exclusion. No
+    // session guard and no shared event id — a retargeting pixel wants every
+    // qualifying view, and it has no server-side twin to dedup against.
+    if (shouldTrackAdRoll(trackCtx)) {
+      initAdRoll();
+      trackAdRollPageView();
     }
   }, [campaign]);
 

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -11,6 +11,7 @@ import { shouldTrackTikTok, initTikTokPixel, trackTikTokViewContent, captureTtcl
 import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
 import { resolveMetaPixelId, resolveTikTokPixelId, resolveGoogleAdsConversionId } from '@/lib/pixelIds';
 import { shouldTrackGoogle, initGoogleAds, captureGclFromUrl } from '@/lib/googleAds';
+import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '@/lib/adroll';
 
 /**
  * Offer detail (/offers/:slug) — the FIRST public content surface for
@@ -89,6 +90,15 @@ export default function MarketplaceOffer() {
         initGoogleAds(googleId);
         markVcFired(campaign.id, 'google');
       }
+    }
+
+    // AdRoll (retargeting): fires here rather than in AdRollRouteTracker because
+    // the gate needs the loaded campaign to apply the test-data exclusion. No
+    // session guard and no shared event id — a retargeting pixel wants every
+    // qualifying view, and it has no server-side twin to dedup against.
+    if (shouldTrackAdRoll(trackCtx)) {
+      initAdRoll();
+      trackAdRollPageView();
     }
   }, [campaign]);
 


### PR DESCRIPTION
Installs the AdRoll pixel (advertisable `XWJKUPH2LRC4LG4ZVFR4MS`) as the fourth ad network, alongside Meta / TikTok / Google Ads. The env vars are already set on the `redeem-frontend` Render service, so this merge is what makes it live.

## Why it differs from the other three pixels

AdRoll's job is **retargeting**, not conversion measurement:

1. **Wider surface.** Meta/TikTok/Google fire only on the campaign funnel, because a conversion belongs to a campaign. AdRoll's asset is the audience pool, so it also fires on the customer-brand browse pages — `/`, `/explore`, `/c/:category`, `/winners`, the static and legal pages. Someone who browsed an offer and left is exactly who retargeting exists to reach.
2. **No event-id dedup.** No server-side counterpart is wired, so `pageView` carries no shared event id and takes no once-per-session guard.
3. **Allow-list, not deny-list.** `isAdRollSurface` enumerates the public customer routes, so a new admin/ops/auth route is untagged by default rather than untagged only if someone remembers to add it.

## Security: token-bearing URLs are excluded

`/r/:token` (reward claim), `/callback?t=…` (screening opt-in), `/t/:slug` and `/share/:slug` are deliberately off the allow-list. `roundtrip.js` reports the full location to AdRoll, and each of those URLs carries a bearer token — tagging them would hand a third-party ad network a working credential for a customer's reward.

## Wiring

Same contract as the existing stubs: `index.html` defines the `adroll` queue + globals but neither injects `roundtrip.js` nor fires a pageView, gated on `VITE_ADROLL_ADV_ID` + `VITE_ADROLL_PIX_ID`. React does both, and only after the gate passes, so the SDK never loads on admin/ops/preview pages.

- Browse pages → `AdRollRouteTracker` fires on each route change (the SPA has no full reloads for `roundtrip.js` to catch on its own).
- The three funnel pages (`/LeadCapture`, `/offers/:slug`, `/flow/:slug`) fire their own pageView once the campaign has loaded, because the test-data exclusion needs it. The `LeadCapture` call sits above the renderer branch, so it covers both the classic `CampaignSignupForm` and the v2 `CampaignPageRenderer`.
- `pixelSuppression` grows `isSuppressedSurface` — the exclusion half of the existing predicate, factored out so AdRoll suppresses on identical terms instead of keeping a second copy that drifts. `isTrackableLeadCapture` behaviour is unchanged.

## Verification

- 2020 frontend tests pass (27 new), eslint clean.
- Redeem build ships the stub with both ids and **no** `s.adroll.com` URL in the HTML; mktr build leaves the placeholders literal so the guard early-returns and `window.adroll` never exists — the operator brand stays fully untagged.
- Headless Chrome against the built bundle, with requests to `s.adroll.com` intercepted so nothing reached the live pixel:

```
/                       sdk-requests=1  script-tags=1  queued=["pageView"]
/explore                sdk-requests=1  script-tags=1  queued=["pageView"]
/c/travel               sdk-requests=1  script-tags=1  queued=["pageView"]
/personal-data-policy   sdk-requests=1  script-tags=1  queued=["pageView"]
/r/sometoken            sdk-requests=0  script-tags=0  queued=[]
/AdminLogin             sdk-requests=0  script-tags=0  queued=null
```

## After merge

`redeem-frontend` rebuilds and picks up the ids already set there. Then AdRoll → **Verify Connection**.

Note: AdRoll drops third-party retargeting cookies on redeem.sg visitors. The existing consent gate covers DNC/PDPA for contact, not ad cookies — worth a look before scaling spend, not a blocker for the pixel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPmex7hZpHS8fJEFyw3KAn