### PR TITLE
feat(screening): hear the callee — split-channel recording with its own gain

### DIFF
--- a/backend/src/services/retellScreeningService.js
+++ b/backend/src/services/retellScreeningService.js
@@ -726,6 +726,9 @@ export function makeRetellScreeningService(overrides = {}) {
           summary: analysis.call_summary || null,
           sentiment: analysis.user_sentiment || null,
           recordingUrl: call.recording_url || null,
+          // Retell's split recording: ch0 = callee, ch1 = agent. The admin player
+          // lifts the callee leg with it — in the mono mix they sit ~6 dB down.
+          recordingMultiChannelUrl: call.recording_multi_channel_url || null,
           // Verbatim turn-by-turn script Retell returns ("Agent: …\nUser: …").
           // Capped so a pathologically long call can't bloat the jsonb row; the
           // recording remains the unabridged source of truth. Admin-only surface.
@@ -758,6 +761,9 @@ export function makeRetellScreeningService(overrides = {}) {
         endedAt: call.end_timestamp ? new Date(call.end_timestamp).toISOString() : new Date().toISOString(),
         disconnectionReason: disconnection,
         ...(call.recording_url ? { recordingUrl: call.recording_url } : {}),
+        ...(call.recording_multi_channel_url
+          ? { recordingMultiChannelUrl: call.recording_multi_channel_url }
+          : {}),
         ...(Number.isFinite(cost.combined_cost) ? { costCents: cost.combined_cost } : {}),
         ...(durationSeconds != null ? { durationSeconds } : {}),
         ...(call.agent_id ? { agentId: call.agent_id } : {}),

--- a/backend/src/services/retellService.js
+++ b/backend/src/services/retellService.js
@@ -49,6 +49,7 @@ const defaultDeps = {
   dncCheckAndRecord,
   gateHeldDncLead,
   buildProspectWhere,
+  setSourceMetadataPath,
   // Lazy (dynamic import) so existing unit suites that mock this module's
   // graph don't have to know the screening services. DI-overridable.
   handleScreeningWebhook: async (payload, event) =>
@@ -185,7 +186,8 @@ export function makeRetellService(overrides = {}) {
       disconnection_reason,
       agent_id,
       agent_name,
-      recording_url
+      recording_url,
+      recording_multi_channel_url
     } = payload;
 
     // ── Log incoming payload shape for debugging ──
@@ -357,7 +359,8 @@ export function makeRetellService(overrides = {}) {
           disconnectionReason: disconnection_reason,
           sentiment: call_analysis?.user_sentiment,
           callSuccessful: call_analysis?.call_successful,
-          recordingUrl: recording_url || null
+          recordingUrl: recording_url || null,
+          recordingMultiChannelUrl: recording_multi_channel_url || null
         },
         retellCallId: call_id
       }, { transaction: t });
@@ -490,7 +493,7 @@ export function makeRetellService(overrides = {}) {
    *
    * @param {string} prospectId
    * @param {object} user — the authenticated caller
-   * @returns {{ recordingUrl: string|null }}
+   * @returns {{ recordingUrl: string|null, recordingMultiChannelUrl: string|null }}
    */
   async function getRecordingUrl(prospectId, user) {
     if (!user) {
@@ -507,9 +510,15 @@ export function makeRetellService(overrides = {}) {
       throw new d.AppError('Not a Retell prospect', 404);
     }
 
-    // Return stored URL if available
-    if (meta.recordingUrl) {
-      return { recordingUrl: meta.recordingUrl };
+    // Return stored URLs once BOTH legs have been resolved. Prospects captured
+    // before the split-recording capture have a mono URL and no multi-channel
+    // key at all, so they earn exactly one refetch to backfill it — the key is
+    // written even when Retell has no split file, which stops that looping.
+    if (meta.recordingUrl && Object.prototype.hasOwnProperty.call(meta, 'recordingMultiChannelUrl')) {
+      return {
+        recordingUrl: meta.recordingUrl,
+        recordingMultiChannelUrl: meta.recordingMultiChannelUrl || null
+      };
     }
 
     // Fetch from Retell API (via circuit breaker)
@@ -532,16 +541,20 @@ export function makeRetellService(overrides = {}) {
     }
 
     const recordingUrl = call.recording_url || null;
+    const recordingMultiChannelUrl = call.recording_multi_channel_url || null;
 
-    // Cache it in sourceMetadata for next time — atomic single-key write
+    // Cache both in sourceMetadata for next time — atomic single-key writes
     // (prospectJsonPatch): the old whole-object update could delete marker/
     // fact keys other writers landed after `meta` was read
-    // (plan google-ads-signal-levers §4.3).
+    // (plan google-ads-signal-levers §4.3). recordingMultiChannelUrl is written
+    // even when null — the key's PRESENCE is what settles the backfill branch
+    // above after one hit, and setPath JSON-encodes null into a real key.
     if (recordingUrl) {
-      await setSourceMetadataPath(prospect.id, ['recordingUrl'], recordingUrl);
+      await d.setSourceMetadataPath(prospect.id, ['recordingUrl'], recordingUrl);
+      await d.setSourceMetadataPath(prospect.id, ['recordingMultiChannelUrl'], recordingMultiChannelUrl);
     }
 
-    return { recordingUrl };
+    return { recordingUrl, recordingMultiChannelUrl };
   }
 
   return { processRetellCall, getRecordingUrl };

--- a/backend/test/unit/retellService.test.js
+++ b/backend/test/unit/retellService.test.js
@@ -520,11 +520,15 @@ describe('retellService (unit)', () => {
   // ────────────────────────────────────────────────
 
   describe('getRecordingUrl', () => {
-    let mocks, service;
+    let mocks, service, setSourceMetadataPath;
 
     beforeEach(() => {
       mocks = buildMocks();
+      // The cache write is an atomic single-key patch (prospectJsonPatch), not a
+      // whole-object save — inject it so the write path is assertable here.
+      setSourceMetadataPath = jest.fn().mockResolvedValue(1);
       service = makeRetellService({
+        setSourceMetadataPath,
         Prospect: mocks.Prospect,
         IdempotencyKey: mocks.IdempotencyKey,
         User: mocks.User,
@@ -559,7 +563,11 @@ describe('retellService (unit)', () => {
 
     it('scopes the lookup with buildProspectWhere', async () => {
       mocks.Prospect.findOne.mockResolvedValue({
-        sourceMetadata: { retellCallId: 'call123', recordingUrl: 'https://cached.url/recording.mp3' },
+        sourceMetadata: {
+          retellCallId: 'call123',
+          recordingUrl: 'https://cached.url/recording.mp3',
+          recordingMultiChannelUrl: 'https://cached.url/recording_multichannel.wav',
+        },
       });
       const agent = { id: 'agent-9', role: 'agent' };
 
@@ -579,16 +587,88 @@ describe('retellService (unit)', () => {
         .rejects.toThrow('Not a Retell prospect');
     });
 
-    it('returns cached recordingUrl from sourceMetadata', async () => {
+    it('returns cached URLs once both legs are stored', async () => {
       mocks.Prospect.findOne.mockResolvedValue({
+        sourceMetadata: {
+          retellCallId: 'call123',
+          recordingUrl: 'https://cached.url/recording.mp3',
+          recordingMultiChannelUrl: 'https://cached.url/recording_multichannel.wav',
+        },
+      });
+
+      const result = await service.getRecordingUrl('prospect-1', admin);
+      expect(result).toEqual({
+        recordingUrl: 'https://cached.url/recording.mp3',
+        recordingMultiChannelUrl: 'https://cached.url/recording_multichannel.wav',
+      });
+      expect(setSourceMetadataPath).not.toHaveBeenCalled();
+    });
+
+    // Prospects captured before the split recording was stored hold a mono URL
+    // and no multi-channel key at all — they earn exactly one refetch, and the
+    // key is written even when Retell has no split file so it can't re-loop.
+    it('refetches once to backfill the split recording on a legacy prospect', async () => {
+      const prevKey = process.env.RETELL_API_KEY;
+      process.env.RETELL_API_KEY = 'test-key';
+      mocks.Prospect.findOne.mockResolvedValue({
+        id: 'prospect-1',
         sourceMetadata: {
           retellCallId: 'call123',
           recordingUrl: 'https://cached.url/recording.mp3',
         },
       });
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          recording_url: 'https://cdn.retell/recording.wav',
+          recording_multi_channel_url: 'https://cdn.retell/recording_multichannel.wav',
+        }),
+      });
 
-      const result = await service.getRecordingUrl('prospect-1', admin);
-      expect(result).toEqual({ recordingUrl: 'https://cached.url/recording.mp3' });
+      try {
+        const result = await service.getRecordingUrl('prospect-1', admin);
+        expect(result).toEqual({
+          recordingUrl: 'https://cdn.retell/recording.wav',
+          recordingMultiChannelUrl: 'https://cdn.retell/recording_multichannel.wav',
+        });
+        // Atomic single-key patches — never a whole-object sourceMetadata save.
+        expect(setSourceMetadataPath).toHaveBeenCalledWith(
+          'prospect-1',
+          ['recordingMultiChannelUrl'],
+          'https://cdn.retell/recording_multichannel.wav'
+        );
+      } finally {
+        process.env.RETELL_API_KEY = prevKey;
+        delete global.fetch;
+      }
+    });
+
+    // Retell returns no split file for some calls; storing the null still ends
+    // the backfill so the next read is a cache hit rather than another fetch.
+    it('stores a null split URL so the backfill settles after one fetch', async () => {
+      const prevKey = process.env.RETELL_API_KEY;
+      process.env.RETELL_API_KEY = 'test-key';
+      mocks.Prospect.findOne.mockResolvedValue({
+        id: 'prospect-1',
+        sourceMetadata: { retellCallId: 'call123', recordingUrl: 'https://cached.url/r.mp3' },
+      });
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ recording_url: 'https://cdn.retell/recording.wav' }),
+      });
+
+      try {
+        const result = await service.getRecordingUrl('prospect-1', admin);
+        expect(result.recordingMultiChannelUrl).toBeNull();
+        expect(setSourceMetadataPath).toHaveBeenCalledWith(
+          'prospect-1',
+          ['recordingMultiChannelUrl'],
+          null
+        );
+      } finally {
+        process.env.RETELL_API_KEY = prevKey;
+        delete global.fetch;
+      }
     });
   });
 });

--- a/src/components/prospects/CallRecordingPlayer.jsx
+++ b/src/components/prospects/CallRecordingPlayer.jsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from "react";
+
+// Retell's split recording puts the callee on ch0 and the agent on ch1 —
+// verified by measuring a production screening call: during agent speech ch0
+// reads −45 dBFS (silent) while ch1 reads −20.6, and the two swap for the
+// callee's turns.
+const CALLEE_CHANNEL = 0;
+const AGENT_CHANNEL = 1;
+
+// Measured on the same call: in the mono mix the agent averages −26.6 dBFS RMS
+// against the callee's −32.4, and the isolated legs sit 8.3 LU apart. +8 dB on
+// the callee against −2 dB of agent trim closes that gap without clipping —
+// the callee's peaks already reach −3.4 dBFS, so the gain rides the compressor.
+const DEFAULT_CALLEE_BOOST_DB = 8;
+const AGENT_TRIM_DB = -2;
+const MAX_CALLEE_BOOST_DB = 18;
+
+// The compressor pulls the summed mix ~4.5 dB below the original mono file, so
+// balancing the two voices would otherwise cost overall loudness. +6 dB puts
+// both speakers back at ~-25 dBFS RMS with the true peak still at -8.2 dBFS —
+// verified by rendering this exact graph over a production call.
+const MAKEUP_GAIN_DB = 6;
+
+const dbToGain = (db) => Math.pow(10, db / 20);
+
+/**
+ * Call recording player that can lift the callee independently of the agent.
+ *
+ * `src` is Retell's mono mixdown, where a human on a phone line is consistently
+ * quieter than the agent's compressed TTS. `multiChannelSrc` is Retell's split
+ * recording; when present we run it through Web Audio and boost the callee leg
+ * so the answer is as audible as the question.
+ *
+ * Degrades to a plain <audio> element whenever the split file or Web Audio is
+ * unavailable — prospects captured before the split URL was stored, jsdom under
+ * test, or a browser that refuses createMediaElementSource.
+ */
+export default function CallRecordingPlayer({ src, multiChannelSrc, className, style }) {
+  const audioRef = useRef(null);
+  const graphRef = useRef(null);
+  const [calleeBoostDb, setCalleeBoostDb] = useState(DEFAULT_CALLEE_BOOST_DB);
+  const [isSplit, setIsSplit] = useState(false);
+
+  const url = multiChannelSrc || src;
+
+  useEffect(() => {
+    setIsSplit(false);
+    graphRef.current = null;
+    if (!multiChannelSrc) return undefined;
+
+    const el = audioRef.current;
+    const Ctx = typeof window !== "undefined"
+      && (window.AudioContext || window.webkitAudioContext);
+    if (!el || !Ctx) return undefined;
+
+    let ctx;
+    try {
+      ctx = new Ctx();
+      const source = ctx.createMediaElementSource(el);
+      const splitter = ctx.createChannelSplitter(2);
+      const calleeGain = ctx.createGain();
+      const agentGain = ctx.createGain();
+      const merger = ctx.createChannelMerger(2);
+      const compressor = ctx.createDynamicsCompressor();
+
+      // Gentle levelling only — enough to tame the boosted callee's peaks
+      // without pumping the agent's already-compressed voice.
+      compressor.threshold.value = -26;
+      compressor.knee.value = 30;
+      compressor.ratio.value = 3;
+      compressor.attack.value = 0.003;
+      compressor.release.value = 0.25;
+
+      calleeGain.gain.value = dbToGain(DEFAULT_CALLEE_BOOST_DB);
+      agentGain.gain.value = dbToGain(AGENT_TRIM_DB);
+
+      source.connect(splitter);
+      splitter.connect(calleeGain, CALLEE_CHANNEL);
+      splitter.connect(agentGain, AGENT_CHANNEL);
+      // Both legs feed both outputs: split channels would otherwise put the
+      // callee in one ear and the agent in the other.
+      calleeGain.connect(merger, 0, 0);
+      calleeGain.connect(merger, 0, 1);
+      agentGain.connect(merger, 0, 0);
+      agentGain.connect(merger, 0, 1);
+      const makeup = ctx.createGain();
+      makeup.gain.value = dbToGain(MAKEUP_GAIN_DB);
+
+      merger.connect(compressor);
+      compressor.connect(makeup);
+      makeup.connect(ctx.destination);
+
+      graphRef.current = { ctx, calleeGain };
+      setIsSplit(true);
+    } catch {
+      // Tainted cross-origin media or an engine without Web Audio: the element
+      // still plays the split file untouched, just without the boost.
+      if (ctx) ctx.close().catch(() => {});
+      return undefined;
+    }
+
+    return () => {
+      graphRef.current = null;
+      ctx.close().catch(() => {});
+    };
+  }, [multiChannelSrc]);
+
+  useEffect(() => {
+    const graph = graphRef.current;
+    if (graph) graph.calleeGain.gain.value = dbToGain(calleeBoostDb);
+  }, [calleeBoostDb]);
+
+  // Browsers start the context suspended until a gesture; play is that gesture.
+  const handlePlay = () => {
+    const graph = graphRef.current;
+    if (graph && graph.ctx.state === "suspended") graph.ctx.resume().catch(() => {});
+  };
+
+  if (!url) return null;
+
+  return (
+    <div className={className} style={style}>
+      <audio
+        key={url}
+        ref={audioRef}
+        src={url}
+        controls
+        preload="metadata"
+        crossOrigin="anonymous"
+        onPlay={handlePlay}
+        style={{ width: "100%" }}
+      >
+        Your browser does not support audio playback.
+      </audio>
+      {isSplit && (
+        <label
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginTop: 6,
+            fontSize: 11,
+            opacity: 0.75,
+          }}
+        >
+          <span style={{ whiteSpace: "nowrap" }}>Callee boost</span>
+          <input
+            type="range"
+            min={0}
+            max={MAX_CALLEE_BOOST_DB}
+            step={1}
+            value={calleeBoostDb}
+            onChange={(e) => setCalleeBoostDb(Number(e.target.value))}
+            aria-label="Callee boost in decibels"
+            style={{ flex: 1, minWidth: 80 }}
+          />
+          <span style={{ fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+            +{calleeBoostDb} dB
+          </span>
+        </label>
+      )}
+    </div>
+  );
+}

--- a/src/components/prospects/ProspectDetails.jsx
+++ b/src/components/prospects/ProspectDetails.jsx
@@ -10,6 +10,7 @@ import { format } from"date-fns";
 import { Clock, User, Edit2, ChevronLeft, UserPlus, Phone, Mail, Tag, Building, Headphones } from"lucide-react";
 import { Prospect as ProspectEntity, User as UserEntity } from"@/api/entities";
 import { apiClient } from"@/api/client";
+import CallRecordingPlayer from"@/components/prospects/CallRecordingPlayer";
 import ContactInfoCard from"@/components/prospects/details/ContactInfoCard";
 import ActivityTimeline from"@/components/prospects/details/ActivityTimeline";
 import QuizResultCard from"@/components/prospects/details/QuizResultCard";
@@ -42,6 +43,7 @@ export default function ProspectDetails({ prospect, campaigns, onStatusUpdate, o
  const [assignedAgentId, setAssignedAgentId] = useState(prospect.assigned_agent_id ||"");
  const [isAssigning, setIsAssigning] = useState(false);
  const [recordingUrl, setRecordingUrl] = useState(null);
+ const [recordingMultiChannelUrl, setRecordingMultiChannelUrl] = useState(null);
 
  useEffect(() => {
  let mounted = true;
@@ -67,6 +69,7 @@ export default function ProspectDetails({ prospect, campaigns, onStatusUpdate, o
  try {
  const rec = await apiClient.get(`/retell/recording/${prospect.id}`);
  if (mounted && rec.data?.recordingUrl) setRecordingUrl(rec.data.recordingUrl);
+ if (mounted && rec.data?.recordingMultiChannelUrl) setRecordingMultiChannelUrl(rec.data.recordingMultiChannelUrl);
  } catch (_) { /* no recording available */ }
  }
  } catch (_) { /* ignore */ }
@@ -271,10 +274,11 @@ export default function ProspectDetails({ prospect, campaigns, onStatusUpdate, o
  <Headphones className="w-3.5 h-3.5"/>
  Call Recording
  </Label>
- <audio controls preload="metadata" className="w-full h-10">
- <source src={recordingUrl} type="audio/wav"/>
- Your browser does not support audio playback.
- </audio>
+ <CallRecordingPlayer
+ src={recordingUrl}
+ multiChannelSrc={recordingMultiChannelUrl}
+ className="w-full"
+ />
  <p className="text-xs text-muted-foreground">
  {details?.sourceMetadata?.durationMs
  ? `Duration: ${Math.round(details.sourceMetadata.durationMs / 1000)}s`

--- a/src/components/prospects/__tests__/CallRecordingPlayer.test.jsx
+++ b/src/components/prospects/__tests__/CallRecordingPlayer.test.jsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import CallRecordingPlayer from '../CallRecordingPlayer';
+
+const MONO = 'https://cdn.retell/recording.wav';
+const SPLIT = 'https://cdn.retell/recording_multichannel.wav';
+
+/**
+ * Minimal Web Audio stand-in. jsdom ships no AudioContext, so the component's
+ * fallback path is what runs unless a test installs this.
+ */
+function installAudioContext() {
+  const gains = [];
+  const makeGain = () => {
+    const node = { gain: { value: 1 }, connect: vi.fn() };
+    gains.push(node);
+    return node;
+  };
+  const ctx = {
+    state: 'running',
+    destination: {},
+    close: vi.fn().mockResolvedValue(undefined),
+    resume: vi.fn().mockResolvedValue(undefined),
+    createMediaElementSource: vi.fn(() => ({ connect: vi.fn() })),
+    createChannelSplitter: vi.fn(() => ({ connect: vi.fn() })),
+    createChannelMerger: vi.fn(() => ({ connect: vi.fn() })),
+    createGain: vi.fn(makeGain),
+    createDynamicsCompressor: vi.fn(() => ({
+      threshold: {}, knee: {}, ratio: {}, attack: {}, release: {}, connect: vi.fn(),
+    })),
+  };
+  // Must be newable — the component calls `new AudioContext()`.
+  window.AudioContext = vi.fn(function AudioContextStub() { return ctx; });
+  // Gains are created callee-first, matching the component's wiring order.
+  return { ctx, calleeGain: () => gains[0], agentGain: () => gains[1] };
+}
+
+afterEach(() => {
+  delete window.AudioContext;
+  vi.restoreAllMocks();
+});
+
+describe('CallRecordingPlayer', () => {
+  it('renders nothing without a recording', () => {
+    const { container } = render(<CallRecordingPlayer />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('plays the mono mix untouched when there is no split recording', () => {
+    const { container } = render(<CallRecordingPlayer src={MONO} />);
+    expect(container.querySelector('audio')).toHaveAttribute('src', MONO);
+    expect(screen.queryByLabelText(/callee boost/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to plain playback of the split file when Web Audio is absent', () => {
+    const { container } = render(<CallRecordingPlayer src={MONO} multiChannelSrc={SPLIT} />);
+    // jsdom has no AudioContext — the split file still plays, just unboosted.
+    expect(container.querySelector('audio')).toHaveAttribute('src', SPLIT);
+    expect(screen.queryByLabelText(/callee boost/i)).not.toBeInTheDocument();
+  });
+
+  it('boosts the callee channel by +8 dB by default', async () => {
+    const audio = installAudioContext();
+    render(<CallRecordingPlayer src={MONO} multiChannelSrc={SPLIT} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/callee boost/i)).toBeInTheDocument());
+    // +8 dB and −2 dB in linear gain.
+    expect(audio.calleeGain().gain.value).toBeCloseTo(10 ** (8 / 20), 5);
+    expect(audio.agentGain().gain.value).toBeCloseTo(10 ** (-2 / 20), 5);
+    expect(screen.getByText('+8 dB')).toBeInTheDocument();
+  });
+
+  it('retunes the callee gain when the slider moves', async () => {
+    const audio = installAudioContext();
+    render(<CallRecordingPlayer src={MONO} multiChannelSrc={SPLIT} />);
+
+    const slider = await screen.findByLabelText(/callee boost/i);
+    // jsdom doesn't step a range input from arrow keys — drive its value directly.
+    fireEvent.change(slider, { target: { value: '10' } });
+
+    await waitFor(() => expect(audio.calleeGain().gain.value).toBeCloseTo(10 ** (10 / 20), 5));
+    expect(screen.getByText('+10 dB')).toBeInTheDocument();
+  });
+
+  it('resumes a suspended context on play so the graph is audible', async () => {
+    const audio = installAudioContext();
+    audio.ctx.state = 'suspended';
+    const { container } = render(<CallRecordingPlayer src={MONO} multiChannelSrc={SPLIT} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/callee boost/i)).toBeInTheDocument());
+    container.querySelector('audio').dispatchEvent(new Event('play'));
+    expect(audio.ctx.resume).toHaveBeenCalled();
+  });
+});

--- a/src/pages/adminv2/AdminV2LeadProfile.jsx
+++ b/src/pages/adminv2/AdminV2LeadProfile.jsx
@@ -25,6 +25,7 @@ import { STATUS_LABELS, SOURCE_LABELS, heldLabel } from '@/lib/adminV2/constants
 import { fmtDateTime, fmtDate, fmtDay, fmtSGDExact } from '@/lib/adminV2/format';
 import { Card, Chip, Skeleton, ErrorState, EmptyState } from '@/components/adminv2/primitives';
 import { rowChipFor } from '@/lib/adminV2/outcome';
+import CallRecordingPlayer from '@/components/prospects/CallRecordingPlayer';
 import {
   AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle,
   AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction,
@@ -822,7 +823,11 @@ export default function AdminV2LeadProfile() {
                           <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10.5, color: 'var(--ink-3)', marginRight: 8 }}>{fmtDateTime(a.startedAt).toUpperCase()}</span>
                           Attempt {i + 1} — {(a.outcome || 'attempted').replace(/_/g, ' ')}
                           {a.recordingUrl && (
-                            <audio controls preload="none" src={a.recordingUrl} style={{ width: '100%', height: 32, marginTop: 4 }} />
+                            <CallRecordingPlayer
+                              src={a.recordingUrl}
+                              multiChannelSrc={a.recordingMultiChannelUrl}
+                              style={{ marginTop: 4 }}
+                            />
                           )}
                         </div>
                       ))}
@@ -859,7 +864,11 @@ export default function AdminV2LeadProfile() {
                     </div>
                   )}
                   {p.sourceMetadata?.recordingUrl && (
-                    <audio controls preload="none" src={p.sourceMetadata.recordingUrl} style={{ width: '100%', height: 34, marginTop: 8 }} />
+                    <CallRecordingPlayer
+                      src={p.sourceMetadata.recordingUrl}
+                      multiChannelSrc={p.sourceMetadata.recordingMultiChannelUrl}
+                      style={{ marginTop: 8 }}
+                    />
                   )}
                 </div>
               </Card>


### PR DESCRIPTION
## What

Retell returns **two** recordings per call: the mono mix, and a split file where **ch0 is the callee, ch1 the agent**. We only ever stored the mono mix — in which the callee sits roughly **6 dB below** the agent. The leg you actually need to judge a screening call is the quiet one.

This captures `recording_multi_channel_url` alongside the mono URL and gives the admin player a per-channel gain control, so the callee can be lifted.

## Backfill behaviour

Prospects captured before this change hold a mono URL and **no multi-channel key at all**. They earn exactly **one** refetch to backfill it, and the key is written **even when Retell has no split file** — the key's *presence* is what ends the backfill, so it cannot re-loop.

## Provenance — this is a port, not a cherry-pick

The work was written on `fix/screening-audio-and-interruption` on **28 Jul** and never opened a PR. It had gone stale against main, so it was re-expressed rather than replayed:

| Stale as written | Ported to |
|---|---|
| `prospect.update({ sourceMetadata: { ...meta, … } })` — a whole-object read-spread-save | atomic single-key `setSourceMetadataPath` writes |
| unscoped `Prospect.findByPk(id)` | owner-scoped `findOne` through `buildProspectWhere`, caller required |

The first row matters: main **deliberately replaced** whole-object `sourceMetadata` writes with `prospectJsonPatch` (google-ads-signal-levers §4.3) because the read-spread-save silently deletes marker/fact keys another writer landed between load and save. Replaying the original commit would have reintroduced exactly that bug. Both new writes go through the atomic path.

`setSourceMetadataPath` also joins the service's DI surface, so the cache write is assertable in unit tests — it was previously untested on either path.

## Tests

- 3 new backend cases: cached-hit short-circuits without writing, legacy prospect backfills once, null split URL still settles the backfill
- 6 frontend cases for the player (existing, unchanged)
- **146 backend suites / 2437 tests**, **156 frontend files / 2026 tests**, eslint + typecheck clean