### PR TITLE
fix(dnc): accept the live registry field `no_text` (spec documents `no_text_message`)

### DIFF
--- a/backend/scripts/dnc-uat-pdf.mjs
+++ b/backend/scripts/dnc-uat-pdf.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Render the completed DNC Registry UAT document as a signed PDF.
+ * Usage: node scripts/dnc-uat-pdf.mjs <sig.png> <chop.png> <out.pdf> --tc1 <png...> --tc2 <png...>
+ * Tall screenshots are passed pre-sliced into page-sized parts, in order.
+ */
+import fs from 'fs';
+import { chromium } from 'playwright';
+
+const [sig, chop, out, ...rest] = process.argv.slice(2);
+const tc1 = [];
+const tc2 = [];
+let bucket = null;
+for (const a of rest) {
+  if (a === '--tc1') bucket = tc1;
+  else if (a === '--tc2') bucket = tc2;
+  else bucket.push(a);
+}
+const uri = (p) => `data:image/png;base64,${fs.readFileSync(p, 'base64')}`;
+const shots = (parts) => parts.map((p) => `<img class="shot" src="${uri(p)}">`).join('\n');
+
+// Env-only, mirroring dncService.js — the org code identifies MKTR to PDPC and
+// this repo is public. Export both before rendering the submission document.
+const ORG_CODE = process.env.DNC_ORG_CODE;
+const ESERVICE_ID = process.env.DNC_ESERVICE_ID || 'checkregistry';
+if (!ORG_CODE) {
+  console.error('Missing required env DNC_ORG_CODE — export it before running.');
+  process.exit(1);
+}
+
+const html = `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+  * { box-sizing: border-box; }
+  body { font: 11pt/1.5 Helvetica, Arial, sans-serif; color: #111; margin: 0; }
+  h1 { font-size: 15pt; margin: 0 0 2pt; }
+  .sub { color: #444; margin-bottom: 14pt; font-size: 10.5pt; }
+  h2 { font-size: 12pt; margin: 16pt 0 8pt; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border: 1px solid #666; padding: 6pt 8pt; vertical-align: top; text-align: left; }
+  th { background: #e8e8e8; font-size: 10pt; }
+  td.c { text-align: center; font-weight: bold; }
+  .shot { width: 100%; border: 1px solid #999; margin: 6pt 0 14pt; }
+  .brk { page-break-before: always; }
+  .kv td { border: 1px solid #666; }
+  .kv td:first-child { width: 38%; background: #f3f3f3; }
+  .signbox { border: 1px solid #666; height: 110pt; position: relative; padding: 6pt; }
+  .signbox img.s { position: absolute; left: 24pt; top: 8pt; height: 62pt; }
+  .signbox img.k { position: absolute; left: 90pt; top: 40pt; height: 52pt; opacity: .92; }
+  .signbox .cap { position: absolute; bottom: 4pt; left: 6pt; font-size: 9pt; color: #444; }
+  .foot { margin-top: 18pt; font-size: 9pt; color: #666; }
+</style></head><body>
+
+<h1>DNC Registry API &ndash; UAT Test Cases</h1>
+<div class="sub">Organisation: MKTR PTE. LTD. (UEN: 202507548M) &middot; orgCode ${ORG_CODE} &middot; eServiceId ${ESERVICE_ID}</div>
+
+<table>
+  <tr><th style="width:5%">S/N</th><th style="width:45%">Test Scenario</th><th style="width:10%">Pass/Fail? (P/F)</th><th>Remarks</th></tr>
+  <tr>
+    <td class="c">1</td>
+    <td>Submit any 8-digit telephone numbers that starts with &quot;3&quot;, &quot;6&quot;, &quot;8&quot; or &quot;9&quot;. You may also use the telephone numbers provided in the test data.</td>
+    <td class="c">P</td>
+    <td>All 24 test-data numbers returned S000; voice/text/fax registry flags match the provided test data (transaction 1992072, results valid until 02-Sep-2026).</td>
+  </tr>
+  <tr>
+    <td class="c">2</td>
+    <td>Submit invalid telephone numbers (i.e. telephone numbers that do not start with &quot;3&quot;, &quot;6&quot;, &quot;8&quot; and &quot;9&quot;). This will return an error.</td>
+    <td class="c">P</td>
+    <td>Invalid numbers rejected with an error (HTTP 500, code S501). Highlighted to DNC Ops in our reply for awareness.</td>
+  </tr>
+</table>
+
+<div class="brk"></div>
+${shots(tc1)}
+
+<div class="brk"></div>
+${shots(tc2)}
+
+<div class="brk"></div>
+<h1>DNC Registry API &ndash; UAT Completion Acknowledgement</h1>
+<h2>Organisation Details</h2>
+<table class="kv">
+  <tr><td>Organisation Name</td><td>MKTR PTE. LTD. (UEN: 202507548M)</td></tr>
+</table>
+<h2>User Acceptance Test (UAT) Details</h2>
+<table class="kv">
+  <tr><td>UAT Completed By (Name)</td><td>Shawn Lee Yi Heng</td></tr>
+  <tr><td>Title</td><td>Product Engineer</td></tr>
+  <tr><td>Telephone Number(s)</td><td>+65 9698 9089</td></tr>
+  <tr><td>Email</td><td>admin@mktr.sg</td></tr>
+  <tr><td>UAT Completion Date</td><td>12 Aug 2026</td></tr>
+  <tr><td>Remarks (if any)</td><td>Both test scenarios passed on 12 Aug 2026. Requests signed with the registered X.509 key from whitelisted IP 159.89.201.126.</td></tr>
+</table>
+
+<h2>UAT Sign-off</h2>
+<p>I acknowledge and accept that the UAT has been completed successfully.</p>
+<table class="kv">
+  <tr><td>Name</td><td>Shawn Lee Yi Heng</td></tr>
+  <tr><td>Title</td><td>Product Engineer</td></tr>
+  <tr><td>Telephone Number(s)</td><td>+65 9698 9089</td></tr>
+  <tr><td>Email Address</td><td>admin@mktr.sg</td></tr>
+  <tr><td>Signature</td><td style="padding:0"><div class="signbox">
+    <img class="s" src="${uri(sig)}">
+    <img class="k" src="${uri(chop)}">
+    <div class="cap">Signed: 12 Aug 2026</div>
+  </div></td></tr>
+</table>
+
+<div class="foot">MKTR PTE. LTD. &middot; DNC Registry API UAT (Log No.: 00668352) &middot; completed 12 Aug 2026</div>
+</body></html>`;
+
+const browser = await chromium.launch({ channel: 'chrome' });
+const page = await browser.newPage();
+await page.setContent(html, { waitUntil: 'networkidle' });
+await page.pdf({ path: out, format: 'A4', printBackground: true, margin: { top: '14mm', bottom: '14mm', left: '13mm', right: '13mm' } });
+await browser.close();
+console.log('wrote', out);

--- a/backend/scripts/dnc-uat-render.mjs
+++ b/backend/scripts/dnc-uat-render.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Render DNC UAT wire evidence (captures JSON from dnc-uat.mjs) into PNG
+ * screenshots, one per test case, via Playwright chromium.
+ * Usage: node render-evidence.mjs <evidence.json> <outdir>
+ */
+import fs from 'fs';
+import path from 'path';
+import { chromium } from 'playwright';
+
+const [evidencePath, outDir, titleOverride] = process.argv.slice(2);
+const captures = JSON.parse(fs.readFileSync(evidencePath, 'utf8'));
+fs.mkdirSync(outDir, { recursive: true });
+
+const TITLES = [
+  'Test Case 1 — Valid 8-digit numbers (UAT test data, 24 numbers)',
+  'Test Case 2 — Invalid numbers (not starting with 3/6/8/9) — expected rejection',
+];
+
+const esc = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const pretty = (s) => { try { return JSON.stringify(JSON.parse(s), null, 2); } catch { return s; } };
+
+function page(cap, title) {
+  const sgt = new Date(cap.at).toLocaleString('en-SG', { timeZone: 'Asia/Singapore', hour12: false });
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>
+  body { margin:0; background:#0d1117; color:#e6edf3; font:14px/1.55 "SF Mono", ui-monospace, Menlo, monospace; }
+  .wrap { width: 1360px; padding: 28px 36px; box-sizing: border-box; }
+  .head { display:flex; justify-content:space-between; align-items:baseline; border-bottom:1px solid #30363d; padding-bottom:14px; margin-bottom:18px; }
+  .head h1 { font-size:17px; margin:0; color:#f0f6fc; font-weight:600; }
+  .head .meta { color:#8b949e; font-size:12.5px; }
+  h2 { font-size:13px; color:#7ee787; text-transform:uppercase; letter-spacing:.08em; margin:20px 0 8px; }
+  h2.resp { color:#79c0ff; }
+  pre { background:#161b22; border:1px solid #30363d; border-radius:8px; padding:14px 16px; margin:0;
+        white-space:pre-wrap; word-break:break-all; font-size:13px; }
+  .status { display:inline-block; margin:14px 0 0; padding:4px 12px; border-radius:6px; font-weight:600;
+            background:${cap.httpStatus < 400 ? '#1f6feb22; color:#79c0ff' : '#da363322; color:#ffa198'}; }
+  .foot { margin-top:20px; color:#8b949e; font-size:12px; border-top:1px solid #30363d; padding-top:12px; }
+  </style></head><body><div class="wrap">
+  <div class="head"><h1>${esc(title)}</h1><div class="meta">DNC Registry API UAT · MKTR PTE. LTD. (UEN 202507548M)</div></div>
+  <h2>Request</h2>
+  <pre>POST ${esc(cap.url)}
+Authorization: ${esc(cap.requestHeaders.Authorization)}
+Content-Type: ${esc(cap.requestHeaders['Content-Type'])}
+
+${esc(pretty(cap.requestBody))}</pre>
+  <span class="status">HTTP ${cap.httpStatus} ${esc(cap.httpStatusText || '')}</span>
+  <h2 class="resp">Response</h2>
+  <pre>${esc(pretty(cap.responseBody))}</pre>
+  <div class="foot">Executed ${sgt} SGT · source IP 159.89.201.126 (whitelisted application server) · endpoint ${esc(new URL(cap.url).host)}</div>
+  </div></body></html>`;
+}
+
+const browser = await chromium.launch({ channel: 'chrome' });
+const bp = await browser.newPage({ viewport: { width: 1360, height: 900 } });
+for (let i = 0; i < captures.length; i += 1) {
+  await bp.setContent(page(captures[i], titleOverride || TITLES[i] || `Capture ${i + 1}`), { waitUntil: 'networkidle' });
+  const file = path.join(outDir, `tc${i + 1}.png`);
+  await bp.screenshot({ path: file, fullPage: true });
+  console.log('wrote', file);
+}
+await browser.close();

--- a/backend/scripts/dnc-uat.mjs
+++ b/backend/scripts/dnc-uat.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * DNC Registry UAT runner — drives the REAL production dncService code path
+ * (signing, auth header, body shape, proxy, response parsing) against PDPC's
+ * UAT environment, per "DNC Registry API - UAT Test Cases_v1.xlsx".
+ *
+ * Usage:
+ *   node scripts/dnc-uat.mjs selfcheck        # offline: sign + verify vs mycert.cer
+ *   node scripts/dnc-uat.mjs tc1              # live: 24 seeded numbers vs expected flags
+ *   node scripts/dnc-uat.mjs tc2              # live: invalid numbers -> expect error
+ *   node scripts/dnc-uat.mjs all              # selfcheck + tc1 + tc2 (+ JSON evidence)
+ *
+ * Reads ~/dnc-keys/privatekey.key and ~/dnc-keys/proxy-credentials.txt unless
+ * DNC_PRIVATE_KEY / DNC_HTTPS_PROXY are set. Never prints the private key.
+ * Requires dummy DB env for the models import chain (never connects): set by run-uat.sh.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import nodeFetch from 'node-fetch';
+
+const svc = await import('../src/services/dncService.js');
+const { buildBaseString, signRequest, buildAuthHeader, checkNumbers, formatDncNumber, nextTimestamp } = svc;
+
+// ── Expected UAT seed data (from "DNC Registry API UAT Test Data" sheet) ──────
+// number: [no_voice_call, no_text_message, no_fax]
+const EXPECTED = {
+  88880005: ['R', 'NR', 'NR'], 88880011: ['NR', 'R', 'NR'], 88880026: ['NR', 'R', 'R'],
+  88880027: ['R', 'R', 'R'],   88880031: ['R', 'NR', 'NR'], 88880036: ['NR', 'R', 'NR'],
+  88880038: ['R', 'R', 'NR'],  88880040: ['R', 'R', 'NR'],  88880050: ['NR', 'NR', 'R'],
+  88880051: ['NR', 'R', 'NR'], 88880052: ['NR', 'R', 'NR'], 88880053: ['R', 'R', 'R'],
+  88880054: ['NR', 'R', 'NR'], 88880057: ['R', 'NR', 'NR'], 88880058: ['R', 'R', 'R'],
+  88880059: ['R', 'R', 'R'],   88880060: ['R', 'R', 'R'],   88880081: ['R', 'R', 'R'],
+  88880082: ['R', 'R', 'R'],   88880083: ['R', 'R', 'R'],   88880084: ['R', 'R', 'R'],
+  88880089: ['R', 'R', 'R'],   88880091: ['R', 'R', 'R'],   88880095: ['R', 'R', 'R'],
+};
+const TC1_NUMBERS = Object.keys(EXPECTED);
+const TC2_NUMBERS = ['12345678', '00000000']; // do not start with 3/6/8/9 -> API must reject
+
+// ── Config (env-first, ~/dnc-keys fallbacks) ──────────────────────────────────
+function mustEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env ${name} — export it before running.`);
+    process.exit(1);
+  }
+  return v;
+}
+function loadPrivateKey() {
+  if (process.env.DNC_PRIVATE_KEY) return process.env.DNC_PRIVATE_KEY.replace(/\\n/g, '\n');
+  return fs.readFileSync(path.join(os.homedir(), 'dnc-keys', 'privatekey.key'), 'utf8');
+}
+function loadProxy() {
+  if (process.env.DNC_HTTPS_PROXY) return process.env.DNC_HTTPS_PROXY;
+  try {
+    const txt = fs.readFileSync(path.join(os.homedir(), 'dnc-keys', 'proxy-credentials.txt'), 'utf8');
+    const m = txt.match(/DNC_HTTPS_PROXY=(\S+)/);
+    return m ? m[1] : null;
+  } catch { return null; }
+}
+function uatConfig() {
+  return {
+    enabled: true,
+    baseUrl: (process.env.DNC_BASE_URL || 'https://uat.dnc.gov.sg/realtime').replace(/\/+$/, ''),
+    // Env-only, mirroring dncService.js — the org code identifies MKTR to PDPC
+    // and this repo is public.
+    orgCode: mustEnv('DNC_ORG_CODE'),
+    eServiceId: process.env.DNC_ESERVICE_ID || 'checkregistry',
+    privateKey: loadPrivateKey(),
+    checkOnBehalf: 'N',
+    proxy: loadProxy(),
+    timeoutMs: Number(process.env.DNC_TIMEOUT_MS) || 20000,
+  };
+}
+
+// ── Wire capture: tee fetch so evidence shows the exact request/response ──────
+const captures = [];
+function teeFetch(url, init) {
+  return nodeFetch(url, init).then(async (res) => {
+    const text = await res.text();
+    captures.push({
+      at: new Date().toISOString(),
+      url,
+      method: init.method,
+      requestHeaders: { ...init.headers },
+      requestBody: init.body,
+      httpStatus: res.status,
+      httpStatusText: res.statusText,
+      responseBody: text,
+    });
+    return { status: res.status, json: async () => JSON.parse(text) };
+  });
+}
+
+const hr = (t) => console.log(`\n━━━ ${t} ${'━'.repeat(Math.max(0, 66 - t.length))}`);
+
+function printCapture(c) {
+  console.log(`POST ${c.url}`);
+  console.log(`Authorization: ${c.requestHeaders.Authorization}`);
+  console.log(`Content-Type: ${c.requestHeaders['Content-Type']}`);
+  console.log(`Payload: ${c.requestBody}`);
+  console.log(`\nHTTP ${c.httpStatus} ${c.httpStatusText}  (${c.at})`);
+  try {
+    console.log(JSON.stringify(JSON.parse(c.responseBody), null, 2));
+  } catch {
+    console.log(c.responseBody);
+  }
+}
+
+// ── Steps ─────────────────────────────────────────────────────────────────────
+function selfcheck(cfg) {
+  hr('SELFCHECK (offline)');
+  const timestamp = nextTimestamp();
+  const baseString = buildBaseString({ orgCode: cfg.orgCode, eServiceId: cfg.eServiceId, timestamp });
+  const appSignature = signRequest(baseString, cfg.privateKey);
+  const header = buildAuthHeader({ orgCode: cfg.orgCode, eServiceId: cfg.eServiceId, timestamp, appSignature });
+  console.log(`Base string      : ${baseString}`);
+  console.log(`Auth header      : ${header.slice(0, 96)}…`);
+  console.log(`Signature 1-line : ${!/[\r\n]/.test(appSignature)}`);
+
+  const cert = new crypto.X509Certificate(fs.readFileSync(path.join(os.homedir(), 'dnc-keys', 'mycert.cer')));
+  const ok = crypto.createVerify('RSA-SHA256').update(baseString, 'utf8').verify(cert.publicKey, appSignature, 'base64');
+  console.log(`Signature verifies against mycert.cer (the key PDPC holds): ${ok ? 'PASS' : 'FAIL'}`);
+
+  const allFormatted = TC1_NUMBERS.every((n) => formatDncNumber(n) === n);
+  console.log(`All 24 seed numbers valid DNC wire format: ${allFormatted ? 'PASS' : 'FAIL'}`);
+  if (!ok || !allFormatted) process.exitCode = 1;
+  return ok && allFormatted;
+}
+
+async function runTc1(cfg) {
+  hr('TC1 — valid numbers (24 seeded UAT test numbers)');
+  const result = await checkNumbers(TC1_NUMBERS, { cfg }, { skipLock: true, skipBudget: true, fetch: teeFetch });
+  printCapture(captures[captures.length - 1]);
+
+  const pass = result.statusCode === 'S000' && result.results.length === TC1_NUMBERS.length;
+  console.log(`\nstatus_code=${result.statusCode} results=${result.results.length}/${TC1_NUMBERS.length} txn=${result.transactionId}`);
+
+  let mismatches = 0;
+  for (const r of result.results) {
+    const exp = EXPECTED[r.number];
+    if (!exp) continue;
+    const got = [r.noVoiceCall ? 'R' : 'NR', r.noTextMessage ? 'R' : 'NR', r.noFax ? 'R' : 'NR'];
+    const match = got.join() === exp.join();
+    if (!match) {
+      mismatches += 1;
+      console.log(`  MISMATCH ${r.number}: expected voice/text/fax=${exp.join('/')} got ${got.join('/')}`);
+    }
+  }
+  console.log(`Seed-data comparison: ${mismatches === 0 ? 'all 24 match expected flags' : `${mismatches} mismatches (see above)`}`);
+  console.log(`TC1 ${pass ? 'PASS' : 'FAIL'}`);
+  if (!pass) process.exitCode = 1;
+  return { pass, mismatches, result };
+}
+
+async function runTc2(cfg) {
+  hr('TC2 — invalid numbers (must be rejected)');
+  const result = await checkNumbers(TC2_NUMBERS, { cfg }, { skipLock: true, skipBudget: true, fetch: teeFetch });
+  const cap = captures[captures.length - 1];
+  printCapture(cap);
+
+  // Any error signal counts: non-S000 status_code or an HTTP error status.
+  const isError = result.statusCode !== 'S000' || cap.httpStatus >= 400;
+  console.log(`\nstatus_code=${result.statusCode ?? '(none)'} http=${cap.httpStatus}`);
+  console.log(`TC2 ${isError ? 'PASS (rejected as expected)' : 'FAIL (accepted invalid numbers)'}`);
+  if (!isError) process.exitCode = 1;
+  return { pass: isError, result };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+const mode = process.argv[2] || 'all';
+const cfg = uatConfig();
+console.log(`DNC UAT runner — ${cfg.baseUrl}  orgCode=${cfg.orgCode}  eServiceId=${cfg.eServiceId}  proxy=${cfg.proxy ? 'droplet' : 'DIRECT'}`);
+
+try {
+  if (mode === 'selfcheck' || mode === 'all') selfcheck(cfg);
+  if (mode === 'tc1' || mode === 'all') await runTc1(cfg);
+  if (mode === 'tc2' || mode === 'all') await runTc2(cfg);
+} catch (err) {
+  console.error(`\nTRANSPORT ERROR: ${err.message}`);
+  process.exitCode = 1;
+}
+
+if (captures.length) {
+  const out = process.env.DNC_UAT_EVIDENCE || path.join(process.cwd(), `dnc-uat-evidence-${Date.now()}.json`);
+  fs.writeFileSync(out, JSON.stringify(captures, null, 2));
+  console.log(`\nWire evidence written: ${out}`);
+}

--- a/backend/src/services/dncService.js
+++ b/backend/src/services/dncService.js
@@ -160,7 +160,9 @@ export function parseResponse(json) {
     ? json.numbers.map((n) => ({
         number: n.number,
         noVoiceCall: n.no_voice_call === 'R',
-        noTextMessage: n.no_text_message === 'R',
+        // Spec v1.1 documents `no_text_message`, but the live UAT system returns
+        // `no_text` (observed 12 Aug 2026, confirmed with DNC Ops). Accept both.
+        noTextMessage: (n.no_text_message ?? n.no_text) === 'R',
         noFax: n.no_fax === 'R',
       }))
     : [];

--- a/backend/test/unit/dncService.test.js
+++ b/backend/test/unit/dncService.test.js
@@ -129,6 +129,22 @@ describe('parseResponse', () => {
     expect(r.results[1].noVoiceCall).toBe(false);
     expect(r.validUntil).toBeInstanceOf(Date);
   });
+
+  it('accepts the live UAT field name no_text (spec says no_text_message)', () => {
+    const json = {
+      msg: 'These results are valid until 02-Sep-2026',
+      numbers: [
+        { number: '88880052', no_voice_call: 'NR', no_text: 'R', no_fax: 'NR' },
+        { number: '88880005', no_voice_call: 'R', no_text: 'NR', no_fax: 'NR' },
+      ],
+      transactionid: '1992072',
+      created_time: '2026-08-12 12:30:00',
+      status_code: 'S000',
+    };
+    const r = dnc.parseResponse(json);
+    expect(r.results[0].noTextMessage).toBe(true);
+    expect(r.results[1].noTextMessage).toBe(false);
+  });
 });
 
 describe('nextTimestamp', () => {


### PR DESCRIPTION
## What

The DNC Registry API spec v1.1 documents the per-number SMS flag as `no_text_message`. The **live system returns `no_text`** (observed 12 Aug 2026 during UAT, confirmed with DNC Ops).

`parseResponse` only read the spec name, so `noTextMessage` came back `false` for every number — **a number registered on the SMS do-not-call list would have been treated as textable.**

```js
- noTextMessage: n.no_text_message === 'R',
+ noTextMessage: (n.no_text_message ?? n.no_text) === 'R',
```

Reads both names, so the parser survives whichever field production returns.

## Also lands the UAT tooling

The runner used for the 12 Aug submission (24/24 expected results matched, txn `1992072`):

| Script | Role |
|---|---|
| `dnc-uat.mjs` | Drives the **real** `dncService` code path (signing, auth header, body shape, proxy, parsing) against PDPC's UAT host |
| `dnc-uat-render.mjs` | Screenshots the captured wire evidence, one PNG per test case |
| `dnc-uat-pdf.mjs` | Renders the signed submission document |

Org code and private key are **env-only** (`DNC_ORG_CODE`, `DNC_PRIVATE_KEY`), matching `dncService.js` — this repo is public, so the working copies' hardcoded org-code defaults were stripped before committing.

## Tests

- `test/unit/dncService.test.js` gains a case asserting the live `no_text` field parses
- 146 unit suites / 2436 tests pass
- `eslint src/ --quiet` and `npm run typecheck` clean

## Provenance

This fix was written during the 12 Aug UAT and had been sitting **uncommitted** in the shared working checkout since then. Everything else in that checkout was either already merged or a superseded draft; this was the only unshipped work.