### PR TITLE
feat(ads): P2 — durable Meta/TikTok delivery outbox (platform_deliveries ledger, ships dark)

### DIFF
--- a/backend/env.example
+++ b/backend/env.example
@@ -746,8 +746,10 @@ GOOGLE_CM_SETTLE_INTERVAL_MINUTES=15
 GOOGLE_DM_TIMEOUT_MS=30000
 
 # --- Google offline outcomes (plan google-ads-signal-levers §4) ---
-# Master switch for the down-funnel events:ingest path + its workers +
-# the Lyfe outcome reconciler.
+# Master switch for the down-funnel events:ingest path + its workers.
+# (The Lyfe outcome reconciler is NO LONGER gated here — it runs whenever the
+# LYFE_SUPABASE_URL + LYFE_SUPABASE_SERVICE_ROLE_KEY credentials exist, since
+# its facts also feed the Meta delivery ledger — ads-centralisation §3.5.)
 GOOGLE_ADS_UPLOADS_ENABLED=false
 # Conversion-action ids (Ads UI import actions, UPLOAD_CLICKS, SECONDARY):
 # per-key worker preflight — a missing id aborts that key's pass, no marker.
@@ -765,3 +767,31 @@ GOOGLE_PENDING_MAX_DAYS=7
 GOOGLE_SEND_MAX_RETRIES=5
 GOOGLE_OUTCOMES_WORKER_MINUTES=10
 GOOGLE_LYFE_RECONCILE_INTERVAL_HOURS=6
+
+# --- Platform-delivery outbox (Meta/TikTok conversions, ads-centralisation §3) ---
+# SOLE control over delivery-row creation (origin eligibility decides WHICH
+# rows; the provider flags above gate sending only). Rows in ANY state own
+# their (prospect, platform, event) pair — legacy direct sends fire only for
+# pairs without rows. Ships dark: unset/false = byte-identical legacy behaviour.
+PLATFORM_DELIVERY_PLANNING_ENABLED=false
+# Ops brake: pauses send work (worker + inline). EXPIRY STILL RUNS — pausing
+# past the delivery deadlines expires those events; this is not cold storage.
+PLATFORM_DELIVERY_PAUSED=false
+# Worker cadence (offset 210s at boot). The hourly invariant sweep and daily
+# retention purge ride this tick.
+PLATFORM_DELIVERY_WORKER_MINUTES=5
+# RESERVED wire attempts per row (pre-wire reservation CAS enforces the cap).
+PLATFORM_DELIVERY_MAX_ATTEMPTS=8
+# Per-request send timeout — keep well under the 10-minute claim lease.
+PLATFORM_DELIVERY_HTTP_TIMEOUT_MS=20000
+# Dedupe-anchor horizons (hours): retries must stay inside the provider's
+# ~48h event-id dedupe window measured from the twin's fire time — lead
+# anchors on capture; CReg anchors on the browser reveal timestamp (fallback:
+# capture + the conservative fallback horizon when the submit carried none);
+# outcomes anchor on the canonical fact time (≤ Meta's 7d with margin).
+PLATFORM_DELIVERY_LEAD_HORIZON_HOURS=47
+PLATFORM_DELIVERY_CREG_HORIZON_HOURS=47
+PLATFORM_DELIVERY_CREG_FALLBACK_HORIZON_HOURS=24
+PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS=156
+# Terminal rows (sent/failed_permanent/expired/skipped) purge after this many days.
+PLATFORM_DELIVERY_RETENTION_DAYS=90

--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -148,6 +148,8 @@ export function validateEnv() {
     'LYFE_LEAD_SUPPRESSED_ENABLED', 'MKTR_LEADS_LEAD_SUPPRESSED_ENABLED',
     'SYNC_AGENT_CRON', 'WHATSAPP_QR_HEADER', 'ENABLE_AUTH_MAPPING',
     'META_LEAD_ADS_ENABLED', 'META_OAUTH_ENABLED',
+    'GOOGLE_ADS_UPLOADS_ENABLED', 'GOOGLE_CM_SYNC_ENABLED',
+    'PLATFORM_DELIVERY_PLANNING_ENABLED', 'PLATFORM_DELIVERY_PAUSED',
   ];
   const mistyped = booleanFlags.filter((k) => {
     const v = process.env[k];
@@ -155,6 +157,29 @@ export function validateEnv() {
   });
   if (mistyped.length > 0) {
     console.warn(`⚠️ Boolean flags with non-boolean values (treated as FALSE by === 'true' checks): ${mistyped.map((k) => `${k}="${process.env[k]}"`).join(', ')}`);
+  }
+
+  // Bounded numerics (ads-centralisation §8): consumers clamp out-of-bounds
+  // values into range at runtime, so a typo can't break delivery — but it CAN
+  // silently give you a different cadence/horizon than you wrote. Warn.
+  const numericBounds = [
+    ['PLATFORM_DELIVERY_WORKER_MINUTES', 1, 60],
+    ['PLATFORM_DELIVERY_MAX_ATTEMPTS', 1, 20],
+    ['PLATFORM_DELIVERY_HTTP_TIMEOUT_MS', 1000, 120000],
+    ['PLATFORM_DELIVERY_LEAD_HORIZON_HOURS', 1, 47],
+    ['PLATFORM_DELIVERY_CREG_HORIZON_HOURS', 1, 47],
+    ['PLATFORM_DELIVERY_CREG_FALLBACK_HORIZON_HOURS', 1, 24],
+    ['PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS', 1, 160],
+    ['PLATFORM_DELIVERY_RETENTION_DAYS', 7, 365],
+  ];
+  const badNumerics = numericBounds.filter(([k, min, max]) => {
+    const v = process.env[k];
+    if (v === undefined || v === '') return false;
+    const n = Number(v);
+    return !Number.isFinite(n) || n < min || n > max;
+  });
+  if (badNumerics.length > 0) {
+    console.warn(`⚠️ Numeric env vars out of bounds (runtime clamps into range): ${badNumerics.map(([k, min, max]) => `${k}="${process.env[k]}" (allowed ${min}–${max})`).join(', ')}`);
   }
 
   // ENABLE_AUTH_MAPPING auto-creates a local account (emailVerified: true) for

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -310,13 +310,10 @@ export async function bootstrapDatabase() {
     // (a) re-send — rows with a durable outcomes fact whose gads marker is
     //     absent or in a due retryWait;
     // (b) settle — due pending markers polled to terminal states (Google's
-    //     diagnostics window: first poll ~30min, up to 24h);
-    // (c) the Lyfe outcome reconciler — the durability net (pg_net never
-    //     retries) that also backfills pre-arc outcomes.
+    //     diagnostics window: first poll ~30min, up to 24h).
     // In-process single-flight; single-instance backend.
     if (process.env.GOOGLE_ADS_UPLOADS_ENABLED === 'true') {
       const workerMinutes = Math.max(1, Number(process.env.GOOGLE_OUTCOMES_WORKER_MINUTES) || 10);
-      const reconcileHours = Math.max(1, Number(process.env.GOOGLE_LYFE_RECONCILE_INTERVAL_HOURS) || 6);
       let outcomesInFlight = false;
       const runOutcomesWorker = async () => {
         if (outcomesInFlight) return;
@@ -331,6 +328,19 @@ export async function bootstrapDatabase() {
           outcomesInFlight = false;
         }
       };
+      setTimeout(runOutcomesWorker, 120_000);
+      setInterval(runOutcomesWorker, workerMinutes * 60 * 1000);
+      logger.info(`[GoogleOutcomes] workers scheduled (${workerMinutes}m worker)`);
+    }
+
+    // Lyfe outcome reconciler — CREDENTIALS-based, un-gated from the Google
+    // flag (ads-centralisation §3.5): it writes durable outcome FACTS
+    // (first-wins) that feed BOTH the Google worker (when enabled) and the
+    // Meta delivery ledger's invariant sweep, and it is the recovery net for
+    // a fully-failed facts+planning transaction (pg_net never retries). Meta
+    // outcome durability must never hang off a Google flag.
+    if (process.env.LYFE_SUPABASE_URL && process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY) {
+      const reconcileHours = Math.max(1, Number(process.env.GOOGLE_LYFE_RECONCILE_INTERVAL_HOURS) || 6);
       let reconcileInFlight = false;
       const runLyfeReconcile = async () => {
         if (reconcileInFlight) return; // a stalled REST pass must not overlap the next tick
@@ -344,13 +354,36 @@ export async function bootstrapDatabase() {
           reconcileInFlight = false;
         }
       };
-      setTimeout(runOutcomesWorker, 120_000);
-      setInterval(runOutcomesWorker, workerMinutes * 60 * 1000);
       setTimeout(runLyfeReconcile, 180_000);
       setInterval(runLyfeReconcile, reconcileHours * 60 * 60 * 1000);
-      logger.info(
-        `[GoogleOutcomes] workers scheduled (${workerMinutes}m worker, ${reconcileHours}h reconcile)`
-      );
+      logger.info(`[GoogleOutcomes] Lyfe reconciler scheduled (${reconcileHours}h, credentials-based)`);
+    }
+
+    // Platform-delivery worker (ads-centralisation §3.3.7): scheduled WHENEVER
+    // THE LEDGER EXISTS — deliberately not provider-flag-gated. With provider
+    // flags off, attempts classify config_blocked and the tick's EXPIRY pass
+    // still runs; PLATFORM_DELIVERY_PAUSED stops send work but never expiry.
+    // Cross-process single-flight via advisory lock 'pd:worker' inside the
+    // service; in-process single-flight here. The §3.5 invariant sweep and
+    // §3.6 retention purge ride the tick on hourly/daily sub-cadences.
+    {
+      const pdMinutes = Math.min(60, Math.max(1, Number(process.env.PLATFORM_DELIVERY_WORKER_MINUTES) || 5));
+      let pdInFlight = false;
+      const runPlatformDeliveryTick = async () => {
+        if (pdInFlight) return;
+        pdInFlight = true;
+        try {
+          const { runDeliveryWorker } = await import('../services/platformDeliveryService.js');
+          await runDeliveryWorker();
+        } catch (err) {
+          logger.warn('[PlatformDelivery] worker tick failed (non-fatal)', { error: err?.message });
+        } finally {
+          pdInFlight = false;
+        }
+      };
+      setTimeout(runPlatformDeliveryTick, 210_000);
+      setInterval(runPlatformDeliveryTick, pdMinutes * 60 * 1000);
+      logger.info(`[PlatformDelivery] worker scheduled (${pdMinutes}m interval, 210s offset)`);
     }
 
     // Redemption CAPI reconciliation sweep — the no-rescan safety net for

--- a/backend/src/database/migrations/126-platform-deliveries.js
+++ b/backend/src/database/migrations/126-platform-deliveries.js
@@ -1,0 +1,80 @@
+/**
+ * 126 — platform_deliveries: the durable Meta/TikTok conversion-delivery
+ * outbox (ads-centralisation §3.1). One row = one (prospect, platform,
+ * eventKey) delivery obligation, planned in the capture / outcome-fact
+ * transaction and drained by inline dispatch + the delivery worker.
+ * At-least-once with provider event-id dedupe; deadlines are anchored on
+ * dedupeAnchorAt (per-key) and firstWireAt (provider dedupe window).
+ *
+ * Pseudonymous personal data: rows join to a person via prospectId — they are
+ * hard-deleted in the erasure transaction (erasureService matrix) and
+ * terminal rows are purged after PLATFORM_DELIVERY_RETENTION_DAYS.
+ */
+
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('platform_deliveries', {
+    id: { type: Sequelize.UUID, defaultValue: Sequelize.literal('gen_random_uuid()'), primaryKey: true },
+    prospectId: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: { model: 'prospects', key: 'id' },
+      onDelete: 'CASCADE',
+    },
+    platform: { type: Sequelize.STRING(16), allowNull: false },
+    eventKey: { type: Sequelize.STRING(32), allowNull: false },
+    eventId: { type: Sequelize.STRING(64), allowNull: false },
+    // Occurrence time (CReg: the browser reveal timestamp when supplied).
+    eventTime: { type: Sequelize.DATE, allowNull: false },
+    // §1.3 anchor for the deadline formula (capture / reveal ts / fact time).
+    dedupeAnchorAt: { type: Sequelize.DATE, allowNull: false },
+    // Destination snapshot; set at planning when resolvable; immutable once non-null.
+    pixelId: { type: Sequelize.STRING(64), allowNull: true },
+    state: { type: Sequelize.STRING(16), allowNull: false, defaultValue: 'pending' },
+    // RESERVED wire attempts — incremented by the pre-wire reservation CAS.
+    sendAttempts: { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+    nextAttemptAt: { type: Sequelize.DATE, allowNull: true },
+    claimedAt: { type: Sequelize.DATE, allowNull: true },
+    claimToken: { type: Sequelize.UUID, allowNull: true },
+    firstWireAt: { type: Sequelize.DATE, allowNull: true },
+    lastAttemptAt: { type: Sequelize.DATE, allowNull: true },
+    sentAt: { type: Sequelize.DATE, allowNull: true },
+    lastStatus: { type: Sequelize.INTEGER, allowNull: true },
+    errorCode: { type: Sequelize.STRING(64), allowNull: true },
+    providerRequestId: { type: Sequelize.STRING(128), allowNull: true },
+    createdAt: { type: Sequelize.DATE, allowNull: false },
+    updatedAt: { type: Sequelize.DATE, allowNull: false },
+  });
+  await queryInterface.sequelize.query(
+    `CREATE UNIQUE INDEX IF NOT EXISTS uq_pd_prospect_platform_event ON platform_deliveries ("prospectId", platform, "eventKey")`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_pd_due ON platform_deliveries ("nextAttemptAt") WHERE state IN ('retry_wait','config_blocked')`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_pd_pending ON platform_deliveries ("createdAt") WHERE state = 'pending'`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_pd_stale ON platform_deliveries ("claimedAt") WHERE state = 'sending'`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_pd_sent ON platform_deliveries (platform, "sentAt")`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_pd_prospect ON platform_deliveries ("prospectId")`
+  );
+  await queryInterface.sequelize.query(
+    `ALTER TABLE platform_deliveries ADD CONSTRAINT chk_pd_platform CHECK (platform IN ('meta','tiktok'))`
+  );
+  await queryInterface.sequelize.query(
+    `ALTER TABLE platform_deliveries ADD CONSTRAINT chk_pd_state CHECK (state IN
+       ('pending','sending','sent','retry_wait','config_blocked','failed_permanent','expired','skipped'))`
+  );
+  await queryInterface.sequelize.query(
+    `ALTER TABLE platform_deliveries ADD CONSTRAINT chk_pd_event CHECK ("eventKey" IN
+       ('lead','complete_registration','confirmed_resident','closed_won'))`
+  );
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('platform_deliveries');
+}

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -207,6 +207,10 @@ export const schemas = {
     // CompleteRegistration dedup id — set when a quiz reveal fired the browser
     // CompleteRegistration; the server fires a matching CAPI event with this id.
     registrationEventId: Joi.string().max(64).optional(),
+    // The browser's quiz-reveal timestamp (stamped beside the id) — anchors
+    // the CReg delivery deadline (ads-centralisation §3.3.1). Server-clamped
+    // to ≤ now in prospectService; whitelisted here so stripUnknown keeps it.
+    registrationEventAt: Joi.string().isoDate().optional(),
     // Google Ads click ids (gclid/gbraid/wbraid) + the CAPTURE timestamp —
     // load-bearing for the offline-conversion age guard, which measures from
     // the click (capture lands minutes after it), never the outcome

--- a/backend/src/models/PlatformDelivery.js
+++ b/backend/src/models/PlatformDelivery.js
@@ -1,0 +1,39 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Durable Meta/TikTok conversion-delivery outbox row (migration 126,
+ * ads-centralisation §3). One row = one (prospect, platform, eventKey)
+ * delivery obligation. Row IN ANY STATE = ledger-owned (legacy direct
+ * senders must not fire for that pair); no row = legacy-eligible.
+ *
+ * States: pending → sending → sent | retry_wait | config_blocked |
+ * failed_permanent | expired | skipped. Terminal reasons live in errorCode.
+ * All state transitions happen through platformDeliveryService's fenced
+ * claim + claimToken CAS — never through plain model saves.
+ */
+const PlatformDelivery = sequelize.define('PlatformDelivery', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  prospectId: { type: DataTypes.UUID, allowNull: false },
+  platform: { type: DataTypes.STRING(16), allowNull: false },
+  eventKey: { type: DataTypes.STRING(32), allowNull: false },
+  eventId: { type: DataTypes.STRING(64), allowNull: false },
+  eventTime: { type: DataTypes.DATE, allowNull: false },
+  dedupeAnchorAt: { type: DataTypes.DATE, allowNull: false },
+  pixelId: { type: DataTypes.STRING(64), allowNull: true },
+  state: { type: DataTypes.STRING(16), allowNull: false, defaultValue: 'pending' },
+  sendAttempts: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+  nextAttemptAt: { type: DataTypes.DATE, allowNull: true },
+  claimedAt: { type: DataTypes.DATE, allowNull: true },
+  claimToken: { type: DataTypes.UUID, allowNull: true },
+  firstWireAt: { type: DataTypes.DATE, allowNull: true },
+  lastAttemptAt: { type: DataTypes.DATE, allowNull: true },
+  sentAt: { type: DataTypes.DATE, allowNull: true },
+  lastStatus: { type: DataTypes.INTEGER, allowNull: true },
+  errorCode: { type: DataTypes.STRING(64), allowNull: true },
+  providerRequestId: { type: DataTypes.STRING(128), allowNull: true },
+}, {
+  tableName: 'platform_deliveries',
+});
+
+export default PlatformDelivery;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -131,6 +131,12 @@ function defineAssociations() {
   ProspectActivity.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'CASCADE' });
   ProspectActivity.belongsTo(User, { foreignKey: 'actorUserId', as: 'actor', onDelete: 'SET NULL' });
 
+  // Platform-delivery outbox (migration 126, ads-centralisation §3) — durable
+  // Meta/TikTok conversion-delivery rows; CASCADE with their prospect.
+  const { PlatformDelivery } = models;
+  Prospect.hasMany(PlatformDelivery, { foreignKey: 'prospectId', as: 'platformDeliveries', onDelete: 'CASCADE' });
+  PlatformDelivery.belongsTo(Prospect, { foreignKey: 'prospectId', as: 'prospect', onDelete: 'CASCADE' });
+
   // ExternalAgent associations (MKTR Leads buyers — a separate table from `users`,
   // so Lyfe agent-sync can never see them). externalAgentId doubles as the webhook
   // destination signal: set => MKTR Leads subscriber; null => Lyfe subscriber.
@@ -403,7 +409,8 @@ export const {
   WaMessageStatus, WaMessageSend, ConsumerObservation, ConsumerProfile, EnrichmentJob,
   EnrichmentScoringConfig, EnrichmentSweepRun,
   MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection,
-  OutreachAccount, OutreachPersona, OutreachEmail, TimelineHiddenEntry
+  OutreachAccount, OutreachPersona, OutreachEmail, TimelineHiddenEntry,
+  PlatformDelivery
 } = models;
 
 export { sequelize };

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -408,6 +408,20 @@ export function makeErasureService(overrides = {}) {
           report.enrichmentJobs = rowCount(jobsMeta);
         }
 
+        // Platform-delivery ledger rows (ads-centralisation §3.6): pseudonymous
+        // delivery bookkeeping keyed to the person's prospects — hard-deleted
+        // in this transaction. An already-claimed in-flight attempt is fenced
+        // by the service's pre-wire fresh-erased re-check ("no NEW send begins
+        // after the check observes erasure"; an in-flight request can't be
+        // recalled — the Google posture).
+        if (pids.length) {
+          const [, pdMeta] = await d.sequelize.query(
+            `DELETE FROM platform_deliveries WHERE "prospectId" IN (:pids)`,
+            { replacements: { pids }, transaction: t }
+          );
+          report.platformDeliveries = rowCount(pdMeta);
+        }
+
         // The person's browsing records (Codex R1 #9): sessions + attribution
         // rows are deleted outright once no other prospect references them;
         // qr_scans keep only device-level aggregates (no person link left).

--- a/backend/src/services/googleOutcomesReconciler.js
+++ b/backend/src/services/googleOutcomesReconciler.js
@@ -38,7 +38,12 @@ const KEYS = { CR: 'confirmed_resident', CW: 'closed_won' };
 const defaultDeps = { Prospect, fetch: globalThis.fetch, mergeFirstWins };
 
 export function reconcilerConfigured() {
-  if (process.env.GOOGLE_ADS_UPLOADS_ENABLED !== 'true') return false;
+  // CREDENTIALS-based, deliberately NOT Google-flag-based (ads-centralisation
+  // §3.5): the reconciler writes durable outcome FACTS (first-wins) consumed
+  // by Google's worker AND the Meta delivery ledger's invariant sweep — Meta
+  // outcome durability must never hang off a Google flag. It is also the
+  // recovery net for a fully-failed facts+planning transaction (no fact, no
+  // row): it re-writes the fact, which the sweep then plans from.
   if (!process.env.LYFE_SUPABASE_URL) return false;
   if (!process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY) return false;
   return true;

--- a/backend/src/services/leadOutcomeService.js
+++ b/backend/src/services/leadOutcomeService.js
@@ -38,7 +38,7 @@
  * override, and that consent flag.
  */
 
-import { Prospect, Campaign } from '../models/index.js';
+import { Prospect, Campaign, sequelize } from '../models/index.js';
 import { setPath as setSourceMetadataPath, mergeFirstWins as mergeSourceMetadataFirstWins } from '../utils/prospectJsonPatch.js';
 import {
   dispatchOutcome as dispatchGoogleOutcome,
@@ -47,39 +47,27 @@ import {
 } from './googleOfflineConversionsService.js';
 import { sendConversionEvent as metaSendConversionEvent } from './metaCapiService.js';
 import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
+import { planOutcomeDeliveriesTx, dispatchOutcomeDelivery } from './platformDeliveryService.js';
+import { OUTCOME_EVENTS as EVENTS, eventNameFor, eventKeysForStatus } from './outcomeEvents.js';
 import { logger } from '../utils/logger.js';
 
 // CAPI events keyed by a stable internal id (NOT the Lyfe status), so event_id +
-// marker are consistent across the qualified/won triggers.
-const EVENTS = {
-  confirmed_resident: { envVar: 'META_EVENT_QUALIFIED', defaultName: 'ConfirmedResident', markerKey: 'confirmedResidentAt' },
-  closed_won: { envVar: 'META_EVENT_WON', defaultName: 'ClosedWon', markerKey: 'closedWonAt' },
-};
-
-/** Resolve the configured CAPI event_name for an internal event key (env-overridable). */
-export function eventNameFor(key) {
-  const e = EVENTS[key];
-  return e ? process.env[e.envVar] || e.defaultName : null;
-}
-
-/**
- * Ordered list of internal event keys a Lyfe status should emit.
- *   - qualified ("agent confirmed SC/PR") → ConfirmedResident
- *   - won (bought a policy; implies SC/PR) → ConfirmedResident (if new) + ClosedWon
- */
-export function eventKeysForStatus(status) {
-  if (status === 'qualified') return ['confirmed_resident'];
-  if (status === 'won') return ['confirmed_resident', 'closed_won'];
-  return [];
-}
+// marker are consistent across the qualified/won triggers. The vocabulary
+// (EVENTS map + eventNameFor + eventKeysForStatus) lives in outcomeEvents.js so
+// the platform-delivery ledger shares it without a static import cycle; the
+// re-exports below keep this module's public surface unchanged.
+export { eventNameFor, eventKeysForStatus };
 
 const realSleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 const defaultDeps = {
   models: { Prospect, Campaign },
+  sequelize,
   sendConversionEvent: metaSendConversionEvent,
   setSourceMetadataPath,
   mergeSourceMetadataFirstWins,
+  planOutcomeDeliveriesTx,
+  dispatchOutcomeDelivery,
   dispatchGoogleOutcome,
   googleUploadsEnabled,
   googleActionIdFor,
@@ -145,31 +133,48 @@ export function makeLeadOutcomeService(overrides = {}) {
     // never lose the outcome, and a later `won` can never rewrite an earlier
     // qualified timestamp. (The admin path writes the same facts inside its
     // edit transaction; this merge is idempotent against that.)
+    // The merge and the delivery-ledger planning share ONE managed transaction
+    // (ads-centralisation §3.3.2): the planner re-reads the PERSISTED facts
+    // in-txn, so rows and facts commit together — a row can never exist
+    // without its fact, and a replayed `won` can never retime an earlier
+    // confirmed_resident (the first-wins fact is the row's eventTime).
+    let erasedMidFlight = false;
     try {
-      const factRows = await d.mergeSourceMetadataFirstWins(
-        prospect.id,
-        ['outcomes'],
-        Object.fromEntries(keys.map((k) => [k, canonicalOccurredAt]))
-      );
-      if (factRows === 0) {
-        // The erased guard is the only thing that blocks a plain merge — a
-        // concurrent erasure won between our load and this write. Nothing
-        // may dispatch from the stale pre-erasure row (B2).
-        const fresh = await m.Prospect.findByPk(prospect.id, { raw: true });
-        if (!fresh || fresh.sourceMetadata?.erased === true) {
-          d.logger.warn('[lead-outcome] row erased mid-flight — dispatch aborted', {
-            prospectId: prospect.id,
-          });
-          return { skipped: 'erased' };
+      await d.sequelize.transaction(async (t) => {
+        const factRows = await d.mergeSourceMetadataFirstWins(
+          prospect.id,
+          ['outcomes'],
+          Object.fromEntries(keys.map((k) => [k, canonicalOccurredAt])),
+          { transaction: t }
+        );
+        if (factRows === 0) {
+          // The erased guard is the only thing that blocks a plain merge — a
+          // concurrent erasure won between our load and this write. Nothing
+          // may dispatch from the stale pre-erasure row (B2).
+          const fresh = await m.Prospect.findByPk(prospect.id, { raw: true, transaction: t });
+          if (!fresh || fresh.sourceMetadata?.erased === true) {
+            erasedMidFlight = true;
+            return;
+          }
         }
-      }
+        // Idempotent row planning from the persisted facts. A planning
+        // failure rolls the whole txn back into the catch below — today's
+        // error path (webhook still 200s); the durability net for a fully-
+        // failed txn (no fact, no row) is the credentials-based Lyfe
+        // reconciler (§3.5), which re-writes the fact for the invariant
+        // sweep to plan from.
+        await d.planOutcomeDeliveriesTx(t, { prospectId: prospect.id, keys });
+      });
     } catch (factErr) {
-      // A fact-write failure is the ONLY unrecoverable branch on the Lyfe
-      // path (pg_net never retries) — the Lyfe reconciler is the durability
-      // net. Loudly logged; dispatch still proceeds with in-memory values.
-      d.logger.error('[lead-outcome] outcome fact write failed (reconciler heals)', {
+      d.logger.error('[lead-outcome] outcome facts+planning transaction failed (reconciler heals)', {
         prospectId: prospect.id, error: factErr?.message || String(factErr),
       });
+    }
+    if (erasedMidFlight) {
+      d.logger.warn('[lead-outcome] row erased mid-flight — dispatch aborted', {
+        prospectId: prospect.id,
+      });
+      return { skipped: 'erased' };
     }
 
     // Send-time em/ph gate (3sites, supersedes the PR B clone hack): derived
@@ -222,21 +227,39 @@ export function makeLeadOutcomeService(overrides = {}) {
       const metaDuplicate = Boolean(prospect.sourceMetadata?.capi?.[markerKey]);
       if (metaDuplicate) duplicate.push(eventName);
 
-      const ctx = {
-        // Stable across qualified/won → Meta dedups any duplicate send.
-        eventId: `${key}:${prospect.id}`,
-        eventTime,
-        marketingConsent,
-        ...(pixelIdOverride ? { pixelIdOverride } : {}),
-      };
+      // Row-ownership routing (ads-centralisation §3.2/§3.3.5): a ledger row
+      // in ANY state owns this (prospect, meta, key) pair — the delivery
+      // service attempts it (or leaves it to the worker) and the result maps
+      // onto this function's legacy return contract. No row ⇒ the PERMANENT
+      // legacy direct-send block below (planning off / marker-aware skip /
+      // failed planning transaction).
+      let ledgerOutcome = null;
+      let result = null;
+      if (!metaDuplicate) {
+        const led = await d.dispatchOutcomeDelivery({ prospectId: prospect.id, key, marketingConsent });
+        if (led.owned) {
+          ledgerOutcome = led.legacyOutcome;
+        } else {
+          const ctx = {
+            // Stable across qualified/won → Meta dedups any duplicate send.
+            eventId: `${key}:${prospect.id}`,
+            eventTime,
+            marketingConsent,
+            ...(pixelIdOverride ? { pixelIdOverride } : {}),
+          };
+          result = await dispatchWithRetry(prospect, ctx, { eventName });
+        }
+      }
 
-      const result = metaDuplicate ? null : await dispatchWithRetry(prospect, ctx, { eventName });
+      if (ledgerOutcome === 'dispatched') dispatched.push(eventName);
+      if (ledgerOutcome === 'duplicate') duplicate.push(eventName);
 
-      if (!metaDuplicate && result?.sent) {
+      if (!metaDuplicate && !ledgerOutcome && result?.sent) {
         // Atomic single-key marker write (prospectJsonPatch) — the old
         // read-spread-save of the whole object could delete keys any OTHER
         // writer (google markers, outcome facts, redemption) landed between
         // this handler's load and save (plan google-ads-signal-levers §4.3).
+        // (Ledger sends write this marker inside their settle transaction.)
         await d.setSourceMetadataPath(prospect.id, ['capi', markerKey], new Date().toISOString());
         dispatched.push(eventName);
       }
@@ -259,7 +282,21 @@ export function makeLeadOutcomeService(overrides = {}) {
         }
       }
 
-      if (!metaDuplicate && !result?.sent) {
+      if (ledgerOutcome && ledgerOutcome !== 'dispatched' && ledgerOutcome !== 'duplicate') {
+        // Ledger-owned but not delivered on this pass — the row (or the
+        // worker) governs the retry; the classification preserves the
+        // external path's 503-on-transient contract.
+        failed.push(eventName);
+        if (ledgerOutcome === 'guarded') guarded.push(eventName);
+        else if (ledgerOutcome === 'transientFailed') transientFailed.push(eventName);
+        else permanentFailed.push(eventName);
+        d.logger.warn(
+          { prospect_id: prospect.id, event_name: eventName, ledger_outcome: ledgerOutcome },
+          '[lead-outcome] ledger dispatch not sent (row governs retry)'
+        );
+      }
+
+      if (!metaDuplicate && !ledgerOutcome && !result?.sent) {
         // Not marked → reconciliation / next trigger can retry. (`guarded` = CAPI off.)
         failed.push(eventName);
         if (result?.reason === 'guarded') {

--- a/backend/src/services/metaCapiService.js
+++ b/backend/src/services/metaCapiService.js
@@ -156,10 +156,15 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
     const body = await res.json().catch(() => ({}));
 
     if (!res.ok) {
-      Sentry.captureException(new Error(`CAPI dispatch failed: HTTP ${res.status}`), {
-        tags: { source: 'capi', event_name: eventName },
-        extra: { status: res.status, body, prospect_id: prospect.id },
-      });
+      // suppressSentry: the platform-delivery ledger classifies failures and
+      // alerts once per row itself — its retries must not multiply captures.
+      // Default off: every legacy caller keeps per-attempt captures.
+      if (!options.suppressSentry) {
+        Sentry.captureException(new Error(`CAPI dispatch failed: HTTP ${res.status}`), {
+          tags: { source: 'capi', event_name: eventName },
+          extra: { status: res.status, body, prospect_id: prospect.id },
+        });
+      }
       logger.warn(
         { status: res.status, body, prospect_id: prospect.id, event_id: ctx.eventId },
         `capi.${logLabel}.failed`
@@ -178,10 +183,12 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
     );
     return { sent: true, status: res.status, body };
   } catch (err) {
-    Sentry.captureException(err, {
-      tags: { source: 'capi', event_name: eventName },
-      extra: { prospect_id: prospect.id, event_id: ctx.eventId },
-    });
+    if (!options.suppressSentry) {
+      Sentry.captureException(err, {
+        tags: { source: 'capi', event_name: eventName },
+        extra: { prospect_id: prospect.id, event_id: ctx.eventId },
+      });
+    }
     logger.error({ err: err.message, prospect_id: prospect.id }, `capi.${logLabel}.error`);
     return { sent: false, error: err.message };
   }

--- a/backend/src/services/outcomeEvents.js
+++ b/backend/src/services/outcomeEvents.js
@@ -1,0 +1,33 @@
+/**
+ * Down-funnel outcome-event vocabulary — the ONE mapping from internal outcome
+ * keys (`confirmed_resident`/`closed_won`) to their Meta CAPI event names
+ * (env-overridable) and their mark-on-success marker keys under
+ * sourceMetadata.capi.
+ *
+ * Extracted verbatim from leadOutcomeService (ads-centralisation §3.3.2) so
+ * the platform-delivery ledger can consume the same vocabulary without a
+ * static import cycle: leadOutcomeService → platformDeliveryService → here.
+ * leadOutcomeService re-exports eventNameFor/eventKeysForStatus, so existing
+ * importers are unchanged.
+ */
+export const OUTCOME_EVENTS = {
+  confirmed_resident: { envVar: 'META_EVENT_QUALIFIED', defaultName: 'ConfirmedResident', markerKey: 'confirmedResidentAt' },
+  closed_won: { envVar: 'META_EVENT_WON', defaultName: 'ClosedWon', markerKey: 'closedWonAt' },
+};
+
+/** Resolve the configured CAPI event_name for an internal event key (env-overridable). */
+export function eventNameFor(key) {
+  const e = OUTCOME_EVENTS[key];
+  return e ? process.env[e.envVar] || e.defaultName : null;
+}
+
+/**
+ * Ordered list of internal event keys a Lyfe status should emit.
+ *   - qualified ("agent confirmed SC/PR") → ConfirmedResident
+ *   - won (bought a policy; implies SC/PR) → ConfirmedResident (if new) + ClosedWon
+ */
+export function eventKeysForStatus(status) {
+  if (status === 'qualified') return ['confirmed_resident'];
+  if (status === 'won') return ['confirmed_resident', 'closed_won'];
+  return [];
+}

--- a/backend/src/services/platformDeliveryService.js
+++ b/backend/src/services/platformDeliveryService.js
@@ -1,0 +1,902 @@
+import { randomUUID } from 'crypto';
+import * as Sentry from '@sentry/node';
+import { sequelize, Prospect, Campaign, PlatformDelivery } from '../models/index.js';
+import { sendConversionEvent as metaSendConversionEvent } from './metaCapiService.js';
+import { sendConversionEvent as tiktokSendConversionEvent } from './tiktokEventsService.js';
+import { eventNameFor, OUTCOME_EVENTS } from './outcomeEvents.js';
+import { canMarketTo as ledgerCanMarketTo } from './consentService.js';
+import { setPath as setSourceMetadataPath } from '../utils/prospectJsonPatch.js';
+import { withAdvisoryLock } from '../utils/advisoryLock.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * platformDeliveryService — the durable Meta/TikTok conversion-delivery outbox
+ * (ads-centralisation §3). One table (`platform_deliveries`), one state
+ * machine, one worker. Guarantee: AT-LEAST-ONCE with provider event-id dedupe,
+ * inside wire-anchored deadlines that keep every retry within the provider's
+ * ~48h event-id dedupe window (§1.3).
+ *
+ * Row-ownership routing (§3.2): per (prospect, platform, eventKey), a row in
+ * ANY state means the ledger owns delivery and the legacy direct senders must
+ * not fire; no row means legacy-eligible. Ownership is queried across ALL
+ * states — never inferred from the pending subset.
+ *
+ * Controls:
+ *  - PLATFORM_DELIVERY_PLANNING_ENABLED — SOLE control over row creation
+ *    (origin eligibility decides WHICH rows; provider flags gate sending only).
+ *  - PLATFORM_DELIVERY_PAUSED — pauses send work (worker + inline). Expiry
+ *    still runs: pausing past the deadlines EXPIRES events (ops brake, not
+ *    cold storage — §3.2, stated plainly).
+ *
+ * State machine: pending → sending → sent | retry_wait | config_blocked |
+ * failed_permanent | expired | skipped. Claims are fenced (claimToken) and
+ * never touch sendAttempts; the pre-wire reservation CAS is what burns an
+ * attempt (§3.3.3–.4). Terminal reasons live in errorCode.
+ */
+
+const PLATFORMS = ['meta', 'tiktok'];
+const SUBMIT_KEYS = ['lead', 'complete_registration'];
+export const OUTCOME_KEYS = Object.keys(OUTCOME_EVENTS); // confirmed_resident, closed_won
+const TERMINAL_STATES = ['sent', 'failed_permanent', 'expired', 'skipped'];
+const STALE_LEASE_SQL = `interval '10 minutes'`;
+const STALE_LEASE_MS = 10 * 60 * 1000;
+const CONFIG_BLOCKED_RETRY_MS = 30 * 60 * 1000;
+const WIRE_DEDUPE_WINDOW_HOURS = 47; // firstWireAt + 47h ≤ the provider's ~48h event-id window
+
+function numEnv(name, def, min, max) {
+  const raw = Number(process.env[name]);
+  if (!Number.isFinite(raw)) return def;
+  return Math.min(max, Math.max(min, raw));
+}
+
+export function planningEnabled() {
+  return process.env.PLATFORM_DELIVERY_PLANNING_ENABLED === 'true';
+}
+
+export function deliveryPaused() {
+  return process.env.PLATFORM_DELIVERY_PAUSED === 'true';
+}
+
+const maxAttempts = () => numEnv('PLATFORM_DELIVERY_MAX_ATTEMPTS', 8, 1, 20);
+const httpTimeoutMs = () => numEnv('PLATFORM_DELIVERY_HTTP_TIMEOUT_MS', 20000, 1000, 120000);
+
+/**
+ * Per-key dedupe-anchor horizon (hours). CReg is anchored on the browser
+ * reveal timestamp when the submit carried one (sourceMetadata
+ * .registrationEventAt); without it the anchor is capture time with the
+ * CONSERVATIVE fallback horizon (legacy cached bundles) — §1.3.
+ */
+export function keyHorizonHours(eventKey, { hasRegistrationAnchor = false } = {}) {
+  if (eventKey === 'lead') return numEnv('PLATFORM_DELIVERY_LEAD_HORIZON_HOURS', 47, 1, 47);
+  if (eventKey === 'complete_registration') {
+    return hasRegistrationAnchor
+      ? numEnv('PLATFORM_DELIVERY_CREG_HORIZON_HOURS', 47, 1, 47)
+      : numEnv('PLATFORM_DELIVERY_CREG_FALLBACK_HORIZON_HOURS', 24, 1, 24);
+  }
+  return numEnv('PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS', 156, 1, 160);
+}
+
+/**
+ * Deadline (epoch ms) past which a row must EXPIRE rather than retry:
+ * min(dedupeAnchorAt + keyHorizon, firstWireAt + 47h) — §1.3/§3.3.4. Once a
+ * wire attempt happened, later retries must stay inside the provider's
+ * event-id window measured from OUR first wire, whatever the anchor allows.
+ */
+export function computeDeadlineMs({ eventKey, dedupeAnchorAt, firstWireAt, hasRegistrationAnchor = false }) {
+  const H = 3600 * 1000;
+  const anchorDeadline =
+    new Date(dedupeAnchorAt).getTime() + keyHorizonHours(eventKey, { hasRegistrationAnchor }) * H;
+  const wireDeadline = firstWireAt ? new Date(firstWireAt).getTime() + WIRE_DEDUPE_WINDOW_HOURS * H : Infinity;
+  return Math.min(anchorDeadline, wireDeadline);
+}
+
+/**
+ * Origin eligibility (§3.2/§0): Retell and Meta-Lead-Ads prospects are
+ * origin-excluded from the ledger exactly as they are from the legacy senders
+ * (shouldFireCapi / shouldFireTikTok origin arm).
+ */
+export function originEligible(prospect) {
+  if (!prospect) return false;
+  if (prospect.leadSource === 'call_bot') return false;
+  if (prospect.retellCallId) return false;
+  if (prospect.sourceMetadata?.metaLeadgenId) return false;
+  return true;
+}
+
+/** Should capture-time planning run for this prospect? (flag ∧ origin) */
+export function submitPlanningApplies({ prospect }) {
+  return planningEnabled() && originEligible(prospect);
+}
+
+function platformEnvPixelId(platform) {
+  return platform === 'meta' ? process.env.META_PIXEL_ID : process.env.TIKTOK_PIXEL_ID;
+}
+
+function campaignPixelId(platform, campaign) {
+  if (!campaign) return null;
+  return (platform === 'meta' ? campaign.metaPixelId : campaign.tiktokPixelId) || null;
+}
+
+/** Destination snapshot at planning: campaign pixel → env pixel → NULL (§3.3.1). */
+function snapshotPixelId(platform, campaign) {
+  return campaignPixelId(platform, campaign) || platformEnvPixelId(platform) || null;
+}
+
+/** Is the platform's sender configured (master flag + token)? Sending-only gate. */
+export function platformConfigured(platform) {
+  if (platform === 'meta') {
+    return process.env.META_CAPI_ENABLED === 'true' && Boolean(process.env.META_CAPI_ACCESS_TOKEN);
+  }
+  return process.env.TIKTOK_EVENTS_API_ENABLED === 'true' && Boolean(process.env.TIKTOK_ACCESS_TOKEN);
+}
+
+function eventNameForKey(eventKey) {
+  if (eventKey === 'lead') return 'Lead';
+  if (eventKey === 'complete_registration') return 'CompleteRegistration';
+  return eventNameFor(eventKey);
+}
+
+// ---------------------------------------------------------------------------
+// Planning
+// ---------------------------------------------------------------------------
+
+/**
+ * Plan the submit-time delivery rows (§3.3.1) inside the caller's SAVEPOINT
+ * (prospectCreateTx wraps this in a nested transaction — a planning failure
+ * must never fail capture; the caller then leaves this prospect to the legacy
+ * direct senders).
+ *
+ * eventTime/dedupeAnchorAt: lead = now/now; complete_registration = the
+ * browser-supplied reveal timestamp (registrationEventAt) for BOTH — absent ⇒
+ * capture time (the conservative CReg fallback horizon then applies at
+ * deadline time, keyed off the missing sourceMetadata.registrationEventAt).
+ */
+export async function planSubmitDeliveriesTx(t, { prospect, sourceCampaign, eventId, registrationEventId, registrationEventAt }) {
+  if (!submitPlanningApplies({ prospect })) return { planned: false };
+  if (!eventId) {
+    // Intake server-generates a UUID when the client omitted one (§3.3.1), so
+    // this is a wiring bug, not a data condition — fail the savepoint loudly.
+    throw new Error('planSubmitDeliveriesTx: eventId is required');
+  }
+  const now = new Date();
+  const regAnchorMs = registrationEventAt ? Date.parse(registrationEventAt) : NaN;
+  const regAnchor = Number.isNaN(regAnchorMs) ? null : new Date(Math.min(regAnchorMs, now.getTime()));
+  const rows = [];
+  for (const platform of PLATFORMS) {
+    rows.push({
+      prospectId: prospect.id,
+      platform,
+      eventKey: 'lead',
+      eventId,
+      eventTime: now,
+      dedupeAnchorAt: now,
+      pixelId: snapshotPixelId(platform, sourceCampaign),
+      state: 'pending',
+    });
+    if (registrationEventId) {
+      rows.push({
+        prospectId: prospect.id,
+        platform,
+        eventKey: 'complete_registration',
+        eventId: registrationEventId,
+        eventTime: regAnchor || now,
+        dedupeAnchorAt: regAnchor || now,
+        pixelId: snapshotPixelId(platform, sourceCampaign),
+        state: 'pending',
+      });
+    }
+  }
+  await PlatformDelivery.bulkCreate(rows, { transaction: t });
+  return { planned: true, rows: rows.length };
+}
+
+/**
+ * Plan Meta outcome delivery rows (§3.3.2) — the ONE shared in-txn helper for
+ * all three outcome entry points (admin edit txn, processLeadOutcome's managed
+ * txn, the invariant sweep). Takes NO timestamp: it re-reads the prospect
+ * inside the caller's transaction and uses each key's PERSISTED winning fact
+ * as eventTime/dedupeAnchorAt — an admin `won` replay can never stamp a later
+ * time onto an older confirmed_resident fact. Aborts on erased / absent fact;
+ * skips keys whose exact legacy marker exists (old-binary sends are not
+ * re-planned). Idempotent (ON CONFLICT DO NOTHING). TikTok outcome rows never
+ * exist (§3).
+ */
+export async function planOutcomeDeliveriesTx(t, { prospectId, keys, campaign }) {
+  if (!planningEnabled()) return { planned: false, reason: 'flag_off' };
+  const validKeys = (keys || []).filter((k) => OUTCOME_KEYS.includes(k));
+  if (!validKeys.length) return { planned: false, reason: 'no_keys' };
+  const prospect = await Prospect.findByPk(prospectId, { transaction: t, raw: true });
+  if (!prospect) return { planned: false, reason: 'no_prospect' };
+  if (prospect.sourceMetadata?.erased === true) return { planned: false, reason: 'erased' };
+  if (!originEligible(prospect)) return { planned: false, reason: 'origin_excluded' };
+
+  let resolvedCampaign = campaign;
+  if (resolvedCampaign === undefined && prospect.campaignId) {
+    resolvedCampaign = await Campaign.findByPk(prospect.campaignId, { transaction: t, raw: true });
+  }
+
+  const facts = prospect.sourceMetadata?.outcomes || {};
+  const markers = prospect.sourceMetadata?.capi || {};
+  let inserted = 0;
+  for (const key of validKeys) {
+    const factMs = facts[key] ? Date.parse(facts[key]) : NaN;
+    if (Number.isNaN(factMs)) continue; // absent/unparseable persisted fact ⇒ plan nothing for this key
+    if (markers[OUTCOME_EVENTS[key].markerKey]) continue; // exact legacy marker ⇒ already delivered pre-ledger
+    // Raw INSERT names "createdAt"/"updatedAt" explicitly (house rule — the
+    // baseline declares them NOT NULL with no database default).
+    const [, meta] = await sequelize.query(
+      `INSERT INTO platform_deliveries
+         (id, "prospectId", platform, "eventKey", "eventId", "eventTime", "dedupeAnchorAt", "pixelId",
+          state, "sendAttempts", "createdAt", "updatedAt")
+       VALUES
+         (gen_random_uuid(), :prospectId, 'meta', :eventKey, :eventId, :eventTime, :eventTime, :pixelId,
+          'pending', 0, now(), now())
+       ON CONFLICT ("prospectId", platform, "eventKey") DO NOTHING`,
+      {
+        replacements: {
+          prospectId,
+          eventKey: key,
+          eventId: `${key}:${prospectId}`,
+          eventTime: new Date(factMs),
+          pixelId: snapshotPixelId('meta', resolvedCampaign),
+        },
+        transaction: t,
+      }
+    );
+    // Sequelize returns the affected count for INSERT as a bare number
+    // (UPDATE/DELETE metadata carries .rowCount instead).
+    inserted += typeof meta === 'number' ? meta : (meta?.rowCount ?? 0);
+  }
+  return { planned: true, inserted };
+}
+
+// ---------------------------------------------------------------------------
+// Claim + settle primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Fenced claim (§3.3.3): due pending/retry_wait/config_blocked rows, or a
+ * STALE sending lease. Never touches sendAttempts. Returns { row, token } or
+ * null on a claim miss.
+ */
+async function claimDelivery(id) {
+  const token = randomUUID();
+  const [rows] = await sequelize.query(
+    `UPDATE platform_deliveries
+        SET state = 'sending', "claimedAt" = now(), "claimToken" = :token, "updatedAt" = now()
+      WHERE id = :id AND (
+        (state IN ('pending','retry_wait','config_blocked') AND ("nextAttemptAt" IS NULL OR "nextAttemptAt" <= now()))
+        OR (state = 'sending' AND "claimedAt" < now() - ${STALE_LEASE_SQL})
+      )
+      RETURNING *`,
+    { replacements: { id, token } }
+  );
+  return rows?.[0] ? { row: rows[0], token } : null;
+}
+
+/**
+ * CAS transition out of `sending`, fenced on the claim token. Returns whether
+ * the transition applied (false = a reclaimer owns the row now; the caller's
+ * result is discarded — the reclaimer's own attempt governs).
+ */
+async function settleFromSending(id, token, fields, { transaction } = {}) {
+  const cols = {
+    nextAttemptAt: '"nextAttemptAt"',
+    sentAt: '"sentAt"',
+    lastStatus: '"lastStatus"',
+    errorCode: '"errorCode"',
+    providerRequestId: '"providerRequestId"',
+  };
+  const sets = ['state = :state', '"updatedAt" = now()'];
+  const replacements = { id, token, state: fields.state };
+  for (const [key, col] of Object.entries(cols)) {
+    if (key in fields) {
+      sets.push(`${col} = :${key}`);
+      replacements[key] = fields[key];
+    }
+  }
+  const [, meta] = await sequelize.query(
+    `UPDATE platform_deliveries SET ${sets.join(', ')}
+      WHERE id = :id AND state = 'sending' AND "claimToken" = :token`,
+    { replacements, transaction }
+  );
+  return (meta?.rowCount ?? 0) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Send-result classification (§3.3.4.7 taxonomy)
+// ---------------------------------------------------------------------------
+
+const META_AUTH_CODES = new Set([190, 102, 104]);
+// TikTok auth-class: HTTP 401/403, or the 401xx access-token body codes the
+// Business API returns (sometimes on HTTP 200).
+const TIKTOK_AUTH_CODES = new Set([40100, 40101, 40102, 40103, 40104, 40105]);
+
+/**
+ * Normalize a sender result ({ sent, status?, body?, error?, reason? }) into
+ * a settle decision. Pure — unit-tested as the settle taxonomy.
+ */
+export function classifySendResult(platform, result, { retryAfterMs = null } = {}) {
+  if (result?.sent) {
+    return {
+      kind: 'sent',
+      status: result.status ?? null,
+      providerRequestId:
+        (platform === 'meta' ? result.body?.fbtrace_id : result.body?.request_id) || null,
+    };
+  }
+  // Sender-internal guards (defensive — config is checked before the wire).
+  if (result?.reason === 'guarded' || result?.reason === 'no_pixel_id') {
+    return { kind: 'config_blocked', errorCode: result.reason };
+  }
+  // Network / timeout (AbortError lands here via the sender's catch).
+  if (result?.error != null) {
+    return { kind: 'retry_wait', errorCode: 'network', retryAfterMs };
+  }
+  const status = typeof result?.status === 'number' ? result.status : null;
+  if (status !== null) {
+    if (status >= 500 || status === 408 || status === 429) {
+      return {
+        kind: 'retry_wait',
+        errorCode: status >= 500 ? 'http_5xx' : `http_${status}`,
+        retryAfterMs,
+        status,
+      };
+    }
+    if (platform === 'tiktok' && (status === 401 || status === 403 || TIKTOK_AUTH_CODES.has(result?.body?.code))) {
+      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, status };
+    }
+    if (platform === 'meta' && status >= 400 && META_AUTH_CODES.has(result?.body?.error?.code)) {
+      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, status };
+    }
+    if (status >= 400) {
+      return { kind: 'failed_permanent', errorCode: 'http_4xx', status };
+    }
+    // 2xx with sent=false: TikTok logical failure (body.code !== 0).
+    return { kind: 'failed_permanent', errorCode: 'logical_reject', status };
+  }
+  return { kind: 'failed_permanent', errorCode: 'unknown' };
+}
+
+/**
+ * Retry backoff (ms): min(60s·2^(sendAttempts−1), 1h) + jitter ≤30s;
+ * auth-class uses the long ladder 30min·2^(n−1) capped at 4h (no jitter);
+ * a provider Retry-After extends (never shortens) the wait. Pure.
+ */
+export function computeBackoffMs(sendAttempts, { authClass = false, retryAfterMs = null, jitterRatio } = {}) {
+  const n = Math.max(1, sendAttempts);
+  let ms;
+  if (authClass) {
+    ms = Math.min(30 * 60_000 * 2 ** (n - 1), 4 * 3600_000);
+  } else {
+    const jitter = Math.floor((jitterRatio ?? Math.random()) * 30_000);
+    ms = Math.min(60_000 * 2 ** (n - 1), 3600_000) + jitter;
+  }
+  if (retryAfterMs != null && Number.isFinite(retryAfterMs)) ms = Math.max(ms, retryAfterMs);
+  return ms;
+}
+
+/** Parse a Retry-After header (delta-seconds or HTTP-date) into ms. */
+export function parseRetryAfterMs(value, now = Date.now()) {
+  if (!value) return null;
+  const secs = Number(value);
+  if (Number.isFinite(secs)) return Math.max(0, Math.floor(secs * 1000));
+  const at = Date.parse(value);
+  return Number.isNaN(at) ? null : Math.max(0, at - now);
+}
+
+/**
+ * Injected-fetch adapter (§3.3.6): enforces PLATFORM_DELIVERY_HTTP_TIMEOUT_MS
+ * via AbortController (20s default — well under the 10-min claim lease) and
+ * captures Retry-After out-of-band for the settle classification.
+ */
+function makeDeliveryFetch(capture) {
+  const timeoutMs = httpTimeoutMs();
+  return async (url, opts = {}) => {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { ...opts, signal: ac.signal });
+      capture.retryAfterMs = parseRetryAfterMs(res.headers?.get?.('retry-after'));
+      return res;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The per-row attempt pipeline (§3.3.4)
+// ---------------------------------------------------------------------------
+
+const defaultSendDeps = {
+  canMarketTo: ledgerCanMarketTo,
+  metaSend: metaSendConversionEvent,
+  tiktokSend: tiktokSendConversionEvent,
+  setSourceMetadataPath,
+  fetch: null, // null ⇒ per-attempt instrumented fetch
+  jitterRatio: undefined,
+};
+
+/**
+ * Attempt ONE delivery end-to-end: fenced claim → rescreen → deadline →
+ * config → consent → final erased check → pre-wire reservation → send →
+ * settle. Returns { outcome, ... } where outcome ∈ 'sent' | 'retry_wait' |
+ * 'config_blocked' | 'failed_permanent' | 'expired' | 'skipped' |
+ * 'claim_miss' | 'paused'.
+ *
+ * marketingConsent: pass a snapshot for inline batches (one canMarketTo per
+ * batch — §3.3.4.4); omit for worker retries (fresh per-row read).
+ */
+export async function processDelivery(id, { marketingConsent, deps = {} } = {}) {
+  const d = { ...defaultSendDeps, ...deps };
+  if (deliveryPaused()) return { outcome: 'paused' };
+
+  const claimed = await claimDelivery(id);
+  if (!claimed) {
+    const current = await PlatformDelivery.findByPk(id, { raw: true });
+    return { outcome: 'claim_miss', state: current?.state || null };
+  }
+  const { row, token } = claimed;
+  const isOutcomeKey = OUTCOME_KEYS.includes(row.eventKey);
+
+  // 1. Rescreen: reload prospect (+ campaign only when the destination is unpinned).
+  const prospect = await Prospect.findByPk(row.prospectId, { raw: true });
+  if (!prospect) {
+    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'no_prospect' });
+    return { outcome: 'skipped', errorCode: 'no_prospect' };
+  }
+  if (prospect.sourceMetadata?.erased === true) {
+    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
+    return { outcome: 'skipped', errorCode: 'erased' };
+  }
+  let campaign = null;
+  if (!row.pixelId && prospect.campaignId) {
+    campaign = await Campaign.findByPk(prospect.campaignId, { raw: true });
+  }
+
+  // 2. Deadline (anchor + wire window). A past-deadline claimed row expires
+  //    under OUR OWN lease — the §3.3.7 rule protects other holders' leases.
+  const hasRegistrationAnchor = Boolean(prospect.sourceMetadata?.registrationEventAt);
+  const deadlineMs = computeDeadlineMs({
+    eventKey: row.eventKey,
+    dedupeAnchorAt: row.dedupeAnchorAt,
+    firstWireAt: row.firstWireAt,
+    hasRegistrationAnchor,
+  });
+  if (Date.now() > deadlineMs) {
+    await settleFromSending(row.id, token, { state: 'expired', errorCode: 'deadline' });
+    return { outcome: 'expired' };
+  }
+
+  // 3. Config check — NO attempt fields touched. Only the deadline ends a
+  //    config-blocked row.
+  const resolvedNow = row.pixelId || campaignPixelId(row.platform, campaign) || platformEnvPixelId(row.platform) || null;
+  if (!platformConfigured(row.platform) || !resolvedNow) {
+    await settleFromSending(row.id, token, {
+      state: 'config_blocked',
+      nextAttemptAt: new Date(Date.now() + CONFIG_BLOCKED_RETRY_MS),
+      errorCode: !platformConfigured(row.platform) ? 'platform_off' : 'no_destination',
+    });
+    return { outcome: 'config_blocked' };
+  }
+
+  // 4. Consent — snapshot for inline batches, per-row on worker retries;
+  //    fail-closed to no-PII.
+  let consent = marketingConsent;
+  if (consent === undefined) {
+    consent = false;
+    try {
+      consent = (await d.canMarketTo({
+        consumerId: prospect.consumerId || null,
+        phone: prospect.phone || null,
+        channel: 'all',
+        campaignId: prospect.campaignId || null,
+      })) === true;
+    } catch (err) {
+      logger.warn({ id: row.id, error: err?.message || String(err) }, 'platform_delivery.consent_check_failed');
+    }
+  }
+
+  // 5. Final fresh erased SELECT, then the pre-wire reservation CAS — the
+  //    guarantee is "no NEW send begins after this check observes erasure";
+  //    an in-flight request can't be recalled (the Google posture,
+  //    googleOfflineConversionsService.js:335).
+  const [freshRows] = await sequelize.query(
+    `SELECT COALESCE("sourceMetadata"::jsonb->>'erased','false') AS erased FROM prospects WHERE id = :id`,
+    { replacements: { id: row.prospectId } }
+  );
+  if (!freshRows?.[0] || freshRows[0].erased === 'true') {
+    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
+    return { outcome: 'skipped', errorCode: 'erased' };
+  }
+
+  const [reserved] = await sequelize.query(
+    `UPDATE platform_deliveries
+        SET "pixelId" = COALESCE("pixelId", :resolvedNow),
+            "sendAttempts" = "sendAttempts" + 1,
+            "firstWireAt" = COALESCE("firstWireAt", now()),
+            "lastAttemptAt" = now(),
+            "updatedAt" = now()
+      WHERE id = :id AND state = 'sending' AND "claimToken" = :token AND "sendAttempts" < :max
+      RETURNING "pixelId", "sendAttempts"`,
+    { replacements: { id: row.id, token, resolvedNow, max: maxAttempts() } }
+  );
+  if (!reserved?.[0]) {
+    // Reservation miss: cap reached (§3.3.4.5) — or the claim was lost, in
+    // which case this CAS misses too and the reclaimer owns the row.
+    const capped = await settleFromSending(row.id, token, { state: 'failed_permanent', errorCode: 'retry_cap' });
+    return capped ? { outcome: 'failed_permanent', errorCode: 'retry_cap' } : { outcome: 'claim_miss' };
+  }
+  const pixelId = reserved[0].pixelId;
+  const sendAttempts = Number(reserved[0].sendAttempts);
+
+  // 6. Send via the existing senders — payload rebuilt from the row (§1.1);
+  //    epoch-seconds eventTime; pinned pixel override; injected fetch.
+  const capture = { retryAfterMs: null };
+  const fetchImpl = d.fetch || makeDeliveryFetch(capture);
+  const ctx = {
+    eventId: row.eventId,
+    eventTime: Math.floor(new Date(row.eventTime).getTime() / 1000),
+    marketingConsent: consent,
+    pixelIdOverride: pixelId,
+  };
+  const send = row.platform === 'meta' ? d.metaSend : d.tiktokSend;
+  let result;
+  try {
+    result = await send(prospect, ctx, { eventName: eventNameForKey(row.eventKey) }, { fetch: fetchImpl });
+  } catch (err) {
+    // The senders never throw by contract; belt-and-braces for injected seams.
+    result = { sent: false, error: err?.message || String(err) };
+  }
+
+  // 7. Settle (CAS on claimToken).
+  const cls = classifySendResult(row.platform, result, { retryAfterMs: capture.retryAfterMs });
+  if (cls.kind === 'sent') {
+    const fields = {
+      state: 'sent',
+      sentAt: new Date(),
+      lastStatus: cls.status,
+      errorCode: null,
+      providerRequestId: cls.providerRequestId,
+    };
+    if (isOutcomeKey) {
+      // The legacy capi.{markerKey} write shares the settle's DB transaction
+      // (§3.3.4.7) — marker and sent-state commit or roll back together.
+      const markerKey = OUTCOME_EVENTS[row.eventKey].markerKey;
+      await sequelize.transaction(async (tx) => {
+        const applied = await settleFromSending(row.id, token, fields, { transaction: tx });
+        if (applied) {
+          await d.setSourceMetadataPath(row.prospectId, ['capi', markerKey], new Date().toISOString(), {
+            transaction: tx,
+          });
+        }
+      });
+    } else {
+      await settleFromSending(row.id, token, fields);
+    }
+    logger.info(
+      { id: row.id, platform: row.platform, eventKey: row.eventKey, attempts: sendAttempts },
+      'platform_delivery.sent'
+    );
+    return { outcome: 'sent' };
+  }
+  if (cls.kind === 'retry_wait') {
+    if (cls.authClass && row.errorCode !== 'auth') {
+      // Sentry once per row on entering the auth-failure ladder.
+      Sentry.captureException(new Error(`platform delivery auth failure (${row.platform})`), {
+        tags: { source: 'platform_delivery', platform: row.platform },
+        extra: { delivery_id: row.id, status: cls.status },
+      });
+    }
+    await settleFromSending(row.id, token, {
+      state: 'retry_wait',
+      nextAttemptAt: new Date(
+        Date.now() + computeBackoffMs(sendAttempts, { authClass: cls.authClass === true, retryAfterMs: cls.retryAfterMs, jitterRatio: d.jitterRatio })
+      ),
+      lastStatus: cls.status ?? null,
+      errorCode: cls.errorCode,
+    });
+    return { outcome: 'retry_wait', errorCode: cls.errorCode };
+  }
+  if (cls.kind === 'config_blocked') {
+    await settleFromSending(row.id, token, {
+      state: 'config_blocked',
+      nextAttemptAt: new Date(Date.now() + CONFIG_BLOCKED_RETRY_MS),
+      errorCode: cls.errorCode,
+    });
+    return { outcome: 'config_blocked', errorCode: cls.errorCode };
+  }
+  await settleFromSending(row.id, token, {
+    state: 'failed_permanent',
+    lastStatus: cls.status ?? null,
+    errorCode: cls.errorCode,
+  });
+  logger.warn(
+    { id: row.id, platform: row.platform, eventKey: row.eventKey, errorCode: cls.errorCode, status: cls.status },
+    'platform_delivery.failed_permanent'
+  );
+  return { outcome: 'failed_permanent', errorCode: cls.errorCode };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch integration (§3.3.5)
+// ---------------------------------------------------------------------------
+
+function isDueNow(row, now = new Date()) {
+  if (row.state === 'pending') return true;
+  if (row.state === 'retry_wait' || row.state === 'config_blocked') {
+    return !row.nextAttemptAt || new Date(row.nextAttemptAt) <= now;
+  }
+  return false;
+}
+
+/**
+ * Submit-time dispatch (replaces prospectDispatch's four direct sends at the
+ * same statement position; invoked FIRE-AND-FORGET — zero new awaited work on
+ * the capture path):
+ *  (a) ownership query across ALL states for the four intended pairs (skipped
+ *      when plannedOk=false: planning is the sole row creator and it just ran
+ *      for this brand-new prospect, so rows cannot exist — §3.4's planning-off
+ *      zero-new-queries budget);
+ *  (b) claimable-due rows attempted in deterministic order (meta lead → meta
+ *      creg → tiktok lead → tiktok creg), ONE consent snapshot, sends
+ *      floating; other-state rows are left to the worker;
+ *  (c) pairs WITHOUT rows: the caller-supplied legacy closures fire — exactly
+ *      today's direct sends.
+ */
+export async function dispatchSubmitDeliveries({ prospect, plannedOk, marketingConsent, legacy = {}, deps = {} }) {
+  const pairs = [
+    ['meta', 'lead', legacy.metaLead],
+    ['meta', 'complete_registration', legacy.metaCompleteRegistration],
+    ['tiktok', 'lead', legacy.tiktokLead],
+    ['tiktok', 'complete_registration', legacy.tiktokCompleteRegistration],
+  ];
+  let owned = new Set();
+  if (plannedOk) {
+    const rows = await PlatformDelivery.findAll({
+      where: { prospectId: prospect.id, eventKey: SUBMIT_KEYS },
+      raw: true,
+    });
+    owned = new Set(rows.map((r) => `${r.platform}:${r.eventKey}`));
+    if (!deliveryPaused()) {
+      const byPair = new Map(rows.map((r) => [`${r.platform}:${r.eventKey}`, r]));
+      for (const [platform, key] of pairs) {
+        const row = byPair.get(`${platform}:${key}`);
+        if (!row || !isDueNow(row)) continue;
+        processDelivery(row.id, { marketingConsent, deps }).catch((err) => {
+          logger.warn({ id: row.id, error: err?.message || String(err) }, 'platform_delivery.inline_dispatch_failed');
+        });
+      }
+    }
+  }
+  for (const [platform, key, fireLegacy] of pairs) {
+    if (owned.has(`${platform}:${key}`)) continue;
+    if (typeof fireLegacy === 'function') fireLegacy();
+  }
+  return { owned: [...owned] };
+}
+
+/** §3.3.5 outcome return-contract mapping (complete). */
+export function mapDeliveryOutcomeToLegacy(res) {
+  switch (res?.outcome) {
+    case 'sent':
+      return 'dispatched';
+    case 'config_blocked':
+      return 'guarded';
+    case 'retry_wait':
+    case 'paused':
+    case 'claim_miss':
+      return 'transientFailed';
+    case 'failed_permanent':
+    case 'expired':
+    case 'skipped':
+      return 'permanentFailed';
+    default:
+      return 'transientFailed';
+  }
+}
+
+/**
+ * Inline ledger dispatch for ONE outcome key (called from processLeadOutcome
+ * after planning). Returns { owned:false } when no row exists (legacy path),
+ * else { owned:true, legacyOutcome } per the §3.3.5 mapping:
+ * pre-existing sent → duplicate · config_blocked → guarded · retry_wait /
+ * paused / held sending / claim-miss → transientFailed · terminal failures →
+ * permanentFailed.
+ */
+export async function dispatchOutcomeDelivery({ prospectId, key, marketingConsent, deps = {} }) {
+  const row = await PlatformDelivery.findOne({
+    where: { prospectId, platform: 'meta', eventKey: key },
+    raw: true,
+  });
+  if (!row) return { owned: false };
+  if (row.state === 'sent') return { owned: true, legacyOutcome: 'duplicate' };
+  if (TERMINAL_STATES.includes(row.state)) return { owned: true, legacyOutcome: 'permanentFailed' };
+  if (deliveryPaused()) return { owned: true, legacyOutcome: 'transientFailed' };
+  if (row.state === 'sending') {
+    const stale = row.claimedAt && new Date(row.claimedAt).getTime() < Date.now() - STALE_LEASE_MS;
+    if (!stale) return { owned: true, legacyOutcome: 'transientFailed' }; // held by an active lease
+  } else if (!isDueNow(row)) {
+    return { owned: true, legacyOutcome: row.state === 'config_blocked' ? 'guarded' : 'transientFailed' };
+  }
+  const res = await processDelivery(row.id, { marketingConsent, deps });
+  return { owned: true, legacyOutcome: mapDeliveryOutcomeToLegacy(res) };
+}
+
+// ---------------------------------------------------------------------------
+// Worker + expiry + invariant sweep + retention (§3.3.7, §3.5, §3.6)
+// ---------------------------------------------------------------------------
+
+let lastInvariantSweepAt = 0;
+let lastRetentionPurgeAt = 0;
+
+/** Test hook: reset the sub-cadence clocks. */
+export function _resetWorkerCadence() {
+  lastInvariantSweepAt = 0;
+  lastRetentionPurgeAt = 0;
+}
+
+/**
+ * One worker tick under advisory lock 'pd:worker' (§7.6). Scheduled whenever
+ * the ledger exists — NOT provider-flag-gated: with providers off, attempts
+ * classify config_blocked and the expiry pass still runs. Honours
+ * PLATFORM_DELIVERY_PAUSED for send work only. The §3.5 invariant sweep and
+ * §3.6 retention purge ride the tick on hourly/daily sub-cadences.
+ */
+export async function runDeliveryWorker({ deps = {}, forceInvariantSweep = false, forceRetentionPurge = false } = {}) {
+  return withAdvisoryLock('pd:worker', async () => {
+    const summary = { attempted: 0, outcomes: {}, expired: 0, invariantPlanned: null, purged: null };
+
+    if (!deliveryPaused()) {
+      const [due] = await sequelize.query(
+        `SELECT id FROM platform_deliveries
+          WHERE (state = 'pending' AND "createdAt" < now() - interval '2 minutes')
+             OR (state IN ('retry_wait','config_blocked') AND ("nextAttemptAt" IS NULL OR "nextAttemptAt" <= now()))
+             OR (state = 'sending' AND "claimedAt" < now() - ${STALE_LEASE_SQL})
+          ORDER BY COALESCE("nextAttemptAt", "createdAt") ASC
+          LIMIT 200`
+      );
+      const queue = [...(due || [])];
+      const lanes = Array.from({ length: Math.min(5, queue.length) }, async () => {
+        for (;;) {
+          const next = queue.shift();
+          if (!next) return;
+          try {
+            const res = await processDelivery(next.id, { deps });
+            summary.attempted += 1;
+            summary.outcomes[res.outcome] = (summary.outcomes[res.outcome] || 0) + 1;
+          } catch (err) {
+            logger.error({ id: next.id, error: err?.message || String(err) }, 'platform_delivery.worker_attempt_failed');
+          }
+        }
+      });
+      await Promise.all(lanes);
+    }
+
+    summary.expired = await runExpiryPass();
+
+    if (forceInvariantSweep || Date.now() - lastInvariantSweepAt > 3600_000) {
+      lastInvariantSweepAt = Date.now();
+      summary.invariantPlanned = await runOutcomeInvariantSweep();
+    }
+    if (forceRetentionPurge || Date.now() - lastRetentionPurgeAt > 24 * 3600_000) {
+      lastRetentionPurgeAt = Date.now();
+      summary.purged = await runRetentionPurge();
+    }
+    if (summary.attempted || summary.expired || summary.invariantPlanned || summary.purged) {
+      logger.info(summary, 'platform_delivery.worker_tick');
+    }
+    return summary;
+  });
+}
+
+/**
+ * Expiry pass (§3.3.7): transitions ONLY pending/retry_wait/config_blocked
+ * past-deadline, plus `sending` when the lease is STALE — never an active
+ * lease (an in-flight settle wins; the CAS re-checks staleness at write
+ * time). Runs even when paused (pausing past deadlines expires events).
+ */
+export async function runExpiryPass() {
+  // Cheap SQL pre-filter on the smallest configured horizon; the exact
+  // per-key deadline (incl. the CReg anchor-vs-fallback split, which needs
+  // the prospect's registrationEventAt) is computed in JS per candidate.
+  const minHorizonHours = Math.min(
+    keyHorizonHours('lead'),
+    keyHorizonHours('complete_registration', { hasRegistrationAnchor: true }),
+    keyHorizonHours('complete_registration', { hasRegistrationAnchor: false }),
+    keyHorizonHours('confirmed_resident')
+  );
+  const [candidates] = await sequelize.query(
+    `SELECT pd.id, pd."eventKey", pd."dedupeAnchorAt", pd."firstWireAt",
+            ((p."sourceMetadata"::jsonb ->> 'registrationEventAt') IS NOT NULL) AS "hasRegAnchor"
+       FROM platform_deliveries pd
+       LEFT JOIN prospects p ON p.id = pd."prospectId"
+      WHERE (pd.state IN ('pending','retry_wait','config_blocked')
+             OR (pd.state = 'sending' AND pd."claimedAt" < now() - ${STALE_LEASE_SQL}))
+        AND (pd."dedupeAnchorAt" < now() - make_interval(hours => :minHorizonHours)
+             OR (pd."firstWireAt" IS NOT NULL AND pd."firstWireAt" < now() - interval '${WIRE_DEDUPE_WINDOW_HOURS} hours'))
+      LIMIT 500`,
+    { replacements: { minHorizonHours } }
+  );
+  let expired = 0;
+  for (const c of candidates || []) {
+    const deadlineMs = computeDeadlineMs({
+      eventKey: c.eventKey,
+      dedupeAnchorAt: c.dedupeAnchorAt,
+      firstWireAt: c.firstWireAt,
+      hasRegistrationAnchor: c.hasRegAnchor === true,
+    });
+    if (Date.now() <= deadlineMs) continue;
+    const [, meta] = await sequelize.query(
+      `UPDATE platform_deliveries
+          SET state = 'expired', "errorCode" = 'deadline', "updatedAt" = now()
+        WHERE id = :id
+          AND (state IN ('pending','retry_wait','config_blocked')
+               OR (state = 'sending' AND "claimedAt" < now() - ${STALE_LEASE_SQL}))`,
+      { replacements: { id: c.id } }
+    );
+    expired += meta?.rowCount ?? 0;
+  }
+  return expired;
+}
+
+/**
+ * Invariant sweep (§3.5, hourly on the tick): outcome facts younger than the
+ * outcome horizon with NO row AND NO exact per-key marker get planned. This
+ * is what heals an admin/webhook planning savepoint failure; the fully-failed
+ * facts+planning transaction (no fact, no row) is healed upstream by the
+ * credentials-based Lyfe reconciler re-writing the fact.
+ */
+export async function runOutcomeInvariantSweep() {
+  if (!planningEnabled()) return 0;
+  const horizonMs = keyHorizonHours('confirmed_resident') * 3600_000;
+  let planned = 0;
+  for (const key of OUTCOME_KEYS) {
+    const markerKey = OUTCOME_EVENTS[key].markerKey;
+    // key/markerKey are code-owned constants (safe to interpolate).
+    const [rows] = await sequelize.query(
+      `SELECT p.id, p."sourceMetadata"::jsonb #>> '{outcomes,${key}}' AS fact
+         FROM prospects p
+        WHERE p."sourceMetadata"::jsonb #>> '{outcomes,${key}}' IS NOT NULL
+          AND p."sourceMetadata"::jsonb #>> '{capi,${markerKey}}' IS NULL
+          AND COALESCE(p."sourceMetadata"::jsonb ->> 'erased', 'false') <> 'true'
+          AND NOT EXISTS (SELECT 1 FROM platform_deliveries pd
+                           WHERE pd."prospectId" = p.id AND pd.platform = 'meta' AND pd."eventKey" = '${key}')
+        LIMIT 200`
+    );
+    for (const r of rows || []) {
+      const factMs = Date.parse(r.fact);
+      if (Number.isNaN(factMs) || Date.now() - factMs > horizonMs) continue;
+      try {
+        await sequelize.transaction(async (t) => {
+          const res = await planOutcomeDeliveriesTx(t, { prospectId: r.id, keys: [key] });
+          planned += res.inserted || 0;
+        });
+      } catch (err) {
+        logger.warn({ prospectId: r.id, key, error: err?.message || String(err) }, 'platform_delivery.invariant_plan_failed');
+      }
+    }
+  }
+  return planned;
+}
+
+/** Retention purge (§3.6, daily on the tick): terminal rows older than PLATFORM_DELIVERY_RETENTION_DAYS, bounded batches. */
+export async function runRetentionPurge() {
+  const days = numEnv('PLATFORM_DELIVERY_RETENTION_DAYS', 90, 7, 365);
+  let total = 0;
+  for (let i = 0; i < 20; i++) {
+    const [, meta] = await sequelize.query(
+      `DELETE FROM platform_deliveries WHERE id IN (
+         SELECT id FROM platform_deliveries
+          WHERE state IN ('sent','failed_permanent','expired','skipped')
+            AND "updatedAt" < now() - make_interval(days => :days)
+          LIMIT 1000)`,
+      { replacements: { days } }
+    );
+    const n = meta?.rowCount ?? 0;
+    total += n;
+    if (n < 1000) break;
+  }
+  return total;
+}

--- a/backend/src/services/platformDeliveryService.js
+++ b/backend/src/services/platformDeliveryService.js
@@ -44,9 +44,14 @@ const CONFIG_BLOCKED_RETRY_MS = 30 * 60 * 1000;
 const WIRE_DEDUPE_WINDOW_HOURS = 47; // firstWireAt + 47h ≤ the provider's ~48h event-id window
 
 function numEnv(name, def, min, max) {
-  const raw = Number(process.env[name]);
-  if (!Number.isFinite(raw)) return def;
-  return Math.min(max, Math.max(min, raw));
+  const raw = process.env[name];
+  // Absent OR blank ⇒ default. (Number('') is 0 — without this, a blank env
+  // row would clamp to the MINIMUM: a blank outcome horizon would silently
+  // become 1h and mass-expire rows. Codex P2 review #6.)
+  if (raw === undefined || String(raw).trim() === '') return def;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return def;
+  return Math.min(max, Math.max(min, n));
 }
 
 export function planningEnabled() {
@@ -205,6 +210,15 @@ export async function planOutcomeDeliveriesTx(t, { prospectId, keys, campaign })
   if (!planningEnabled()) return { planned: false, reason: 'flag_off' };
   const validKeys = (keys || []).filter((k) => OUTCOME_KEYS.includes(k));
   if (!validKeys.length) return { planned: false, reason: 'no_keys' };
+  // Row-lock the prospect BEFORE reading facts/erased: the admin and webhook
+  // callers already hold this lock (their facts write took it), but the
+  // invariant sweep would otherwise read pre-erasure facts and insert a row
+  // AFTER erasure deleted everything and committed (Codex P2 review #3).
+  // Also pins the global prospect → delivery lock order (see the settle txn).
+  await sequelize.query(`SELECT id FROM prospects WHERE id = :prospectId FOR UPDATE`, {
+    replacements: { prospectId },
+    transaction: t,
+  });
   const prospect = await Prospect.findByPk(prospectId, { transaction: t, raw: true });
   if (!prospect) return { planned: false, reason: 'no_prospect' };
   if (prospect.sourceMetadata?.erased === true) return { planned: false, reason: 'erased' };
@@ -344,10 +358,10 @@ export function classifySendResult(platform, result, { retryAfterMs = null } = {
       };
     }
     if (platform === 'tiktok' && (status === 401 || status === 403 || TIKTOK_AUTH_CODES.has(result?.body?.code))) {
-      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, status };
+      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, retryAfterMs, status };
     }
     if (platform === 'meta' && status >= 400 && META_AUTH_CODES.has(result?.body?.error?.code)) {
-      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, status };
+      return { kind: 'retry_wait', errorCode: 'auth', authClass: true, retryAfterMs, status };
     }
     if (status >= 400) {
       return { kind: 'failed_permanent', errorCode: 'http_4xx', status };
@@ -389,19 +403,40 @@ export function parseRetryAfterMs(value, now = Date.now()) {
  * Injected-fetch adapter (§3.3.6): enforces PLATFORM_DELIVERY_HTTP_TIMEOUT_MS
  * via AbortController (20s default — well under the 10-min claim lease) and
  * captures Retry-After out-of-band for the settle classification.
+ *
+ * The abort timer covers the WHOLE exchange, body read included: the senders
+ * consume `res.json()` after headers arrive, and a stalled body would
+ * otherwise let an attempt outlive the claim lease and race its own reclaim
+ * (Codex P2 review #1). The timer is cleared when json() settles; if the
+ * sender never reads the body it self-fires at the timeout, where aborting an
+ * abandoned response is a no-op. Applied over ANY base fetch, injected test
+ * seams included. Exported for the unit suite.
  */
-function makeDeliveryFetch(capture) {
+export function makeDeliveryFetch(capture, baseFetch) {
   const timeoutMs = httpTimeoutMs();
+  const doFetch = baseFetch || fetch;
   return async (url, opts = {}) => {
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeoutMs);
+    let res;
     try {
-      const res = await fetch(url, { ...opts, signal: ac.signal });
-      capture.retryAfterMs = parseRetryAfterMs(res.headers?.get?.('retry-after'));
-      return res;
-    } finally {
+      res = await doFetch(url, { ...opts, signal: ac.signal });
+    } catch (err) {
       clearTimeout(timer);
+      throw err;
     }
+    capture.retryAfterMs = parseRetryAfterMs(res.headers?.get?.('retry-after'));
+    if (typeof res.json === 'function') {
+      const origJson = res.json.bind(res);
+      res.json = async () => {
+        try {
+          return await origJson();
+        } finally {
+          clearTimeout(timer);
+        }
+      };
+    }
+    return res;
   };
 }
 
@@ -441,14 +476,17 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
   const isOutcomeKey = OUTCOME_KEYS.includes(row.eventKey);
 
   // 1. Rescreen: reload prospect (+ campaign only when the destination is unpinned).
+  // Every settle below is fenced on OUR claim token — a lost CAS means a
+  // reclaimer owns the row and ITS attempt governs, so we report claim_miss
+  // instead of our own classification (Codex P2 review #7).
   const prospect = await Prospect.findByPk(row.prospectId, { raw: true });
   if (!prospect) {
-    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'no_prospect' });
-    return { outcome: 'skipped', errorCode: 'no_prospect' };
+    const ok = await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'no_prospect' });
+    return ok ? { outcome: 'skipped', errorCode: 'no_prospect' } : { outcome: 'claim_miss' };
   }
   if (prospect.sourceMetadata?.erased === true) {
-    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
-    return { outcome: 'skipped', errorCode: 'erased' };
+    const ok = await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
+    return ok ? { outcome: 'skipped', errorCode: 'erased' } : { outcome: 'claim_miss' };
   }
   let campaign = null;
   if (!row.pixelId && prospect.campaignId) {
@@ -465,20 +503,20 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
     hasRegistrationAnchor,
   });
   if (Date.now() > deadlineMs) {
-    await settleFromSending(row.id, token, { state: 'expired', errorCode: 'deadline' });
-    return { outcome: 'expired' };
+    const ok = await settleFromSending(row.id, token, { state: 'expired', errorCode: 'deadline' });
+    return ok ? { outcome: 'expired' } : { outcome: 'claim_miss' };
   }
 
   // 3. Config check — NO attempt fields touched. Only the deadline ends a
   //    config-blocked row.
   const resolvedNow = row.pixelId || campaignPixelId(row.platform, campaign) || platformEnvPixelId(row.platform) || null;
   if (!platformConfigured(row.platform) || !resolvedNow) {
-    await settleFromSending(row.id, token, {
+    const ok = await settleFromSending(row.id, token, {
       state: 'config_blocked',
       nextAttemptAt: new Date(Date.now() + CONFIG_BLOCKED_RETRY_MS),
       errorCode: !platformConfigured(row.platform) ? 'platform_off' : 'no_destination',
     });
-    return { outcome: 'config_blocked' };
+    return ok ? { outcome: 'config_blocked' } : { outcome: 'claim_miss' };
   }
 
   // 4. Consent — snapshot for inline batches, per-row on worker retries;
@@ -507,8 +545,8 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
     { replacements: { id: row.prospectId } }
   );
   if (!freshRows?.[0] || freshRows[0].erased === 'true') {
-    await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
-    return { outcome: 'skipped', errorCode: 'erased' };
+    const ok = await settleFromSending(row.id, token, { state: 'skipped', errorCode: 'erased' });
+    return ok ? { outcome: 'skipped', errorCode: 'erased' } : { outcome: 'claim_miss' };
   }
 
   const [reserved] = await sequelize.query(
@@ -532,9 +570,11 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
   const sendAttempts = Number(reserved[0].sendAttempts);
 
   // 6. Send via the existing senders — payload rebuilt from the row (§1.1);
-  //    epoch-seconds eventTime; pinned pixel override; injected fetch.
+  //    epoch-seconds eventTime; pinned pixel override. The timeout wrapper is
+  //    ALWAYS applied — an injected deps.fetch is a base transport, never a
+  //    way around the lease-protecting timeout.
   const capture = { retryAfterMs: null };
-  const fetchImpl = d.fetch || makeDeliveryFetch(capture);
+  const fetchImpl = makeDeliveryFetch(capture, d.fetch || undefined);
   const ctx = {
     eventId: row.eventId,
     eventTime: Math.floor(new Date(row.eventTime).getTime() / 1000),
@@ -544,7 +584,9 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
   const send = row.platform === 'meta' ? d.metaSend : d.tiktokSend;
   let result;
   try {
-    result = await send(prospect, ctx, { eventName: eventNameForKey(row.eventKey) }, { fetch: fetchImpl });
+    // suppressSentry: the ledger owns failure classification + the once-per-
+    // row auth alert; per-attempt sender captures would multiply on retries.
+    result = await send(prospect, ctx, { eventName: eventNameForKey(row.eventKey), suppressSentry: true }, { fetch: fetchImpl });
   } catch (err) {
     // The senders never throw by contract; belt-and-braces for injected seams.
     result = { sent: false, error: err?.message || String(err) };
@@ -560,21 +602,30 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
       errorCode: null,
       providerRequestId: cls.providerRequestId,
     };
+    let settleApplied = false;
     if (isOutcomeKey) {
       // The legacy capi.{markerKey} write shares the settle's DB transaction
       // (§3.3.4.7) — marker and sent-state commit or roll back together.
+      // Lock order: PROSPECT FIRST, then the delivery row — erasure locks
+      // prospects and then deletes deliveries, so settling in the opposite
+      // order could deadlock a PDPA erasure (Codex P2 review #4).
       const markerKey = OUTCOME_EVENTS[row.eventKey].markerKey;
       await sequelize.transaction(async (tx) => {
-        const applied = await settleFromSending(row.id, token, fields, { transaction: tx });
-        if (applied) {
+        await sequelize.query(`SELECT id FROM prospects WHERE id = :pid FOR UPDATE`, {
+          replacements: { pid: row.prospectId },
+          transaction: tx,
+        });
+        settleApplied = await settleFromSending(row.id, token, fields, { transaction: tx });
+        if (settleApplied) {
           await d.setSourceMetadataPath(row.prospectId, ['capi', markerKey], new Date().toISOString(), {
             transaction: tx,
           });
         }
       });
     } else {
-      await settleFromSending(row.id, token, fields);
+      settleApplied = await settleFromSending(row.id, token, fields);
     }
+    if (!settleApplied) return { outcome: 'claim_miss' }; // a reclaimer owns the row; its attempt governs
     logger.info(
       { id: row.id, platform: row.platform, eventKey: row.eventKey, attempts: sendAttempts },
       'platform_delivery.sent'
@@ -589,7 +640,7 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
         extra: { delivery_id: row.id, status: cls.status },
       });
     }
-    await settleFromSending(row.id, token, {
+    const ok = await settleFromSending(row.id, token, {
       state: 'retry_wait',
       nextAttemptAt: new Date(
         Date.now() + computeBackoffMs(sendAttempts, { authClass: cls.authClass === true, retryAfterMs: cls.retryAfterMs, jitterRatio: d.jitterRatio })
@@ -597,21 +648,22 @@ export async function processDelivery(id, { marketingConsent, deps = {} } = {}) 
       lastStatus: cls.status ?? null,
       errorCode: cls.errorCode,
     });
-    return { outcome: 'retry_wait', errorCode: cls.errorCode };
+    return ok ? { outcome: 'retry_wait', errorCode: cls.errorCode } : { outcome: 'claim_miss' };
   }
   if (cls.kind === 'config_blocked') {
-    await settleFromSending(row.id, token, {
+    const ok = await settleFromSending(row.id, token, {
       state: 'config_blocked',
       nextAttemptAt: new Date(Date.now() + CONFIG_BLOCKED_RETRY_MS),
       errorCode: cls.errorCode,
     });
-    return { outcome: 'config_blocked', errorCode: cls.errorCode };
+    return ok ? { outcome: 'config_blocked', errorCode: cls.errorCode } : { outcome: 'claim_miss' };
   }
-  await settleFromSending(row.id, token, {
+  const settled = await settleFromSending(row.id, token, {
     state: 'failed_permanent',
     lastStatus: cls.status ?? null,
     errorCode: cls.errorCode,
   });
+  if (!settled) return { outcome: 'claim_miss' };
   logger.warn(
     { id: row.id, platform: row.platform, eventKey: row.eventKey, errorCode: cls.errorCode, status: cls.status },
     'platform_delivery.failed_permanent'
@@ -850,20 +902,31 @@ export async function runExpiryPass() {
  */
 export async function runOutcomeInvariantSweep() {
   if (!planningEnabled()) return 0;
-  const horizonMs = keyHorizonHours('confirmed_resident') * 3600_000;
+  const horizonHours = keyHorizonHours('confirmed_resident');
+  const horizonMs = horizonHours * 3600_000;
   let planned = 0;
   for (const key of OUTCOME_KEYS) {
     const markerKey = OUTCOME_EVENTS[key].markerKey;
-    // key/markerKey are code-owned constants (safe to interpolate).
+    // key/markerKey are code-owned constants (safe to interpolate). Age and
+    // origin eligibility are filtered IN SQL, before the LIMIT — otherwise
+    // permanently-ineligible facts (past-horizon, Retell-origin) would occupy
+    // the batch forever and starve young eligible facts (Codex P2 review #2).
+    // The ::timestamptz cast is regex-guarded; every fact writer normalizes
+    // through toISOString(), and the JS re-checks below stay as the belt.
     const [rows] = await sequelize.query(
       `SELECT p.id, p."sourceMetadata"::jsonb #>> '{outcomes,${key}}' AS fact
          FROM prospects p
-        WHERE p."sourceMetadata"::jsonb #>> '{outcomes,${key}}' IS NOT NULL
+        WHERE p."sourceMetadata"::jsonb #>> '{outcomes,${key}}' ~ '^\\d{4}-\\d{2}-\\d{2}T'
+          AND (p."sourceMetadata"::jsonb #>> '{outcomes,${key}}')::timestamptz >= now() - make_interval(hours => :horizonHours)
           AND p."sourceMetadata"::jsonb #>> '{capi,${markerKey}}' IS NULL
           AND COALESCE(p."sourceMetadata"::jsonb ->> 'erased', 'false') <> 'true'
+          AND p."leadSource" <> 'call_bot'
+          AND p."retellCallId" IS NULL
+          AND p."sourceMetadata"::jsonb ->> 'metaLeadgenId' IS NULL
           AND NOT EXISTS (SELECT 1 FROM platform_deliveries pd
                            WHERE pd."prospectId" = p.id AND pd.platform = 'meta' AND pd."eventKey" = '${key}')
-        LIMIT 200`
+        LIMIT 200`,
+      { replacements: { horizonHours } }
     );
     for (const r of rows || []) {
       const factMs = Date.parse(r.fact);

--- a/backend/src/services/prospectCreateTx.js
+++ b/backend/src/services/prospectCreateTx.js
@@ -51,10 +51,14 @@ export function makeCreateTxRunner({ d, m }) {
    * @param {object|null} ctx.externalConsent Third-party-disclosure evidence.
    * @param {object|null} ctx.dncConsent DNC-consent evidence.
    * @param {Array} ctx.acceptedProfileFacts Validated profile-question facts.
+   * @param {string|undefined} ctx.eventId Meta/TikTok Lead dedup id (server-generated when the client omits one).
+   * @param {string|undefined} ctx.registrationEventId Quiz CompleteRegistration dedup id.
+   * @param {string|undefined} ctx.registrationEventAt Browser reveal timestamp (clamped ISO) — the CReg deadline anchor.
    *
    * @returns {Promise<{
    *   prospect: object, quarantined: boolean, heldReason: string|null,
-   *   finalAgentId: string|null, dncHeld: boolean, screeningHeld: boolean
+   *   finalAgentId: string|null, dncHeld: boolean, screeningHeld: boolean,
+   *   deliveriesPlanned: boolean
    * }>} The committed row plus the outcome flags the post-commit stages read.
    */
   return async function runCreateTx(ctx) {
@@ -79,6 +83,9 @@ export function makeCreateTxRunner({ d, m }) {
       externalConsent,
       dncConsent,
       acceptedProfileFacts,
+      eventId,
+      registrationEventId,
+      registrationEventAt,
     } = ctx;
 
     let quarantined = false;
@@ -91,6 +98,9 @@ export function makeCreateTxRunner({ d, m }) {
     let dncAlreadyCharged = false;
     // Screening hold bookkeeping (plan §5.2) — mirrors the DNC shape.
     let screeningHeld = false;
+    // Platform-delivery ledger planning outcome (ads-centralisation §3.3.1) —
+    // false = the legacy direct senders cover this prospect.
+    let deliveriesPlanned = false;
 
     const prospect = await d.sequelize.transaction(async (t) => {
       // The internal quota gate applies ONLY to the internal path. For external
@@ -225,6 +235,31 @@ export function makeCreateTxRunner({ d, m }) {
         });
       }
 
+      // Platform-delivery ledger (ads-centralisation §3.3.1): persist the
+      // submit-time delivery obligations (meta/tiktok × lead/creg) IN THIS
+      // transaction, savepoint-isolated like the enrichment outbox above —
+      // planning must never fail capture. A savepoint failure leaves
+      // deliveriesPlanned=false, and the dispatch stage fires the legacy
+      // direct senders for exactly this prospect instead.
+      if (d.submitPlanningApplies({ prospect: newProspect })) {
+        try {
+          await d.sequelize.transaction({ transaction: t }, async (sp) => {
+            await d.planSubmitDeliveriesTx(sp, {
+              prospect: newProspect,
+              sourceCampaign,
+              eventId,
+              registrationEventId,
+              registrationEventAt,
+            });
+          });
+          deliveriesPlanned = true;
+        } catch (planErr) {
+          d.logger.warn('[delivery] submit planning failed (legacy senders cover this prospect)', {
+            error: planErr?.message || String(planErr),
+          });
+        }
+      }
+
       const campaignName = sourceCampaign?.name || 'Unknown Campaign';
       // Source-aware phrase ("via TikTok ad" / "via web form" / "via {name} QR
       // code" …) instead of the old hardcoded "via {qr} QR code", which
@@ -326,6 +361,6 @@ export function makeCreateTxRunner({ d, m }) {
       return newProspect;
     });
 
-    return { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld };
+    return { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld, deliveriesPlanned };
   };
 }

--- a/backend/src/services/prospectDispatch.js
+++ b/backend/src/services/prospectDispatch.js
@@ -41,6 +41,7 @@ export function makeDispatchRunner({ d, m }) {
    * @param {boolean} ctx.dncHeld The lead was born dnc_pending (block mode).
    * @param {boolean} ctx.dncFlagApplies DNC runs in flag mode for this lead.
    * @param {boolean} ctx.screeningHeld The lead is awaiting an AI screening call.
+   * @param {boolean} ctx.deliveriesPlanned Capture txn planned platform-delivery rows (§3.3.1).
    * @param {string|null} ctx.externalAgentId MKTR Leads buyer, when external.
    * @param {object|null} ctx.sourceCampaign Campaign (pixel overrides, design_config).
    * @param {object|null} ctx.sourceQrTag QR tag, for the webhook payload.
@@ -71,6 +72,7 @@ export function makeDispatchRunner({ d, m }) {
       dncHeld,
       dncFlagApplies,
       screeningHeld,
+      deliveriesPlanned,
       externalAgentId,
       sourceCampaign,
       sourceQrTag,
@@ -187,9 +189,15 @@ export function makeDispatchRunner({ d, m }) {
       });
     }
 
-    // Meta CAPI dispatch (fire-and-forget; post-commit; guard inside sendLeadEvent)
-    d.sendLeadEvent(prospect, {
-      eventId,
+    // Meta + TikTok submit-time dispatch (ads-centralisation §3.3.5), at the
+    // same statement position the four direct sends held. Row-ownership
+    // routing: pairs the capture txn planned into platform_deliveries are
+    // delivered through the ledger (inline claim now, worker later); pairs
+    // WITHOUT rows fire the legacy closures below — exactly the pre-ledger
+    // direct sends, permanently kept for the planning-off / savepoint-failed
+    // path. The whole block is fire-and-forget: zero new awaited work on the
+    // capture path (§3.4). Per-campaign pixel overrides ride as before.
+    const legacyMetaCtx = {
       fbp,
       fbc,
       eventSourceUrl,
@@ -197,34 +205,7 @@ export function makeDispatchRunner({ d, m }) {
       clientUserAgent,
       pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
       marketingConsent: capiMarketingConsent,
-    }).catch((err) => {
-      d.logger.error('[CAPI] sendLeadEvent error', { error: err?.message || String(err) });
-    });
-
-    // Meta CAPI CompleteRegistration (quiz funnel). Fired server-side only when
-    // the browser sent a registrationEventId (the quiz reveal happened), using
-    // that same id so Meta dedups it against the Pixel CompleteRegistration fired
-    // at the reveal. No-op for non-quiz leads. Guard inside sendCompleteRegistrationEvent.
-    if (registrationEventId) {
-      d.sendCompleteRegistrationEvent(prospect, {
-        eventId: registrationEventId,
-        fbp,
-        fbc,
-        eventSourceUrl,
-        clientIp,
-        clientUserAgent,
-        pixelIdOverride: sourceCampaign?.metaPixelId || undefined,
-        marketingConsent: capiMarketingConsent,
-      }).catch((err) => {
-        d.logger.error('[CAPI] sendCompleteRegistrationEvent error', { error: err?.message || String(err) });
-      });
-    }
-
-    // TikTok Events API dispatch (fire-and-forget; post-commit; guard inside the
-    // sender). Mirrors the Meta CAPI pair: a Lead at submit, plus a
-    // CompleteRegistration when the quiz reveal fired one — each deduped against
-    // the browser ttq pixel via the shared event ids. Per-campaign tiktokPixelId
-    // overrides env TIKTOK_PIXEL_ID.
+    };
     const tiktokCtxBase = {
       ttclid,
       ttp,
@@ -234,14 +215,45 @@ export function makeDispatchRunner({ d, m }) {
       pixelIdOverride: sourceCampaign?.tiktokPixelId || undefined,
       marketingConsent: capiMarketingConsent,
     };
-    d.sendTikTokLeadEvent(prospect, { eventId, ...tiktokCtxBase }).catch((err) => {
-      d.logger.error('[TikTok] sendTikTokLeadEvent error', { error: err?.message || String(err) });
+    d.dispatchSubmitDeliveries({
+      prospect,
+      plannedOk: deliveriesPlanned === true,
+      marketingConsent: capiMarketingConsent,
+      legacy: {
+        // Meta CAPI Lead (guard inside sendLeadEvent).
+        metaLead: () => {
+          d.sendLeadEvent(prospect, { eventId, ...legacyMetaCtx }).catch((err) => {
+            d.logger.error('[CAPI] sendLeadEvent error', { error: err?.message || String(err) });
+          });
+        },
+        // Meta CAPI CompleteRegistration — only when the browser sent a
+        // registrationEventId (the quiz reveal happened), with that same id so
+        // Meta dedups it against the Pixel CompleteRegistration fired at the
+        // reveal. No-op closure absent for non-quiz leads.
+        metaCompleteRegistration: registrationEventId
+          ? () => {
+              d.sendCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...legacyMetaCtx }).catch((err) => {
+                d.logger.error('[CAPI] sendCompleteRegistrationEvent error', { error: err?.message || String(err) });
+              });
+            }
+          : null,
+        // TikTok mirror of the Meta pair, deduped via the shared event ids.
+        tiktokLead: () => {
+          d.sendTikTokLeadEvent(prospect, { eventId, ...tiktokCtxBase }).catch((err) => {
+            d.logger.error('[TikTok] sendTikTokLeadEvent error', { error: err?.message || String(err) });
+          });
+        },
+        tiktokCompleteRegistration: registrationEventId
+          ? () => {
+              d.sendTikTokCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...tiktokCtxBase }).catch((err) => {
+                d.logger.error('[TikTok] sendTikTokCompleteRegistrationEvent error', { error: err?.message || String(err) });
+              });
+            }
+          : null,
+      },
+    }).catch((err) => {
+      d.logger.error('[delivery] submit dispatch error', { error: err?.message || String(err) });
     });
-    if (registrationEventId) {
-      d.sendTikTokCompleteRegistrationEvent(prospect, { eventId: registrationEventId, ...tiktokCtxBase }).catch((err) => {
-        d.logger.error('[TikTok] sendTikTokCompleteRegistrationEvent error', { error: err?.message || String(err) });
-      });
-    }
 
     // Redeem Ops reward-entitlement hook — post-commit, fire-and-forget (a
     // Redeem Ops failure must never fail or slow lead capture). No-op unless

--- a/backend/src/services/prospectMutationService.js
+++ b/backend/src/services/prospectMutationService.js
@@ -182,6 +182,21 @@ export function makeProspectMutationOps({ d, m }) {
                 Object.fromEntries(factKeys.map((k) => [k, adminOccurredAt])),
                 { transaction: t }
               );
+              // Delivery-ledger planning (ads-centralisation §3.3.2, call
+              // site 1): rows minted from the JUST-PERSISTED facts — the
+              // helper re-reads them in-txn, so a replayed transition can
+              // never retime an earlier fact. Savepoint-isolated: planning
+              // failure must not fail the staff edit (the invariant sweep
+              // heals the missing rows).
+              try {
+                await d.sequelize.transaction({ transaction: t }, async (sp) => {
+                  await d.planOutcomeDeliveriesTx(sp, { prospectId: prospect.id, keys: factKeys });
+                });
+              } catch (planErr) {
+                d.logger.warn('[delivery] outcome planning failed on admin edit (sweep heals)', {
+                  prospectId: prospect.id, error: planErr?.message || String(planErr),
+                });
+              }
             }
           }
           if (!editingDemographics) return;

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import {
   Prospect,
   User,
@@ -42,8 +42,18 @@ import {
   sendTikTokCompleteRegistrationEvent,
 } from './tiktokEventsService.js';
 // Cycle-safe + graph-neutral: leadOutcomeService imports only models,
-// metaCapiService and consentService — all already in this module's graph.
+// metaCapiService, consentService, outcomeEvents and platformDeliveryService —
+// all already in (or leaves of) this module's graph.
 import { processLeadOutcome, eventKeysForStatus } from './leadOutcomeService.js';
+// Platform-delivery ledger (ads-centralisation §3): capture-time planning,
+// row-ownership submit dispatch, and the shared outcome planner injected into
+// the mutation ops. Leaf-safe: the service imports senders/models/consent only.
+import {
+  submitPlanningApplies,
+  planSubmitDeliveriesTx,
+  dispatchSubmitDeliveries,
+  planOutcomeDeliveriesTx,
+} from './platformDeliveryService.js';
 import {
   mergeFirstWins as mergeSourceMetadataFirstWins,
   removePaths as removeSourceMetadataPaths,
@@ -125,6 +135,10 @@ const defaultDeps = {
   sendTikTokCompleteRegistrationEvent,
   processLeadOutcome,
   eventKeysForStatus,
+  submitPlanningApplies,
+  planSubmitDeliveriesTx,
+  dispatchSubmitDeliveries,
+  planOutcomeDeliveriesTx,
   mergeSourceMetadataFirstWins,
   removeSourceMetadataPaths,
   getOrCreateProspectShareLink,
@@ -185,14 +199,29 @@ export function makeProspectService(overrides = {}) {
     const safeBody = body || {};
     // Prefer controller-supplied meta context; fall back to body fields if any
     // caller posts directly without the controller's extraction step.
-    const eventId = meta?.eventId ?? safeBody.eventId;
+    // A missing client eventId is SERVER-GENERATED (ads-centralisation §3.3.1)
+    // so no submit bypasses delivery-ledger durability — with no browser twin
+    // the id only has to be unique and stable across retries, which a UUID is.
+    const eventId = meta?.eventId ?? safeBody.eventId ?? randomUUID();
     const fbp = meta?.fbp ?? safeBody.fbp;
     const fbc = meta?.fbc ?? safeBody.fbc;
     const eventSourceUrl = meta?.eventSourceUrl ?? safeBody.eventSourceUrl;
     const clientIp = meta?.clientIp;
     const clientUserAgent = meta?.clientUserAgent;
     // Quiz CompleteRegistration dedup id (Meta CAPI) + TikTok attribution ids.
+    // registrationEventId is NEVER server-generated — absent means no quiz
+    // reveal happened, so no CompleteRegistration exists to deliver.
     const registrationEventId = meta?.registrationEventId ?? safeBody.registrationEventId;
+    // Browser reveal timestamp (§3.3.1): stamped at quiz reveal beside the
+    // registration event id; anchors the CReg delivery deadline. CLAMPED to
+    // now — a forged future value must not extend the dedupe horizon
+    // (gclCapturedAt precedent below). Unparseable ⇒ dropped (the ledger then
+    // uses capture time with the conservative fallback horizon).
+    const rawRegistrationEventAt = meta?.registrationEventAt ?? safeBody.registrationEventAt;
+    const regRevealMs = rawRegistrationEventAt ? Date.parse(rawRegistrationEventAt) : NaN;
+    const registrationEventAt = Number.isNaN(regRevealMs)
+      ? undefined
+      : new Date(Math.min(regRevealMs, Date.now())).toISOString();
     const ttclid = meta?.ttclid ?? safeBody.ttclid;
     const ttp = meta?.ttp ?? safeBody.ttp;
     // Google click ids + capture time (plan google-ads-signal-levers §4.1) —
@@ -245,7 +274,7 @@ export function makeProspectService(overrides = {}) {
     // Strip from body so they don't reach Sequelize as bogus Prospect attributes.
     const {
       eventId: _e, fbp: _p, fbc: _c, eventSourceUrl: _u,
-      registrationEventId: _re, ttclid: _tc, ttp: _tp,
+      registrationEventId: _re, registrationEventAt: _rea, ttclid: _tc, ttp: _tp,
       gclid: _gc, gbraid: _gb, wbraid: _wb, gclCapturedAt: _gca,
       consent_contact: _cc, consent_terms: _ct, consent_third_party: _ctp, consent_dnc: _cd,
       consent_copy_version: _ccv,
@@ -289,6 +318,7 @@ export function makeProspectService(overrides = {}) {
       ...(clientIp ? { clientIp } : {}),
       ...(clientUserAgent ? { clientUserAgent } : {}),
       ...(registrationEventId ? { registrationEventId } : {}),
+      ...(registrationEventAt ? { registrationEventAt } : {}),
       ...(ttclid ? { ttclid } : {}),
       ...(ttp ? { ttp } : {}),
       ...(gclid || gbraid || wbraid
@@ -794,6 +824,9 @@ export function makeProspectService(overrides = {}) {
         externalConsent,
         dncConsent,
         acceptedProfileFacts,
+        eventId,
+        registrationEventId,
+        registrationEventAt,
       });
     } catch (err) {
       // Concurrent same-campaign duplicate: both requests passed the precheck;
@@ -815,7 +848,7 @@ export function makeProspectService(overrides = {}) {
       throw err;
     }
 
-    const { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld } = txOutcome;
+    const { prospect, quarantined, heldReason, finalAgentId, dncHeld, screeningHeld, deliveriesPlanned } = txOutcome;
 
     // Hot-path signals (P3-5). Every capture lands here exactly once, after the
     // row commits, so these three answer "are leads arriving, and are they
@@ -842,6 +875,7 @@ export function makeProspectService(overrides = {}) {
       dncHeld,
       dncFlagApplies,
       screeningHeld,
+      deliveriesPlanned,
       externalAgentId,
       sourceCampaign,
       sourceQrTag,

--- a/backend/src/services/tiktokEventsService.js
+++ b/backend/src/services/tiktokEventsService.js
@@ -148,10 +148,14 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
     const ok = res.ok && body.code === 0;
 
     if (!ok) {
-      Sentry.captureException(new Error(`TikTok Events API failed: HTTP ${res.status} code ${body.code}`), {
-        tags: { source: 'tiktok_events', event_name: eventName },
-        extra: { status: res.status, body, prospect_id: prospect.id },
-      });
+      // suppressSentry: mirror of metaCapiService — the delivery ledger's
+      // retries classify + alert themselves; legacy callers are unchanged.
+      if (!options.suppressSentry) {
+        Sentry.captureException(new Error(`TikTok Events API failed: HTTP ${res.status} code ${body.code}`), {
+          tags: { source: 'tiktok_events', event_name: eventName },
+          extra: { status: res.status, body, prospect_id: prospect.id },
+        });
+      }
       logger.warn(
         { status: res.status, code: body.code, message: body.message, prospect_id: prospect.id, event_id: ctx.eventId },
         `tiktok.${logLabel}.failed`
@@ -165,10 +169,12 @@ export async function sendConversionEvent(prospect, ctx = {}, options = {}, deps
     );
     return { sent: true, status: res.status, body };
   } catch (err) {
-    Sentry.captureException(err, {
-      tags: { source: 'tiktok_events', event_name: eventName },
-      extra: { prospect_id: prospect.id, event_id: ctx.eventId },
-    });
+    if (!options.suppressSentry) {
+      Sentry.captureException(err, {
+        tags: { source: 'tiktok_events', event_name: eventName },
+        extra: { prospect_id: prospect.id, event_id: ctx.eventId },
+      });
+    }
     logger.error({ err: err.message, prospect_id: prospect.id }, `tiktok.${logLabel}.error`);
     return { sent: false, error: err.message };
   }

--- a/backend/src/utils/advisoryLock.js
+++ b/backend/src/utils/advisoryLock.js
@@ -1,0 +1,55 @@
+import { sequelize } from '../models/index.js';
+import { logger } from './logger.js';
+
+/**
+ * Shared advisory-lock helpers (ads-centralisation §7.6) — every new singleton
+ * background job runs under one of these instead of hand-rolling lock SQL.
+ *
+ * withAdvisoryLock: SESSION-scoped lock keyed by a STRING (hashed server-side
+ * with hashtext). Held on a DEDICATED connection for the duration of `fn` —
+ * pooled connections get recycled between queries, which would silently
+ * release a session lock mid-job (precedents: testRunLock.js:15-48,
+ * enrichmentSweepService.js withAdvisoryLock). Skip-if-held: a second caller
+ * gets { acquired: false } and does no work. The unlock + connection release
+ * run in `finally` — a throwing fn must never leak the lock.
+ *
+ * advisoryXactLock: TRANSACTION-scoped variant (pg_advisory_xact_lock) —
+ * blocks until granted, releases automatically at commit/rollback. For
+ * serializing short critical sections against each other inside transactions
+ * (e.g. per-session touchpoint stamp-vs-sweep in P3).
+ */
+export async function withAdvisoryLock(key, fn) {
+  if (typeof key !== 'string' || !key) throw new Error('withAdvisoryLock: key must be a non-empty string');
+  const cm = sequelize.connectionManager;
+  // The pg-dialect connection is the raw `pg` client; sequelize types it as a
+  // bare object, so name the one method we use.
+  const conn = /** @type {{ query: (q: { text: string, values: string[] }) => Promise<{ rows?: Array<{ ok?: boolean }> } & Array<{ ok?: boolean }>> }} */ (
+    await cm.getConnection({ type: 'write' })
+  );
+  let acquired = false;
+  try {
+    const res = await conn.query({ text: 'SELECT pg_try_advisory_lock(hashtext($1)) AS ok', values: [key] });
+    acquired = Boolean(res?.rows?.[0]?.ok ?? res?.[0]?.ok);
+    if (!acquired) return { acquired: false };
+    return { acquired: true, value: await fn() };
+  } finally {
+    if (acquired) {
+      try {
+        await conn.query({ text: 'SELECT pg_advisory_unlock(hashtext($1))', values: [key] });
+      } catch (err) {
+        logger.warn({ key, error: err?.message || String(err) }, 'advisory_lock.unlock_failed');
+      }
+    }
+    cm.releaseConnection(conn);
+  }
+}
+
+/**
+ * Take a transaction-scoped advisory lock inside `transaction`. Blocks until
+ * granted; Postgres releases it at commit/rollback (nothing to unlock).
+ */
+export async function advisoryXactLock(transaction, key) {
+  if (!transaction) throw new Error('advisoryXactLock: transaction is required');
+  if (typeof key !== 'string' || !key) throw new Error('advisoryXactLock: key must be a non-empty string');
+  await sequelize.query('SELECT pg_advisory_xact_lock(hashtext($1))', { bind: [key], transaction });
+}

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -18,7 +18,7 @@ import {
   RewardEntitlement, RedemptionEvent, Redemption, Draw, DrawEntry, DrawAttempt,
   ShortLink, WebhookSubscriber, WebhookDelivery, Verification, WaitlistSignup,
   ConsentEvent, ConsumerSuppression, PartnerOrganisation, RewardOffer, Activation,
-  SessionVisit, IdempotencyKey,
+  SessionVisit, IdempotencyKey, PlatformDelivery,
 } from '../../src/models/index.js';
 import { markPhoneVerified, isPhoneRecentlyVerified } from '../../src/services/verifiedPhoneStore.js';
 import { phoneHashOf } from '../../src/services/consumerService.js';
@@ -167,6 +167,19 @@ describe('PDPA erasure — full matrix', () => {
       key: `retell:call:call-in-${RUN}`, scope: 'retell:call',
       responseBody: { prospectId: prospect1.id, status: 'created' },
       expiresAt: new Date(Date.now() + 24 * 3600_000),
+    });
+
+    // Platform-delivery ledger rows (ads-centralisation §3.6): a pending and a
+    // sent row for this person — both must be hard-deleted in the erasure txn.
+    await PlatformDelivery.create({
+      prospectId: prospect1.id, platform: 'meta', eventKey: 'lead',
+      eventId: `erase-ev-${RUN}`, eventTime: new Date(), dedupeAnchorAt: new Date(),
+      state: 'pending',
+    });
+    await PlatformDelivery.create({
+      prospectId: prospect2.id, platform: 'tiktok', eventKey: 'lead',
+      eventId: `erase-ev2-${RUN}`, eventTime: new Date(), dedupeAnchorAt: new Date(),
+      state: 'sent', sentAt: new Date(),
     });
 
     // Redeem-ops chain: offer → activation → issued entitlement + redemption.
@@ -359,6 +372,8 @@ describe('PDPA erasure — full matrix', () => {
     expect(report.referralCopiesScrubbed).toBe(1);
     expect(report.sessionVisits).toBe(1);
     expect(report.attributions).toBe(1);
+    expect(report.platformDeliveries).toBe(2);
+    expect(await PlatformDelivery.count({ where: { prospectId: [prospect1.id, prospect2.id] } })).toBe(0);
     expect(report.idempotencyKeys).toBe(1);
     expect(report.retellCallIds).toContain(`call-in-${RUN}`);
     expect(report.leadDeletedQueued).toBeGreaterThanOrEqual(1);

--- a/backend/test/leadOutcomeService.test.js
+++ b/backend/test/leadOutcomeService.test.js
@@ -52,10 +52,20 @@ function buildDeps(overrides = {}) {
   const dispatchGoogleOutcome = overrides.dispatchGoogleOutcome ?? jest.fn().mockResolvedValue({ sent: true });
   const googleUploadsEnabled = overrides.googleUploadsEnabled ?? jest.fn().mockReturnValue(false);
   const googleActionIdFor = overrides.googleActionIdFor ?? jest.fn().mockReturnValue('act-1');
+  // Platform-delivery ledger seams (ads-centralisation §3.3.2/§3.3.5):
+  // this suite exercises the LEGACY direct-send contract, which is exactly
+  // the ledger's no-row path — so the ledger reports "not owned" and the
+  // facts+planning transaction is a pass-through stub (the fixtures' ids are
+  // not real rows; DB-backed coverage lives in platformDeliveries.test.js).
+  const fakeTransaction = (a, b) => (typeof a === 'function' ? a('t') : b('sp'));
+  const planOutcomeDeliveriesTx = overrides.planOutcomeDeliveriesTx ?? jest.fn().mockResolvedValue({ planned: false });
+  const dispatchOutcomeDelivery = overrides.dispatchOutcomeDelivery ?? jest.fn().mockResolvedValue({ owned: false });
   return {
     deps: {
       models: { Prospect, Campaign }, sendConversionEvent, canMarketTo, setSourceMetadataPath,
       mergeSourceMetadataFirstWins, dispatchGoogleOutcome, googleUploadsEnabled, googleActionIdFor,
+      sequelize: { transaction: fakeTransaction },
+      planOutcomeDeliveriesTx, dispatchOutcomeDelivery,
       logger: silentLogger, sleep, ...overrides.deps,
     },
     mergeSourceMetadataFirstWins,

--- a/backend/test/platformDeliveries.test.js
+++ b/backend/test/platformDeliveries.test.js
@@ -1,0 +1,658 @@
+/**
+ * DB-backed coverage for the platform-delivery outbox core
+ * (ads-centralisation §3.7): planning at both entry points (facts+rows
+ * atomicity, persisted-fact reads, erased/absent aborts, marker-aware skips,
+ * idempotence), the fenced claim/reservation/settle machine (races, ghost
+ * settles, the in-CAS reservation cap, config_blocked semantics, destination
+ * pinning), row-ownership routing (no dual send; the §3.3.5 outcome mapping
+ * incl. paused pending), the capture-path budget (plannedOk=false performs no
+ * queries), and the erasure fence.
+ */
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { sequelize, Prospect, PlatformDelivery } from '../src/models/index.js';
+import {
+  planSubmitDeliveriesTx,
+  planOutcomeDeliveriesTx,
+  processDelivery,
+  dispatchSubmitDeliveries,
+  dispatchOutcomeDelivery,
+} from '../src/services/platformDeliveryService.js';
+import { makeLeadOutcomeService } from '../src/services/leadOutcomeService.js';
+import { makeProspectService } from '../src/services/prospectService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+let admin;
+let campaign;
+
+const PLANNING_FLAG = 'PLATFORM_DELIVERY_PLANNING_ENABLED';
+
+function planningOn() { process.env[PLANNING_FLAG] = 'true'; }
+
+async function planned(prospect, { campaign: c = null, eventId = `ev-${prospect.id}`, registrationEventId, registrationEventAt } = {}) {
+  await sequelize.transaction(async (t) => {
+    await planSubmitDeliveriesTx(t, {
+      prospect, sourceCampaign: c, eventId, registrationEventId, registrationEventAt,
+    });
+  });
+  return PlatformDelivery.findAll({ where: { prospectId: prospect.id }, order: [['platform', 'ASC'], ['eventKey', 'ASC']], raw: true });
+}
+
+async function rowById(id) {
+  return PlatformDelivery.findByPk(id, { raw: true });
+}
+
+/** Force a row into an exact state via raw SQL (bypasses the state machine on purpose). */
+async function forceRow(id, sets) {
+  const cols = [];
+  const repl = { id };
+  for (const [k, v] of Object.entries(sets)) {
+    cols.push(`"${k}" = :${k}`);
+    repl[k] = v;
+  }
+  await sequelize.query(
+    `UPDATE platform_deliveries SET ${cols.join(', ')}, "updatedAt" = now() WHERE id = :id`,
+    { replacements: repl }
+  );
+}
+
+const metaOn = () => {
+  process.env.META_CAPI_ENABLED = 'true';
+  process.env.META_CAPI_ACCESS_TOKEN = 'test-token';
+};
+const tiktokOn = () => {
+  process.env.TIKTOK_EVENTS_API_ENABLED = 'true';
+  process.env.TIKTOK_ACCESS_TOKEN = 'test-token';
+};
+
+beforeAll(async () => {
+  await getApp();
+  ({ user: admin } = await createTestUser({ role: 'admin' }));
+  campaign = await createTestCampaign(admin.id, { metaPixelId: 'pix-meta-camp', tiktokPixelId: 'pix-tt-camp' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+afterEach(() => {
+  delete process.env[PLANNING_FLAG];
+  delete process.env.PLATFORM_DELIVERY_PAUSED;
+  delete process.env.META_CAPI_ENABLED;
+  delete process.env.META_CAPI_ACCESS_TOKEN;
+  delete process.env.TIKTOK_EVENTS_API_ENABLED;
+  delete process.env.TIKTOK_ACCESS_TOKEN;
+  delete process.env.META_PIXEL_ID;
+  delete process.env.TIKTOK_PIXEL_ID;
+  delete process.env.PLATFORM_DELIVERY_MAX_ATTEMPTS;
+  jest.restoreAllMocks();
+});
+
+describe('submit-time planning (§3.3.1)', () => {
+  it('plans nothing with the flag off — the SOLE row-creation control', async () => {
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('plans meta+tiktok lead rows (and CReg pairs only with a registrationEventId), pinning the campaign pixel', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign, registrationEventId: 'reg-1', registrationEventAt: new Date(Date.now() - 60_000).toISOString() });
+    expect(rows.map((r) => `${r.platform}:${r.eventKey}`).sort()).toEqual([
+      'meta:complete_registration', 'meta:lead', 'tiktok:complete_registration', 'tiktok:lead',
+    ]);
+    for (const r of rows) {
+      expect(r.state).toBe('pending');
+      expect(r.pixelId).toBe(r.platform === 'meta' ? 'pix-meta-camp' : 'pix-tt-camp');
+      expect(r.sendAttempts).toBe(0);
+    }
+    const creg = rows.find((r) => r.platform === 'meta' && r.eventKey === 'complete_registration');
+    const lead = rows.find((r) => r.platform === 'meta' && r.eventKey === 'lead');
+    // CReg anchors on the browser reveal timestamp — strictly before the lead's capture anchor.
+    expect(new Date(creg.dedupeAnchorAt).getTime()).toBeLessThan(new Date(lead.dedupeAnchorAt).getTime());
+    expect(creg.eventId).toBe('reg-1');
+  });
+
+  it('origin-excludes Retell / Meta-Lead-Ads prospects even with the flag on', async () => {
+    planningOn();
+    const retell = await createTestProspect(campaign.id, { leadSource: 'call_bot', retellCallId: `call-${Date.now()}` });
+    expect(await planned(retell, { campaign })).toHaveLength(0);
+    const mla = await createTestProspect(campaign.id, { leadSource: 'website', sourceMetadata: { metaLeadgenId: 'lg-1' } });
+    expect(await planned(mla, { campaign })).toHaveLength(0);
+  });
+
+  it('falls back to the env pixel, then NULL, at planning time', async () => {
+    planningOn();
+    process.env.META_PIXEL_ID = 'pix-meta-env';
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign: null });
+    const meta = rows.find((r) => r.platform === 'meta');
+    const tiktok = rows.find((r) => r.platform === 'tiktok');
+    expect(meta.pixelId).toBe('pix-meta-env');
+    expect(tiktok.pixelId).toBeNull(); // no campaign, no env id — resolvable later or config_blocked
+  });
+});
+
+describe('outcome planning — the shared in-txn helper (§3.3.2)', () => {
+  it('reads each key\'s PERSISTED fact as eventTime (an admin replay cannot retime CR)', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const t1 = '2026-08-10T00:00:00.000Z';
+    const t2 = '2026-08-15T00:00:00.000Z';
+    await p.update({ sourceMetadata: { outcomes: { confirmed_resident: t1, closed_won: t2 } } });
+    await sequelize.transaction(async (t) => {
+      // Caller passes NO timestamps — a later `won` replay carries none either.
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: p.id, keys: ['confirmed_resident', 'closed_won'] });
+      expect(res.inserted).toBe(2);
+    });
+    const rows = await PlatformDelivery.findAll({ where: { prospectId: p.id }, raw: true });
+    const cr = rows.find((r) => r.eventKey === 'confirmed_resident');
+    const cw = rows.find((r) => r.eventKey === 'closed_won');
+    expect(cr.platform).toBe('meta');
+    expect(new Date(cr.eventTime).toISOString()).toBe(t1);
+    expect(new Date(cr.dedupeAnchorAt).toISOString()).toBe(t1);
+    expect(new Date(cw.eventTime).toISOString()).toBe(t2);
+    expect(cr.eventId).toBe(`confirmed_resident:${p.id}`);
+    // Idempotent: replay inserts nothing and retimes nothing.
+    await p.update({ sourceMetadata: { outcomes: { confirmed_resident: '2026-08-16T00:00:00.000Z', closed_won: t2 } } });
+    await sequelize.transaction(async (t) => {
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: p.id, keys: ['confirmed_resident'] });
+      expect(res.inserted).toBe(0);
+    });
+    expect(new Date((await rowById(cr.id)).eventTime).toISOString()).toBe(t1);
+  });
+
+  it('aborts on erased and on an absent fact; skips keys with the exact legacy marker', async () => {
+    planningOn();
+    const erased = await createTestProspect(campaign.id, { leadSource: 'website', sourceMetadata: { erased: true, outcomes: { confirmed_resident: '2026-08-10T00:00:00Z' } } });
+    await sequelize.transaction(async (t) => {
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: erased.id, keys: ['confirmed_resident'] });
+      expect(res).toMatchObject({ planned: false, reason: 'erased' });
+    });
+    expect(await PlatformDelivery.count({ where: { prospectId: erased.id } })).toBe(0);
+
+    const noFact = await createTestProspect(campaign.id, { leadSource: 'website' });
+    await sequelize.transaction(async (t) => {
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: noFact.id, keys: ['confirmed_resident'] });
+      expect(res.inserted).toBe(0);
+    });
+
+    const marked = await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: { outcomes: { confirmed_resident: '2026-08-10T00:00:00Z' }, capi: { confirmedResidentAt: '2026-08-10T00:01:00Z' } },
+    });
+    await sequelize.transaction(async (t) => {
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: marked.id, keys: ['confirmed_resident'] });
+      expect(res.inserted).toBe(0); // old-binary outcome send is never re-planned
+    });
+  });
+
+  it('origin-excludes Retell prospects (outcome events stay legacy-guarded for them)', async () => {
+    planningOn();
+    const retell = await createTestProspect(campaign.id, {
+      leadSource: 'call_bot', retellCallId: `call-o-${Date.now()}`,
+      sourceMetadata: { outcomes: { confirmed_resident: '2026-08-10T00:00:00Z' } },
+    });
+    await sequelize.transaction(async (t) => {
+      const res = await planOutcomeDeliveriesTx(t, { prospectId: retell.id, keys: ['confirmed_resident'] });
+      expect(res).toMatchObject({ planned: false, reason: 'origin_excluded' });
+    });
+  });
+});
+
+describe('claim / reservation / settle machine (§3.3.3–.4)', () => {
+  async function onePendingRow(overrides = {}) {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign });
+    const row = rows.find((r) => r.platform === 'meta' && r.eventKey === 'lead');
+    if (Object.keys(overrides).length) await forceRow(row.id, overrides);
+    return { p, row: await rowById(row.id) };
+  }
+
+  it('claim race: exactly one of two concurrent attempts wins; the loser reports claim_miss', async () => {
+    metaOn();
+    const { row } = await onePendingRow();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const metaSend = jest.fn(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 150));
+      inFlight -= 1;
+      return { sent: true, status: 200, body: { fbtrace_id: 'fb-race' } };
+    });
+    const deps = { metaSend, canMarketTo: async () => false };
+    const [a, b] = await Promise.all([
+      processDelivery(row.id, { deps }),
+      processDelivery(row.id, { deps }),
+    ]);
+    const outcomes = [a.outcome, b.outcome].sort();
+    expect(outcomes).toEqual(['claim_miss', 'sent']);
+    expect(metaSend).toHaveBeenCalledTimes(1);
+    expect(maxInFlight).toBe(1);
+    const settled = await rowById(row.id);
+    expect(settled.state).toBe('sent');
+    expect(settled.sendAttempts).toBe(1);
+    expect(settled.providerRequestId).toBe('fb-race');
+  });
+
+  it('stale-lease reclaim resends; a ghost settle with the old token loses the CAS', async () => {
+    metaOn();
+    const ghostToken = '00000000-0000-4000-8000-000000000001';
+    const { row } = await onePendingRow({
+      state: 'sending', claimToken: ghostToken,
+      claimedAt: new Date(Date.now() - 11 * 60_000),
+      firstWireAt: new Date(Date.now() - 20 * 60_000), // a wire happened; settle was lost (accept-then-crash)
+      sendAttempts: 1,
+      lastAttemptAt: new Date(Date.now() - 20 * 60_000),
+    });
+    const metaSend = jest.fn(async () => ({ sent: true, status: 200, body: { fbtrace_id: 'fb-2' } }));
+    const res = await processDelivery(row.id, { deps: { metaSend, canMarketTo: async () => false } });
+    expect(res.outcome).toBe('sent'); // resend INSIDE the wire deadline — at-least-once
+    expect(metaSend).toHaveBeenCalledTimes(1);
+    // The ghost's settle (old token) must now hit nothing.
+    const [, meta] = await sequelize.query(
+      `UPDATE platform_deliveries SET state = 'retry_wait', "updatedAt" = now()
+        WHERE id = :id AND state = 'sending' AND "claimToken" = :token`,
+      { replacements: { id: row.id, token: ghostToken } }
+    );
+    expect(meta.rowCount).toBe(0);
+    expect((await rowById(row.id)).state).toBe('sent');
+  });
+
+  it('expires (never resends) a reclaimed row whose first wire was beyond the dedupe window', async () => {
+    metaOn();
+    const { row } = await onePendingRow({
+      state: 'sending', claimToken: '00000000-0000-4000-8000-000000000002',
+      claimedAt: new Date(Date.now() - 11 * 60_000),
+      firstWireAt: new Date(Date.now() - 48 * 3600_000),
+      sendAttempts: 1,
+    });
+    const metaSend = jest.fn();
+    const res = await processDelivery(row.id, { deps: { metaSend } });
+    expect(res.outcome).toBe('expired');
+    expect(metaSend).not.toHaveBeenCalled();
+    expect((await rowById(row.id)).state).toBe('expired');
+    expect((await rowById(row.id)).errorCode).toBe('deadline');
+  });
+
+  it('enforces the reservation cap IN the CAS — a capped row settles failed_permanent/retry_cap without a wire', async () => {
+    metaOn();
+    process.env.PLATFORM_DELIVERY_MAX_ATTEMPTS = '3';
+    const { row } = await onePendingRow({ sendAttempts: 3 });
+    const metaSend = jest.fn();
+    const res = await processDelivery(row.id, { deps: { metaSend } });
+    expect(res).toMatchObject({ outcome: 'failed_permanent', errorCode: 'retry_cap' });
+    expect(metaSend).not.toHaveBeenCalled();
+    const after = await rowById(row.id);
+    expect(after.state).toBe('failed_permanent');
+    expect(after.errorCode).toBe('retry_cap');
+    expect(after.sendAttempts).toBe(3); // the reservation never went through
+  });
+
+  it('config_blocked is non-terminal and burns NO attempt fields; it sends once config resolves', async () => {
+    const { row } = await onePendingRow(); // provider flags OFF
+    const res = await processDelivery(row.id, { deps: { metaSend: jest.fn() } });
+    expect(res.outcome).toBe('config_blocked');
+    let after = await rowById(row.id);
+    expect(after.state).toBe('config_blocked');
+    expect(after.sendAttempts).toBe(0);
+    expect(after.firstWireAt).toBeNull();
+    expect(after.lastAttemptAt).toBeNull();
+    expect(after.nextAttemptAt).not.toBeNull();
+
+    metaOn();
+    await forceRow(row.id, { nextAttemptAt: new Date(Date.now() - 1000) });
+    const metaSend = jest.fn(async () => ({ sent: true, status: 200, body: { fbtrace_id: 'fb-3' } }));
+    const res2 = await processDelivery(row.id, { deps: { metaSend, canMarketTo: async () => false } });
+    expect(res2.outcome).toBe('sent');
+    after = await rowById(row.id);
+    expect(after.sendAttempts).toBe(1);
+  });
+
+  it('destination pinned at planning survives campaign edit + env change; NULL destination blocks then pins on resolve', async () => {
+    planningOn();
+    metaOn();
+    const owner = await createTestUser({ role: 'admin' });
+    const editable = await createTestCampaign(owner.user.id, { metaPixelId: 'pix-original' });
+    const p = await createTestProspect(editable.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign: editable });
+    const metaRow = rows.find((r) => r.platform === 'meta' && r.eventKey === 'lead');
+    expect(metaRow.pixelId).toBe('pix-original');
+
+    await editable.update({ metaPixelId: 'pix-edited' });
+    process.env.META_PIXEL_ID = 'pix-env-late';
+    const metaSend = jest.fn(async (prospect, ctx) => ({ sent: true, status: 200, body: { fbtrace_id: `fb-${ctx.pixelIdOverride}` } }));
+    const res = await processDelivery(metaRow.id, { deps: { metaSend, canMarketTo: async () => false } });
+    expect(res.outcome).toBe('sent');
+    expect(metaSend.mock.calls[0][1].pixelIdOverride).toBe('pix-original'); // pinned, immutable once non-null
+
+    // NULL-destination row: blocks with zero attempt-field writes, then pins
+    // the late-resolved id. The prospect must be CAMPAIGN-LESS — a campaign
+    // pixel would resolve the destination at attempt time.
+    delete process.env.META_PIXEL_ID;
+    const p2 = await createTestProspect(null, { leadSource: 'website' });
+    const rows2 = await planned(p2, { campaign: null });
+    const nullRow = rows2.find((r) => r.platform === 'meta' && r.eventKey === 'lead');
+    expect(nullRow.pixelId).toBeNull();
+    const blocked = await processDelivery(nullRow.id, { deps: { metaSend: jest.fn() } });
+    expect(blocked.outcome).toBe('config_blocked');
+    expect((await rowById(nullRow.id)).sendAttempts).toBe(0);
+
+    process.env.META_PIXEL_ID = 'pix-env-resolved';
+    await forceRow(nullRow.id, { nextAttemptAt: new Date(Date.now() - 1000) });
+    const res2 = await processDelivery(nullRow.id, { deps: { metaSend, canMarketTo: async () => false } });
+    expect(res2.outcome).toBe('sent');
+    expect(metaSend.mock.calls[1][1].pixelIdOverride).toBe('pix-env-resolved');
+    expect((await rowById(nullRow.id)).pixelId).toBe('pix-env-resolved'); // pinned by the reservation CAS
+  });
+
+  it('writes the legacy capi marker in the settle transaction for outcome keys', async () => {
+    planningOn();
+    metaOn();
+    const factAt = new Date(Date.now() - 3600_000).toISOString(); // inside the 156h outcome horizon
+    const p = await createTestProspect(campaign.id, { leadSource: 'website', sourceMetadata: { outcomes: { confirmed_resident: factAt } } });
+    await sequelize.transaction(async (t) => {
+      await planOutcomeDeliveriesTx(t, { prospectId: p.id, keys: ['confirmed_resident'], campaign: null });
+    });
+    const row = await PlatformDelivery.findOne({ where: { prospectId: p.id, eventKey: 'confirmed_resident' }, raw: true });
+    process.env.META_PIXEL_ID = 'pix-any';
+    const before = Date.now();
+    const res = await processDelivery(row.id, { deps: { metaSend: async () => ({ sent: true, status: 200, body: { fbtrace_id: 'fb-o' } }), canMarketTo: async () => false } });
+    expect(res.outcome).toBe('sent');
+    const fresh = await Prospect.findByPk(p.id, { raw: true });
+    const marker = fresh.sourceMetadata?.capi?.confirmedResidentAt;
+    expect(marker).toBeTruthy();
+    expect(Date.parse(marker)).toBeGreaterThanOrEqual(before - 1000); // marker records DELIVERY time
+  });
+
+  it('skips (erased) between claim and wire — the pre-wire fresh check fences the send', async () => {
+    planningOn();
+    metaOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = await planned(p, { campaign });
+    const row = rows.find((r) => r.platform === 'meta' && r.eventKey === 'lead');
+    await p.update({ sourceMetadata: { erased: true } });
+    const metaSend = jest.fn();
+    const res = await processDelivery(row.id, { deps: { metaSend } });
+    expect(res).toMatchObject({ outcome: 'skipped', errorCode: 'erased' });
+    expect(metaSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('row-ownership routing (§3.2/§3.3.5)', () => {
+  it('plannedOk=false performs NO ownership query and fires every legacy closure synchronously (§3.4 budget)', async () => {
+    const findAllSpy = jest.spyOn(PlatformDelivery, 'findAll');
+    const fired = [];
+    const legacy = {
+      metaLead: () => fired.push('metaLead'),
+      metaCompleteRegistration: () => fired.push('metaCReg'),
+      tiktokLead: () => fired.push('tiktokLead'),
+      tiktokCompleteRegistration: null, // no reveal happened
+    };
+    const promise = dispatchSubmitDeliveries({ prospect: { id: 'no-such' }, plannedOk: false, marketingConsent: false, legacy });
+    // The legacy closures fire synchronously — before the promise resolves.
+    expect(fired).toEqual(['metaLead', 'metaCReg', 'tiktokLead']);
+    await promise;
+    expect(findAllSpy).not.toHaveBeenCalled();
+  });
+
+  it('pairs WITH rows never fire legacy senders (no dual send), even when the ledger attempt is blocked', async () => {
+    planningOn(); // provider flags OFF ⇒ the ledger attempt config_blocks; legacy must STILL not fire
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    await planned(p, { campaign, registrationEventId: 'reg-dual' });
+    const fired = [];
+    const legacy = {
+      metaLead: () => fired.push('metaLead'),
+      metaCompleteRegistration: () => fired.push('metaCReg'),
+      tiktokLead: () => fired.push('tiktokLead'),
+      tiktokCompleteRegistration: () => fired.push('tiktokCReg'),
+    };
+    const { owned } = await dispatchSubmitDeliveries({ prospect: p, plannedOk: true, marketingConsent: false, legacy });
+    expect(owned).toHaveLength(4);
+    expect(fired).toEqual([]);
+    // Give the floating inline attempts a beat, then confirm they classified config_blocked.
+    await new Promise((r) => setTimeout(r, 300));
+    const states = (await PlatformDelivery.findAll({ where: { prospectId: p.id }, raw: true })).map((r) => r.state);
+    expect(new Set(states)).toEqual(new Set(['config_blocked']));
+  });
+
+  it('mixed states: only the pair WITHOUT a row falls back to legacy', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    await planned(p, { campaign }); // lead rows only — no CReg rows
+    const fired = [];
+    const legacy = {
+      metaLead: () => fired.push('metaLead'),
+      metaCompleteRegistration: () => fired.push('metaCReg'),
+      tiktokLead: () => fired.push('tiktokLead'),
+      tiktokCompleteRegistration: () => fired.push('tiktokCReg'),
+    };
+    await dispatchSubmitDeliveries({ prospect: p, plannedOk: true, marketingConsent: false, legacy });
+    expect(fired.sort()).toEqual(['metaCReg', 'tiktokCReg']);
+  });
+
+  it('dispatchOutcomeDelivery maps every row state onto the legacy contract (§3.3.5, incl. paused pending)', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website', sourceMetadata: { outcomes: { confirmed_resident: new Date().toISOString() } } });
+    expect(await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).toEqual({ owned: false });
+
+    await sequelize.transaction(async (t) => {
+      await planOutcomeDeliveriesTx(t, { prospectId: p.id, keys: ['confirmed_resident'] });
+    });
+    const row = await PlatformDelivery.findOne({ where: { prospectId: p.id, eventKey: 'confirmed_resident' }, raw: true });
+
+    // pending + PAUSED ⇒ transientFailed (send work paused, row stays owned)
+    process.env.PLATFORM_DELIVERY_PAUSED = 'true';
+    expect(await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' }))
+      .toEqual({ owned: true, legacyOutcome: 'transientFailed' });
+    expect((await rowById(row.id)).state).toBe('pending');
+    delete process.env.PLATFORM_DELIVERY_PAUSED;
+
+    // held by an ACTIVE lease ⇒ transientFailed
+    await forceRow(row.id, { state: 'sending', claimedAt: new Date(), claimToken: '00000000-0000-4000-8000-00000000000a' });
+    expect((await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).legacyOutcome).toBe('transientFailed');
+
+    // config_blocked, not due ⇒ guarded
+    await forceRow(row.id, { state: 'config_blocked', claimToken: null, claimedAt: null, nextAttemptAt: new Date(Date.now() + 3600_000) });
+    expect((await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).legacyOutcome).toBe('guarded');
+
+    // retry_wait, not due ⇒ transientFailed
+    await forceRow(row.id, { state: 'retry_wait', nextAttemptAt: new Date(Date.now() + 3600_000) });
+    expect((await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).legacyOutcome).toBe('transientFailed');
+
+    // terminal failure ⇒ permanentFailed
+    await forceRow(row.id, { state: 'expired', nextAttemptAt: null });
+    expect((await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).legacyOutcome).toBe('permanentFailed');
+
+    // pre-existing sent ⇒ duplicate
+    await forceRow(row.id, { state: 'sent' });
+    expect((await dispatchOutcomeDelivery({ prospectId: p.id, key: 'confirmed_resident' })).legacyOutcome).toBe('duplicate');
+  });
+});
+
+describe('outcome entry points — facts+rows atomicity (§3.3.2)', () => {
+  function outcomeService(overrides = {}) {
+    return makeLeadOutcomeService({
+      googleUploadsEnabled: () => false,
+      canMarketTo: async () => false,
+      sendConversionEvent: jest.fn(async () => ({ sent: true, status: 200, body: {} })),
+      logger: silentLogger,
+      ...overrides,
+    });
+  }
+
+  it('processLeadOutcome commits fact + row together; the row carries the persisted fact time', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const occurredAt = new Date(Date.now() - 3600_000).toISOString(); // inside the outcome horizon
+    const svc = outcomeService();
+    const result = await svc.processLeadOutcome({ external_id: p.id, new_status: 'qualified', occurred_at: occurredAt });
+    expect(result.skipped).toBeUndefined();
+    const fresh = await Prospect.findByPk(p.id, { raw: true });
+    expect(fresh.sourceMetadata.outcomes.confirmed_resident).toBe(occurredAt);
+    const row = await PlatformDelivery.findOne({ where: { prospectId: p.id, eventKey: 'confirmed_resident' }, raw: true });
+    expect(row).not.toBeNull();
+    expect(new Date(row.eventTime).toISOString()).toBe(occurredAt);
+  });
+
+  it('a failed planning step rolls the WHOLE facts+planning txn back — no fact, no row (reconciler heals)', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const svc = outcomeService({
+      planOutcomeDeliveriesTx: jest.fn(async () => { throw new Error('boom'); }),
+    });
+    await svc.processLeadOutcome({ external_id: p.id, new_status: 'qualified', occurred_at: '2026-08-14T03:00:00.000Z' });
+    const fresh = await Prospect.findByPk(p.id, { raw: true });
+    expect(fresh.sourceMetadata?.outcomes?.confirmed_resident).toBeUndefined();
+    expect(await PlatformDelivery.count({ where: { prospectId: p.id } })).toBe(0);
+  });
+
+  it('routes ledger-owned keys through the row and maps a not-due row to transientFailed (external 503 contract feed)', async () => {
+    planningOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const svc = outcomeService();
+    // First pass plans the row; provider flags are OFF so the inline attempt config_blocks ⇒ guarded.
+    const first = await svc.processLeadOutcome({
+      external_id: p.id, new_status: 'qualified', occurred_at: new Date(Date.now() - 3600_000).toISOString(),
+    });
+    expect(first.guarded).toContain('ConfirmedResident');
+    // Force the row into a future retry_wait: the replay must classify transientFailed off the ROW,
+    // and the legacy sender must never fire (ownership).
+    const row = await PlatformDelivery.findOne({ where: { prospectId: p.id, eventKey: 'confirmed_resident' }, raw: true });
+    await forceRow(row.id, { state: 'retry_wait', nextAttemptAt: new Date(Date.now() + 3600_000), errorCode: 'http_5xx' });
+    const sendConversionEvent = jest.fn();
+    const svc2 = outcomeService({ sendConversionEvent });
+    const replay = await svc2.processLeadOutcome({ external_id: p.id, new_status: 'qualified', occurred_at: '2026-08-14T04:00:00.000Z' });
+    expect(replay.transientFailed).toContain('ConfirmedResident');
+    expect(sendConversionEvent).not.toHaveBeenCalled();
+  });
+
+  it('admin edit plans rows inside the status transaction (savepoint-isolated: a planner failure never fails the edit)', async () => {
+    planningOn();
+    const svc = makeProspectService({
+      buildProspectWhere: async () => ({}),
+      processLeadOutcome: jest.fn(async () => ({ dispatched: [], duplicate: [], failed: [] })),
+      logger: silentLogger,
+    });
+    const p1 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    await svc.updateProspect(p1.id, { leadStatus: 'qualified' }, { id: admin.id, role: 'admin' });
+    const fresh1 = await Prospect.findByPk(p1.id, { raw: true });
+    expect(fresh1.sourceMetadata.outcomes.confirmed_resident).toBeTruthy();
+    const row = await PlatformDelivery.findOne({ where: { prospectId: p1.id, eventKey: 'confirmed_resident' }, raw: true });
+    expect(row).not.toBeNull();
+    expect(new Date(row.eventTime).toISOString()).toBe(fresh1.sourceMetadata.outcomes.confirmed_resident);
+
+    // Savepoint isolation: a throwing planner loses the rows but keeps the edit + the fact.
+    const svcBroken = makeProspectService({
+      buildProspectWhere: async () => ({}),
+      processLeadOutcome: jest.fn(async () => ({ dispatched: [], duplicate: [], failed: [] })),
+      planOutcomeDeliveriesTx: jest.fn(async () => { throw new Error('planner down'); }),
+      logger: silentLogger,
+    });
+    const p2 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const updated = await svcBroken.updateProspect(p2.id, { leadStatus: 'qualified' }, { id: admin.id, role: 'admin' });
+    expect(updated.leadStatus).toBe('qualified');
+    const fresh2 = await Prospect.findByPk(p2.id, { raw: true });
+    expect(fresh2.sourceMetadata.outcomes.confirmed_resident).toBeTruthy();
+    expect(await PlatformDelivery.count({ where: { prospectId: p2.id } })).toBe(0); // sweep heals
+  });
+});
+
+describe('capture path (§3.3.1/§3.4/§3.8)', () => {
+  function captureService(overrides = {}) {
+    return makeProspectService({
+      dispatchEvent: jest.fn(async () => {}),
+      canMarketTo: async () => false,
+      sendLeadEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendCompleteRegistrationEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendTikTokLeadEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendTikTokCompleteRegistrationEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      logger: silentLogger,
+      ...overrides,
+    });
+  }
+
+  const submitBody = (extra = {}) => ({
+    firstName: 'Cap',
+    lastName: 'Ture',
+    // Random 8-digit number — the helpers factory mints Date.now()+n phones in
+    // THIS SAME campaign, so a clock-derived suffix here can collide with it
+    // under the per-campaign (campaignId, phone) unique index.
+    phone: `+65${String(10000000 + Math.floor(Math.random() * 89999999))}`,
+    leadSource: 'website',
+    campaignId: campaign.id,
+    ...extra,
+  });
+
+  it('plans the four rows in the capture transaction and persists the clamped reveal timestamp', async () => {
+    planningOn();
+    const svc = captureService();
+    const future = new Date(Date.now() + 3600_000).toISOString();
+    const { prospect } = await svc.createProspect(submitBody(), null, {
+      meta: { eventId: 'cap-ev-1', registrationEventId: 'cap-reg-1', registrationEventAt: future },
+    });
+    const rows = await PlatformDelivery.findAll({ where: { prospectId: prospect.id }, raw: true });
+    expect(rows).toHaveLength(4);
+    const fresh = await Prospect.findByPk(prospect.id, { raw: true });
+    // Forged future reveal is clamped to ≤ now.
+    expect(Date.parse(fresh.sourceMetadata.registrationEventAt)).toBeLessThanOrEqual(Date.now());
+    const creg = rows.find((r) => r.platform === 'meta' && r.eventKey === 'complete_registration');
+    expect(Date.parse(new Date(creg.dedupeAnchorAt).toISOString())).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('server-generates a persisted eventId when the client omits one, and the lead rows use it', async () => {
+    planningOn();
+    const svc = captureService();
+    const { prospect } = await svc.createProspect(submitBody(), null, {});
+    const fresh = await Prospect.findByPk(prospect.id, { raw: true });
+    expect(fresh.sourceMetadata.eventId).toMatch(/^[0-9a-f-]{36}$/);
+    const rows = await PlatformDelivery.findAll({ where: { prospectId: prospect.id, eventKey: 'lead' }, raw: true });
+    expect(rows).toHaveLength(2);
+    for (const r of rows) expect(r.eventId).toBe(fresh.sourceMetadata.eventId);
+  });
+
+  it('savepoint failure ⇒ capture succeeds, no rows, and the legacy senders fire (§3.3.1)', async () => {
+    planningOn();
+    const sendLeadEvent = jest.fn(async () => ({ sent: false, reason: 'guarded' }));
+    const sendTikTokLeadEvent = jest.fn(async () => ({ sent: false, reason: 'guarded' }));
+    const svc = captureService({
+      sendLeadEvent,
+      sendTikTokLeadEvent,
+      planSubmitDeliveriesTx: jest.fn(async () => { throw new Error('outbox down'); }),
+    });
+    const { prospect } = await svc.createProspect(submitBody(), null, { meta: { eventId: 'cap-ev-sp' } });
+    expect(prospect.id).toBeTruthy();
+    expect(await PlatformDelivery.count({ where: { prospectId: prospect.id } })).toBe(0);
+    await new Promise((r) => setTimeout(r, 100)); // dispatch is fire-and-forget
+    expect(sendLeadEvent).toHaveBeenCalledTimes(1);
+    expect(sendTikTokLeadEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('planning OFF is byte-equivalent legacy: no rows, legacy senders fire (§3.8 rollback shape)', async () => {
+    const sendLeadEvent = jest.fn(async () => ({ sent: false, reason: 'guarded' }));
+    const svc = captureService({ sendLeadEvent });
+    const { prospect } = await svc.createProspect(submitBody(), null, { meta: { eventId: 'cap-ev-off' } });
+    expect(await PlatformDelivery.count({ where: { prospectId: prospect.id } })).toBe(0);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(sendLeadEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('planning ON: ledger owns the pairs — legacy senders never fire (no dual send)', async () => {
+    planningOn();
+    const sendLeadEvent = jest.fn();
+    const sendTikTokLeadEvent = jest.fn();
+    const svc = captureService({ sendLeadEvent, sendTikTokLeadEvent });
+    const { prospect } = await svc.createProspect(submitBody(), null, { meta: { eventId: 'cap-ev-own' } });
+    await new Promise((r) => setTimeout(r, 300));
+    expect(sendLeadEvent).not.toHaveBeenCalled();
+    expect(sendTikTokLeadEvent).not.toHaveBeenCalled();
+    const rows = await PlatformDelivery.findAll({ where: { prospectId: prospect.id }, raw: true });
+    expect(rows).toHaveLength(2);
+    // Provider flags are off ⇒ the inline attempts classified config_blocked (no wire, no legacy).
+    for (const r of rows) expect(['pending', 'config_blocked']).toContain(r.state);
+  });
+});

--- a/backend/test/platformDeliveryWorker.test.js
+++ b/backend/test/platformDeliveryWorker.test.js
@@ -1,0 +1,271 @@
+/**
+ * DB-backed worker coverage (ads-centralisation §3.3.7/§3.5/§3.6): due-scan
+ * ordering + bounded concurrency, the expiry rules (runs with provider flags
+ * off; transitions only unsent states + STALE sending — never an active
+ * lease; a paused ledger still expires), the accept-then-disconnect provider
+ * fake (at-least-once), the hourly outcome invariant sweep, and the daily
+ * retention purge.
+ */
+import { jest } from '@jest/globals';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { sequelize, PlatformDelivery } from '../src/models/index.js';
+import {
+  runDeliveryWorker,
+  runExpiryPass,
+  runOutcomeInvariantSweep,
+  runRetentionPurge,
+  processDelivery,
+  _resetWorkerCadence,
+} from '../src/services/platformDeliveryService.js';
+
+let admin;
+let campaign;
+
+async function mintRow(prospectId, overrides = {}) {
+  return PlatformDelivery.create({
+    prospectId,
+    platform: 'meta',
+    eventKey: 'lead',
+    eventId: `ev-${prospectId}-${overrides.eventKey || 'lead'}`,
+    eventTime: new Date(),
+    dedupeAnchorAt: new Date(),
+    pixelId: 'pix-w',
+    state: 'pending',
+    ...overrides,
+  });
+}
+
+async function forceRow(id, sets) {
+  const cols = [];
+  const repl = { id };
+  for (const [k, v] of Object.entries(sets)) {
+    cols.push(`"${k}" = :${k}`);
+    repl[k] = v;
+  }
+  await sequelize.query(
+    `UPDATE platform_deliveries SET ${cols.join(', ')}, "updatedAt" = now() WHERE id = :id`,
+    { replacements: repl }
+  );
+}
+
+const rowById = (id) => PlatformDelivery.findByPk(id, { raw: true });
+
+beforeAll(async () => {
+  await getApp();
+  ({ user: admin } = await createTestUser({ role: 'admin' }));
+  campaign = await createTestCampaign(admin.id, { metaPixelId: 'pix-w' });
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+beforeEach(async () => {
+  _resetWorkerCadence();
+  // The worker's due-scan and the invariant sweep are GLOBAL — start every
+  // test from an empty ledger so rows left by earlier suites in this same
+  // jest process can't leak into scans.
+  await sequelize.query(`DELETE FROM platform_deliveries`);
+});
+
+afterEach(() => {
+  delete process.env.PLATFORM_DELIVERY_PLANNING_ENABLED;
+  delete process.env.PLATFORM_DELIVERY_PAUSED;
+  delete process.env.META_CAPI_ENABLED;
+  delete process.env.META_CAPI_ACCESS_TOKEN;
+  jest.restoreAllMocks();
+});
+
+const metaOn = () => {
+  process.env.META_CAPI_ENABLED = 'true';
+  process.env.META_CAPI_ACCESS_TOKEN = 'test-token';
+};
+
+describe('runDeliveryWorker — send pass', () => {
+  it('attempts due rows in COALESCE(nextAttemptAt, createdAt) order with concurrency ≤5', async () => {
+    metaOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const rows = [];
+    for (let i = 0; i < 7; i++) {
+      const r = await mintRow(p.id, {
+        prospectId: (await createTestProspect(campaign.id, { leadSource: 'website' })).id,
+        state: 'retry_wait',
+        nextAttemptAt: new Date(Date.now() - (7 - i) * 60_000), // row 0 most overdue
+      });
+      rows.push(r);
+    }
+    const order = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const metaSend = jest.fn(async (prospect, ctx) => {
+      order.push(ctx.eventId);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((res) => setTimeout(res, 60));
+      inFlight -= 1;
+      return { sent: true, status: 200, body: { fbtrace_id: 'fb-w' } };
+    });
+    const out = await runDeliveryWorker({ deps: { metaSend, canMarketTo: async () => false } });
+    expect(out.acquired).toBe(true);
+    expect(out.value.attempted).toBe(7);
+    expect(out.value.outcomes.sent).toBe(7);
+    expect(maxInFlight).toBeLessThanOrEqual(5);
+    // Every due row was attempted exactly once; the first five lane fills are
+    // drawn from the five most-overdue rows (send-call order within them can
+    // race on claim latency, so assert membership, not sequence).
+    expect(new Set(order)).toEqual(new Set(rows.map((r) => r.eventId)));
+    expect(new Set(order.slice(0, 5))).toEqual(new Set(rows.slice(0, 5).map((r) => r.eventId)));
+  });
+
+  it('PAUSED skips send work but the expiry pass still runs', async () => {
+    metaOn();
+    process.env.PLATFORM_DELIVERY_PAUSED = 'true';
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const due = await mintRow(p.id, { state: 'pending', createdAt: new Date(Date.now() - 10 * 60_000) });
+    await forceRow(due.id, { createdAt: new Date(Date.now() - 10 * 60_000) }); // model create ignores createdAt override
+    const p2 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const past = await mintRow(p2.id, { eventKey: 'confirmed_resident', eventId: `cr:${p2.id}` });
+    await forceRow(past.id, { dedupeAnchorAt: new Date(Date.now() - 200 * 3600_000) });
+    const metaSend = jest.fn();
+    const out = await runDeliveryWorker({ deps: { metaSend } });
+    expect(metaSend).not.toHaveBeenCalled();
+    expect(out.value.attempted).toBe(0);
+    expect(out.value.expired).toBe(1);
+    expect((await rowById(past.id)).state).toBe('expired');
+    expect((await rowById(due.id)).state).toBe('pending'); // paused, not expired (inside horizon)
+  });
+
+  it('with provider flags OFF the attempts classify config_blocked and expiry still runs in the same tick', async () => {
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const due = await mintRow(p.id, { state: 'retry_wait', nextAttemptAt: new Date(Date.now() - 1000) });
+    const p2 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const old = await mintRow(p2.id, {});
+    await forceRow(old.id, { dedupeAnchorAt: new Date(Date.now() - 60 * 3600_000) });
+    const out = await runDeliveryWorker({ deps: {} });
+    expect(out.value.outcomes.config_blocked).toBeGreaterThanOrEqual(1);
+    expect((await rowById(due.id)).state).toBe('config_blocked');
+    expect((await rowById(old.id)).state).toBe('expired');
+  });
+
+  it('accept-then-disconnect provider: the retry resends the SAME event id (at-least-once with provider dedupe)', async () => {
+    metaOn();
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const row = await mintRow(p.id, {});
+    // Attempt 1: the provider ingested the event but the socket died before the response.
+    const disconnecting = jest.fn(async () => ({ sent: false, error: 'socket hang up' }));
+    const first = await processDelivery(row.id, { deps: { metaSend: disconnecting, canMarketTo: async () => false, jitterRatio: 0 } });
+    expect(first.outcome).toBe('retry_wait');
+    let mid = await rowById(row.id);
+    expect(mid.state).toBe('retry_wait');
+    expect(mid.sendAttempts).toBe(1);
+    expect(mid.firstWireAt).not.toBeNull(); // the wire anchor exists even though the result was lost
+    // Attempt 2 (due): same eventId goes out again — the provider dedupes.
+    await forceRow(row.id, { nextAttemptAt: new Date(Date.now() - 1000) });
+    const sends = [];
+    const ok = jest.fn(async (prospect, ctx) => { sends.push(ctx.eventId); return { sent: true, status: 200, body: { fbtrace_id: 'fb-2' } }; });
+    const second = await processDelivery(row.id, { deps: { metaSend: ok, canMarketTo: async () => false } });
+    expect(second.outcome).toBe('sent');
+    expect(sends).toEqual([row.eventId]);
+    expect((await rowById(row.id)).sendAttempts).toBe(2);
+  });
+});
+
+describe('runExpiryPass — §3.3.7 rules', () => {
+  it('never touches an ACTIVE sending lease, even past deadline; a stale lease expires', async () => {
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const active = await mintRow(p.id, {});
+    await forceRow(active.id, {
+      state: 'sending', claimedAt: new Date(), claimToken: '00000000-0000-4000-8000-0000000000b1',
+      dedupeAnchorAt: new Date(Date.now() - 60 * 3600_000),
+    });
+    expect(await runExpiryPass()).toBe(0);
+    expect((await rowById(active.id)).state).toBe('sending'); // in-flight settle wins
+
+    await forceRow(active.id, { claimedAt: new Date(Date.now() - 11 * 60_000) });
+    expect(await runExpiryPass()).toBe(1);
+    expect((await rowById(active.id)).state).toBe('expired');
+  });
+
+  it('applies the CReg anchor-vs-fallback split off the prospect\'s persisted reveal timestamp', async () => {
+    const withAnchor = await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: { registrationEventAt: new Date(Date.now() - 30 * 3600_000).toISOString() },
+    });
+    const anchored = await mintRow(withAnchor.id, { eventKey: 'complete_registration', eventId: `reg-${withAnchor.id}` });
+    await forceRow(anchored.id, { dedupeAnchorAt: new Date(Date.now() - 30 * 3600_000) });
+
+    const withoutAnchor = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const fallback = await mintRow(withoutAnchor.id, { eventKey: 'complete_registration', eventId: `reg-${withoutAnchor.id}` });
+    await forceRow(fallback.id, { dedupeAnchorAt: new Date(Date.now() - 30 * 3600_000) });
+
+    await runExpiryPass();
+    // 30h old: inside the 47h anchored horizon, past the 24h fallback horizon.
+    expect((await rowById(anchored.id)).state).toBe('pending');
+    expect((await rowById(fallback.id)).state).toBe('expired');
+  });
+});
+
+describe('runOutcomeInvariantSweep — §3.5', () => {
+  it('plans rows for young facts with no row and no marker; skips marked, old, and already-rowed facts', async () => {
+    process.env.PLATFORM_DELIVERY_PLANNING_ENABLED = 'true';
+    const young = await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: { outcomes: { confirmed_resident: new Date(Date.now() - 3600_000).toISOString() } },
+    });
+    const marked = await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: {
+        outcomes: { confirmed_resident: new Date(Date.now() - 3600_000).toISOString() },
+        capi: { confirmedResidentAt: new Date().toISOString() },
+      },
+    });
+    const old = await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: { outcomes: { confirmed_resident: new Date(Date.now() - 200 * 3600_000).toISOString() } },
+    });
+    const planned = await runOutcomeInvariantSweep();
+    // The sweep is global — prospects from earlier suites in this jest
+    // process may be healed too, so assert per-prospect, not the total.
+    expect(planned).toBeGreaterThanOrEqual(1);
+    expect(await PlatformDelivery.count({ where: { prospectId: young.id, eventKey: 'confirmed_resident' } })).toBe(1);
+    expect(await PlatformDelivery.count({ where: { prospectId: marked.id } })).toBe(0);
+    expect(await PlatformDelivery.count({ where: { prospectId: old.id } })).toBe(0);
+    // Idempotent: a second sweep plans nothing new (every plannable fact now has its row).
+    expect(await runOutcomeInvariantSweep()).toBe(0);
+  });
+
+  it('plans nothing with the planning flag off (sole row-creation control)', async () => {
+    await createTestProspect(campaign.id, {
+      leadSource: 'website',
+      sourceMetadata: { outcomes: { closed_won: new Date().toISOString() } },
+    });
+    expect(await runOutcomeInvariantSweep()).toBe(0);
+  });
+});
+
+describe('runRetentionPurge — §3.6', () => {
+  it('purges only terminal rows older than the retention window', async () => {
+    const p = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const oldSent = await mintRow(p.id, {});
+    await forceRow(oldSent.id, { state: 'sent' });
+    await sequelize.query(
+      `UPDATE platform_deliveries SET "updatedAt" = now() - interval '100 days' WHERE id = :id`,
+      { replacements: { id: oldSent.id } }
+    );
+    const p2 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const oldPending = await mintRow(p2.id, {});
+    await sequelize.query(
+      `UPDATE platform_deliveries SET "updatedAt" = now() - interval '100 days' WHERE id = :id`,
+      { replacements: { id: oldPending.id } }
+    );
+    const p3 = await createTestProspect(campaign.id, { leadSource: 'website' });
+    const freshSent = await mintRow(p3.id, {});
+    await forceRow(freshSent.id, { state: 'sent' });
+
+    const purged = await runRetentionPurge();
+    expect(purged).toBe(1);
+    expect(await rowById(oldSent.id)).toBeNull();
+    expect(await rowById(oldPending.id)).not.toBeNull(); // non-terminal rows are never purged
+    expect(await rowById(freshSent.id)).not.toBeNull();
+  });
+});

--- a/backend/test/prospectServiceCapi.test.js
+++ b/backend/test/prospectServiceCapi.test.js
@@ -151,18 +151,22 @@ describe('prospectService.createProspect → CAPI wire-up (Phase 2)', () => {
     );
 
     const created = deps.models.Prospect.create.mock.calls[0][0];
-    expect(created.sourceMetadata).toEqual({ keep: 'me', clientIp: '1.2.3.4' });
+    // eventId is always present now — server-generated when the client omits
+    // one, so no submit bypasses delivery-ledger durability (ads-centralisation §3.3.1).
+    expect(created.sourceMetadata).toEqual({ keep: 'me', clientIp: '1.2.3.4', eventId: expect.any(String) });
   });
 
-  it('does NOT touch sourceMetadata when no meta-fields are present (no empty object pollution)', async () => {
+  it('writes only the server-generated eventId when no meta-fields are present (§3.3.1)', async () => {
     const deps = buildDeps();
     const svc = makeProspectService(deps);
 
     await svc.createProspect({ ...baseBody }, { id: 'admin-1', role: 'admin' }, {});
 
     const created = deps.models.Prospect.create.mock.calls[0][0];
-    // incoming.sourceMetadata is left untouched (undefined here, since not set)
-    expect(created.sourceMetadata).toBeUndefined();
+    // The one deliberate addition: a UUID eventId (delivery-ledger dedup key).
+    // Everything else stays untouched — no empty-object pollution beyond it.
+    expect(created.sourceMetadata).toEqual({ eventId: expect.any(String) });
+    expect(created.sourceMetadata.eventId).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   it('calls sendLeadEvent post-commit with the created prospect and ctx', async () => {
@@ -233,7 +237,8 @@ describe('prospectService.createProspect → CAPI wire-up (Phase 2)', () => {
     expect(deps.sendLeadEvent).toHaveBeenCalledTimes(1);
     const [, ctxArg] = deps.sendLeadEvent.mock.calls[0];
     expect(ctxArg).toEqual({
-      eventId: undefined,
+      // Server-generated when the client sends none (ads-centralisation §3.3.1).
+      eventId: expect.any(String),
       fbp: undefined,
       fbc: undefined,
       eventSourceUrl: undefined,
@@ -266,6 +271,7 @@ describe('createProspect → consent persistence (Phase 4 step 1b)', () => {
     expect(created.sourceMetadata).toEqual({
       consent_contact: true,
       consent_terms: true,
+      eventId: expect.any(String), // always present since ads-centralisation §3.3.1
     });
   });
 
@@ -283,6 +289,7 @@ describe('createProspect → consent persistence (Phase 4 step 1b)', () => {
     expect(created.sourceMetadata).toEqual({
       consent_contact: false,
       consent_terms: true,
+      eventId: expect.any(String), // always present since ads-centralisation §3.3.1
     });
   });
 
@@ -293,7 +300,8 @@ describe('createProspect → consent persistence (Phase 4 step 1b)', () => {
     await svc.createProspect({ ...baseBody }, { id: 'admin-1', role: 'admin' }, {});
 
     const created = deps.models.Prospect.create.mock.calls[0][0];
-    expect(created.sourceMetadata).toBeUndefined();
+    // Only the always-present server-generated eventId — no consent keys.
+    expect(created.sourceMetadata).toEqual({ eventId: expect.any(String) });
   });
 
   it('strips consent fields from Prospect attributes (no Sequelize attribute leakage)', async () => {

--- a/backend/test/retellRecordingScope.test.js
+++ b/backend/test/retellRecordingScope.test.js
@@ -29,7 +29,11 @@ beforeAll(async () => {
   prospect = await createTestProspect(campaign.id, {
     assignedAgentId: owner.user.id,
     leadSource: 'call_bot',
-    sourceMetadata: { retellCallId: 'call-p1-4', recordingUrl: RECORDING_URL },
+    // recordingMultiChannelUrl key present = both legs already resolved (the
+    // #470 split-recording contract) — without it the endpoint earns a one-off
+    // live Retell refetch, which 503s in tests (no API). null = "refetched,
+    // Retell had no split file", the cached mono-URL shape.
+    sourceMetadata: { retellCallId: 'call-p1-4', recordingUrl: RECORDING_URL, recordingMultiChannelUrl: null },
   });
 });
 

--- a/backend/test/unit/googleOutcomesReconciler.test.js
+++ b/backend/test/unit/googleOutcomesReconciler.test.js
@@ -1,0 +1,67 @@
+/**
+ * Lyfe outcome reconciler gating (ads-centralisation §3.5): CREDENTIALS-based,
+ * NOT Google-flag-based — its first-wins facts feed the Google worker AND the
+ * Meta delivery ledger's invariant sweep, so Meta outcome durability must
+ * never hang off GOOGLE_ADS_UPLOADS_ENABLED. Runs the reconciler through its
+ * DI seam with the Google flag explicitly OFF and observes the fact write.
+ */
+import { jest } from '@jest/globals';
+import '../setup.js';
+import { reconcilerConfigured, reconcileLyfeOutcomes } from '../../src/services/googleOutcomesReconciler.js';
+
+const CREDS = {
+  LYFE_SUPABASE_URL: 'https://example.supabase.co',
+  LYFE_SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+};
+
+afterEach(() => {
+  delete process.env.LYFE_SUPABASE_URL;
+  delete process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY;
+  delete process.env.GOOGLE_ADS_UPLOADS_ENABLED;
+});
+
+describe('reconcilerConfigured', () => {
+  it('is TRUE with credentials even when the Google flag is off/unset', () => {
+    process.env.GOOGLE_ADS_UPLOADS_ENABLED = 'false';
+    Object.assign(process.env, CREDS);
+    expect(reconcilerConfigured()).toBe(true);
+  });
+
+  it('is FALSE without either credential', () => {
+    process.env.LYFE_SUPABASE_URL = CREDS.LYFE_SUPABASE_URL;
+    expect(reconcilerConfigured()).toBe(false);
+    delete process.env.LYFE_SUPABASE_URL;
+    process.env.LYFE_SUPABASE_SERVICE_ROLE_KEY = CREDS.LYFE_SUPABASE_SERVICE_ROLE_KEY;
+    expect(reconcilerConfigured()).toBe(false);
+  });
+});
+
+describe('reconcileLyfeOutcomes with the Google flag OFF', () => {
+  it('runs end-to-end and writes the outcome fact (first-wins merge observed)', async () => {
+    process.env.GOOGLE_ADS_UPLOADS_ENABLED = 'false';
+    Object.assign(process.env, CREDS);
+
+    const lead = { id: 'l-1', external_id: 'p-1', status: 'qualified', updated_at: '2026-08-10T00:00:00Z' };
+    const fetch = jest.fn(async (url) => ({
+      ok: true,
+      json: async () => (String(url).includes('/leads') ? [lead] : []),
+    }));
+    const Prospect = { findAll: jest.fn().mockResolvedValue([{ id: 'p-1', sourceMetadata: {} }]) };
+    const mergeFirstWins = jest.fn().mockResolvedValue(1);
+
+    const summary = await reconcileLyfeOutcomes({ fetch, Prospect, mergeFirstWins });
+
+    expect(summary.ran).toBe(true);
+    expect(mergeFirstWins).toHaveBeenCalledTimes(1);
+    const [prospectId, path, patch] = mergeFirstWins.mock.calls[0];
+    expect(prospectId).toBe('p-1');
+    expect(path).toEqual(['outcomes']);
+    expect(Object.keys(patch)).toEqual(['confirmed_resident']);
+    expect(summary.factsWritten).toBe(1);
+  });
+
+  it('still guards on missing credentials', async () => {
+    const summary = await reconcileLyfeOutcomes({ fetch: jest.fn() });
+    expect(summary).toEqual({ ran: false, reason: 'guarded' });
+  });
+});

--- a/backend/test/unit/platformDeliveryService.test.js
+++ b/backend/test/unit/platformDeliveryService.test.js
@@ -1,0 +1,221 @@
+/**
+ * Pure-function unit matrix for the platform-delivery outbox
+ * (ads-centralisation §3.7): settle taxonomy, deadline math (per key, incl.
+ * the CReg anchor-present/absent split and the wire anchor), backoff ladders,
+ * Retry-After parsing, origin-vs-flag planning, and the §3.3.5 outcome
+ * return-contract mapping. No database.
+ */
+import '../setup.js';
+import {
+  classifySendResult,
+  computeBackoffMs,
+  computeDeadlineMs,
+  keyHorizonHours,
+  parseRetryAfterMs,
+  originEligible,
+  submitPlanningApplies,
+  planningEnabled,
+  deliveryPaused,
+  mapDeliveryOutcomeToLegacy,
+} from '../../src/services/platformDeliveryService.js';
+import { OUTCOME_EVENTS, eventNameFor, eventKeysForStatus } from '../../src/services/outcomeEvents.js';
+
+const H = 3600 * 1000;
+
+afterEach(() => {
+  delete process.env.PLATFORM_DELIVERY_PLANNING_ENABLED;
+  delete process.env.PLATFORM_DELIVERY_PAUSED;
+  delete process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS;
+  delete process.env.PLATFORM_DELIVERY_LEAD_HORIZON_HOURS;
+  delete process.env.META_EVENT_QUALIFIED;
+});
+
+describe('classifySendResult — the settle taxonomy (§3.3.4.7)', () => {
+  it('maps a sent Meta result with its fbtrace id', () => {
+    const r = classifySendResult('meta', { sent: true, status: 200, body: { fbtrace_id: 'fb-1' } });
+    expect(r).toEqual({ kind: 'sent', status: 200, providerRequestId: 'fb-1' });
+  });
+
+  it('maps a sent TikTok result with its request id', () => {
+    const r = classifySendResult('tiktok', { sent: true, status: 200, body: { code: 0, request_id: 'tt-1' } });
+    expect(r).toEqual({ kind: 'sent', status: 200, providerRequestId: 'tt-1' });
+  });
+
+  it('maps sender-internal guarded/no_pixel_id to config_blocked (defensive)', () => {
+    expect(classifySendResult('meta', { sent: false, reason: 'guarded' }).kind).toBe('config_blocked');
+    expect(classifySendResult('tiktok', { sent: false, reason: 'no_pixel_id' }).kind).toBe('config_blocked');
+  });
+
+  it('maps network/timeout errors to retry_wait', () => {
+    const r = classifySendResult('meta', { sent: false, error: 'This operation was aborted' });
+    expect(r.kind).toBe('retry_wait');
+    expect(r.errorCode).toBe('network');
+  });
+
+  it('maps 5xx/408/429 to retry_wait and carries Retry-After', () => {
+    expect(classifySendResult('meta', { sent: false, status: 503 }).kind).toBe('retry_wait');
+    expect(classifySendResult('meta', { sent: false, status: 408 }).kind).toBe('retry_wait');
+    const r = classifySendResult('tiktok', { sent: false, status: 429 }, { retryAfterMs: 90_000 });
+    expect(r.kind).toBe('retry_wait');
+    expect(r.retryAfterMs).toBe(90_000);
+  });
+
+  it('maps Meta auth-class body codes (190/102/104) to the auth retry ladder', () => {
+    for (const code of [190, 102, 104]) {
+      const r = classifySendResult('meta', { sent: false, status: 400, body: { error: { code } } });
+      expect(r).toMatchObject({ kind: 'retry_wait', errorCode: 'auth', authClass: true });
+    }
+  });
+
+  it('maps TikTok auth via HTTP 401/403 AND via body code on HTTP 200', () => {
+    expect(classifySendResult('tiktok', { sent: false, status: 401, body: {} })).toMatchObject({ errorCode: 'auth' });
+    // TikTok can return auth failures as HTTP 200 with a 401xx body code.
+    const r = classifySendResult('tiktok', { sent: false, status: 200, body: { code: 40105 } });
+    expect(r).toMatchObject({ kind: 'retry_wait', errorCode: 'auth', authClass: true });
+  });
+
+  it('maps other 4xx to failed_permanent', () => {
+    const r = classifySendResult('meta', { sent: false, status: 400, body: { error: { code: 100 } } });
+    expect(r).toMatchObject({ kind: 'failed_permanent', errorCode: 'http_4xx' });
+  });
+
+  it('maps a TikTok 200-with-nonzero-code logical failure to failed_permanent', () => {
+    const r = classifySendResult('tiktok', { sent: false, status: 200, body: { code: 40001 } });
+    expect(r).toMatchObject({ kind: 'failed_permanent', errorCode: 'logical_reject' });
+  });
+});
+
+describe('computeBackoffMs', () => {
+  it('grows 60s·2^(n−1) capped at 1h, with jitter ≤30s', () => {
+    expect(computeBackoffMs(1, { jitterRatio: 0 })).toBe(60_000);
+    expect(computeBackoffMs(3, { jitterRatio: 0 })).toBe(240_000);
+    expect(computeBackoffMs(12, { jitterRatio: 0 })).toBe(3600_000); // cap
+    const withJitter = computeBackoffMs(1, { jitterRatio: 0.999 });
+    expect(withJitter).toBeGreaterThan(60_000);
+    expect(withJitter).toBeLessThanOrEqual(60_000 + 30_000);
+  });
+
+  it('uses the long auth ladder 30min·2^(n−1) capped at 4h', () => {
+    expect(computeBackoffMs(1, { authClass: true })).toBe(30 * 60_000);
+    expect(computeBackoffMs(2, { authClass: true })).toBe(60 * 60_000);
+    expect(computeBackoffMs(9, { authClass: true })).toBe(4 * 3600_000); // cap
+  });
+
+  it('honours Retry-After as a floor, never a shortening', () => {
+    expect(computeBackoffMs(1, { jitterRatio: 0, retryAfterMs: 300_000 })).toBe(300_000);
+    expect(computeBackoffMs(6, { jitterRatio: 0, retryAfterMs: 1000 })).toBe(1920_000);
+  });
+});
+
+describe('computeDeadlineMs — per-key horizons + the wire anchor (§1.3)', () => {
+  const anchor = Date.parse('2026-08-01T00:00:00Z');
+
+  it('lead: anchor + 47h', () => {
+    expect(computeDeadlineMs({ eventKey: 'lead', dedupeAnchorAt: new Date(anchor), firstWireAt: null }))
+      .toBe(anchor + 47 * H);
+  });
+
+  it('complete_registration WITH a reveal anchor: 47h from it', () => {
+    expect(computeDeadlineMs({
+      eventKey: 'complete_registration', dedupeAnchorAt: new Date(anchor), firstWireAt: null, hasRegistrationAnchor: true,
+    })).toBe(anchor + 47 * H);
+  });
+
+  it('complete_registration WITHOUT a reveal anchor: the conservative 24h', () => {
+    expect(computeDeadlineMs({
+      eventKey: 'complete_registration', dedupeAnchorAt: new Date(anchor), firstWireAt: null, hasRegistrationAnchor: false,
+    })).toBe(anchor + 24 * H);
+  });
+
+  it('outcomes: 156h from the fact time', () => {
+    expect(computeDeadlineMs({ eventKey: 'confirmed_resident', dedupeAnchorAt: new Date(anchor), firstWireAt: null }))
+      .toBe(anchor + 156 * H);
+  });
+
+  it('the wire anchor wins when firstWireAt + 47h is earlier than the anchor horizon', () => {
+    const firstWire = anchor + 1 * H;
+    expect(computeDeadlineMs({
+      eventKey: 'confirmed_resident', dedupeAnchorAt: new Date(anchor), firstWireAt: new Date(firstWire),
+    })).toBe(firstWire + 47 * H); // < anchor + 156h
+  });
+
+  it('clamps env horizons into their §8 bounds', () => {
+    process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS = '500';
+    expect(keyHorizonHours('confirmed_resident')).toBe(160);
+    process.env.PLATFORM_DELIVERY_LEAD_HORIZON_HOURS = '99';
+    expect(keyHorizonHours('lead')).toBe(47);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds', () => {
+    expect(parseRetryAfterMs('120')).toBe(120_000);
+  });
+  it('parses an HTTP-date relative to now', () => {
+    const now = Date.parse('2026-08-01T00:00:00Z');
+    expect(parseRetryAfterMs('Sat, 01 Aug 2026 00:05:00 GMT', now)).toBe(300_000);
+  });
+  it('returns null on garbage/absent', () => {
+    expect(parseRetryAfterMs('soon')).toBeNull();
+    expect(parseRetryAfterMs(null)).toBeNull();
+  });
+});
+
+describe('origin-vs-flag planning (§3.2)', () => {
+  const web = { leadSource: 'website', retellCallId: null, sourceMetadata: {} };
+
+  it('originEligible excludes call_bot, retell, and Meta Lead Ads prospects', () => {
+    expect(originEligible(web)).toBe(true);
+    expect(originEligible({ ...web, leadSource: 'call_bot' })).toBe(false);
+    expect(originEligible({ ...web, retellCallId: 'call-1' })).toBe(false);
+    expect(originEligible({ ...web, sourceMetadata: { metaLeadgenId: 'lg-1' } })).toBe(false);
+  });
+
+  it('submitPlanningApplies = planning flag ∧ origin eligibility', () => {
+    expect(submitPlanningApplies({ prospect: web })).toBe(false); // flag unset
+    process.env.PLATFORM_DELIVERY_PLANNING_ENABLED = 'true';
+    expect(submitPlanningApplies({ prospect: web })).toBe(true);
+    expect(submitPlanningApplies({ prospect: { ...web, retellCallId: 'c' } })).toBe(false);
+  });
+
+  it('flag readers require the literal "true"', () => {
+    process.env.PLATFORM_DELIVERY_PLANNING_ENABLED = '1';
+    expect(planningEnabled()).toBe(false);
+    process.env.PLATFORM_DELIVERY_PAUSED = 'true';
+    expect(deliveryPaused()).toBe(true);
+  });
+});
+
+describe('mapDeliveryOutcomeToLegacy — §3.3.5 contract, complete', () => {
+  it('covers every outcome', () => {
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'sent' })).toBe('dispatched');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'config_blocked' })).toBe('guarded');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'retry_wait' })).toBe('transientFailed');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'paused' })).toBe('transientFailed');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'claim_miss' })).toBe('transientFailed');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'failed_permanent' })).toBe('permanentFailed');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'expired' })).toBe('permanentFailed');
+    expect(mapDeliveryOutcomeToLegacy({ outcome: 'skipped' })).toBe('permanentFailed');
+  });
+});
+
+describe('outcomeEvents — the shared per-key vocabulary (§3.3.2)', () => {
+  it('pins the marker keys the ledger and the legacy path both write', () => {
+    expect(OUTCOME_EVENTS.confirmed_resident.markerKey).toBe('confirmedResidentAt');
+    expect(OUTCOME_EVENTS.closed_won.markerKey).toBe('closedWonAt');
+  });
+
+  it('resolves env-overridable event names', () => {
+    expect(eventNameFor('confirmed_resident')).toBe('ConfirmedResident');
+    process.env.META_EVENT_QUALIFIED = 'CustomCR';
+    expect(eventNameFor('confirmed_resident')).toBe('CustomCR');
+    expect(eventNameFor('closed_won')).toBe('ClosedWon');
+    expect(eventNameFor('nope')).toBeNull();
+  });
+
+  it('maps statuses to ordered key lists', () => {
+    expect(eventKeysForStatus('qualified')).toEqual(['confirmed_resident']);
+    expect(eventKeysForStatus('won')).toEqual(['confirmed_resident', 'closed_won']);
+    expect(eventKeysForStatus('contacted')).toEqual([]);
+  });
+});

--- a/backend/test/unit/platformDeliveryService.test.js
+++ b/backend/test/unit/platformDeliveryService.test.js
@@ -17,6 +17,7 @@ import {
   planningEnabled,
   deliveryPaused,
   mapDeliveryOutcomeToLegacy,
+  makeDeliveryFetch,
 } from '../../src/services/platformDeliveryService.js';
 import { OUTCOME_EVENTS, eventNameFor, eventKeysForStatus } from '../../src/services/outcomeEvents.js';
 
@@ -27,6 +28,7 @@ afterEach(() => {
   delete process.env.PLATFORM_DELIVERY_PAUSED;
   delete process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS;
   delete process.env.PLATFORM_DELIVERY_LEAD_HORIZON_HOURS;
+  delete process.env.PLATFORM_DELIVERY_HTTP_TIMEOUT_MS;
   delete process.env.META_EVENT_QUALIFIED;
 });
 
@@ -82,6 +84,13 @@ describe('classifySendResult — the settle taxonomy (§3.3.4.7)', () => {
   it('maps a TikTok 200-with-nonzero-code logical failure to failed_permanent', () => {
     const r = classifySendResult('tiktok', { sent: false, status: 200, body: { code: 40001 } });
     expect(r).toMatchObject({ kind: 'failed_permanent', errorCode: 'logical_reject' });
+  });
+
+  it('auth-class classifications carry Retry-After so the backoff floor applies (Codex #8)', () => {
+    const meta = classifySendResult('meta', { sent: false, status: 400, body: { error: { code: 190 } } }, { retryAfterMs: 90_000 });
+    expect(meta.retryAfterMs).toBe(90_000);
+    const tt = classifySendResult('tiktok', { sent: false, status: 200, body: { code: 40105 } }, { retryAfterMs: 45_000 });
+    expect(tt.retryAfterMs).toBe(45_000);
   });
 });
 
@@ -144,6 +153,48 @@ describe('computeDeadlineMs — per-key horizons + the wire anchor (§1.3)', () 
     expect(keyHorizonHours('confirmed_resident')).toBe(160);
     process.env.PLATFORM_DELIVERY_LEAD_HORIZON_HOURS = '99';
     expect(keyHorizonHours('lead')).toBe(47);
+  });
+
+  it('treats a BLANK env value as absent — the default, never a min-clamped zero (Codex #6)', () => {
+    process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS = '';
+    expect(keyHorizonHours('confirmed_resident')).toBe(156);
+    process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS = '  ';
+    expect(keyHorizonHours('confirmed_resident')).toBe(156);
+    process.env.PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS = 'abc';
+    expect(keyHorizonHours('confirmed_resident')).toBe(156);
+  });
+});
+
+describe('makeDeliveryFetch — the timeout covers the BODY read (Codex #1)', () => {
+  it('a stalled body aborts at the timeout instead of outliving the claim lease', async () => {
+    process.env.PLATFORM_DELIVERY_HTTP_TIMEOUT_MS = '1000';
+    const capture = {};
+    const base = async (url, opts) => ({
+      status: 200,
+      headers: { get: () => null },
+      // Headers arrived; the body never does. A real undici read rejects on
+      // abort — the fake wires the same contract to the wrapper's signal.
+      json: () => new Promise((resolve, reject) => {
+        opts.signal.addEventListener('abort', () => reject(new Error('body aborted')));
+      }),
+    });
+    const wrapped = makeDeliveryFetch(capture, base);
+    const res = await wrapped('https://provider.test/events', {});
+    await expect(res.json()).rejects.toThrow('body aborted');
+  }, 10000);
+
+  it('a settling body clears the timer, and Retry-After is captured out-of-band', async () => {
+    process.env.PLATFORM_DELIVERY_HTTP_TIMEOUT_MS = '1000';
+    const capture = {};
+    const base = async () => ({
+      status: 429,
+      headers: { get: (h) => (h === 'retry-after' ? '120' : null) },
+      json: async () => ({ code: 0 }),
+    });
+    const wrapped = makeDeliveryFetch(capture, base);
+    const res = await wrapped('https://provider.test/events', {});
+    await expect(res.json()).resolves.toEqual({ code: 0 });
+    expect(capture.retryAfterMs).toBe(120_000);
   });
 });
 

--- a/backend/test/unit/prospectCreateStages.test.js
+++ b/backend/test/unit/prospectCreateStages.test.js
@@ -16,6 +16,7 @@ import { jest } from '@jest/globals';
 import '../setup.js';
 import { makeCreateTxRunner } from '../../src/services/prospectCreateTx.js';
 import { makeDispatchRunner } from '../../src/services/prospectDispatch.js';
+import { dispatchSubmitDeliveries } from '../../src/services/platformDeliveryService.js';
 
 const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn() };
 
@@ -35,6 +36,10 @@ function txDeps(overrides = {}) {
     enqueueMapJobsTx: jest.fn().mockResolvedValue(undefined),
     deductLeadCredit: jest.fn().mockResolvedValue(undefined),
     deductExternalLeadBalance: jest.fn().mockResolvedValue(true),
+    // Platform-delivery planning (ads-centralisation §3.3.1) — default OFF,
+    // mirroring the dark flag.
+    submitPlanningApplies: jest.fn().mockReturnValue(false),
+    planSubmitDeliveriesTx: jest.fn().mockResolvedValue({ planned: true, rows: 2 }),
     AppError: class extends Error {},
     logger,
     ...overrides,
@@ -153,6 +158,36 @@ describe('createProspect PERSIST stage (unit)', () => {
     expect(out.prospect.id).toBe('p-1');
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[enrichment]'), expect.anything());
   });
+
+  it('plans platform deliveries in the txn when planning applies, and reports deliveriesPlanned', async () => {
+    const planSubmitDeliveriesTx = jest.fn().mockResolvedValue({ planned: true, rows: 2 });
+    const { d, m } = txDeps({
+      submitPlanningApplies: jest.fn().mockReturnValue(true),
+      planSubmitDeliveriesTx,
+    });
+
+    const out = await makeCreateTxRunner({ d, m })({
+      ...baseCtx, eventId: 'ev-1', registrationEventId: 'reg-1', registrationEventAt: '2026-08-19T00:00:00.000Z',
+    });
+
+    expect(out.deliveriesPlanned).toBe(true);
+    expect(planSubmitDeliveriesTx).toHaveBeenCalledTimes(1);
+    const [, args] = planSubmitDeliveriesTx.mock.calls[0];
+    expect(args).toMatchObject({ eventId: 'ev-1', registrationEventId: 'reg-1', registrationEventAt: '2026-08-19T00:00:00.000Z' });
+  });
+
+  it('never fails capture when delivery planning throws — deliveriesPlanned=false routes to legacy (§3.3.1)', async () => {
+    const { d, m } = txDeps({
+      submitPlanningApplies: jest.fn().mockReturnValue(true),
+      planSubmitDeliveriesTx: jest.fn().mockRejectedValue(new Error('ledger down')),
+    });
+
+    const out = await makeCreateTxRunner({ d, m })(baseCtx);
+
+    expect(out.prospect.id).toBe('p-1');
+    expect(out.deliveriesPlanned).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('[delivery]'), expect.anything());
+  });
 });
 
 function dispatchDeps(overrides = {}) {
@@ -166,6 +201,10 @@ function dispatchDeps(overrides = {}) {
     sendTikTokLeadEvent: jest.fn().mockResolvedValue(undefined),
     sendTikTokCompleteRegistrationEvent: jest.fn().mockResolvedValue(undefined),
     onLeadCaptured: jest.fn().mockResolvedValue({ ok: true }),
+    // The REAL router: with deliveriesPlanned absent (plannedOk=false) it
+    // fires every legacy closure synchronously and touches no database —
+    // exactly the pre-ledger direct-send behaviour these tests assert.
+    dispatchSubmitDeliveries,
     drainMapJobs: jest.fn().mockResolvedValue(undefined),
     getOrCreateProspectShareLink: jest.fn().mockResolvedValue({ url: '/share/abc' }),
     scheduleScreeningAttempt: jest.fn().mockResolvedValue(undefined),

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -62,6 +62,12 @@ export default function LeadCapture() {
   // Pixel, TikTok Pixel, and (threaded into submit) the server-side CAPI so all
   // three dedup against one another.
   const registrationEventIdRef = useRef(null);
+  // When the quiz reveal actually happened (ISO) — stamped in handleQuizReveal
+  // beside the browser CompleteRegistration fire and threaded into submit: the
+  // server anchors the CReg delivery deadline on it (ads-centralisation §3.3.1;
+  // the reveal can precede a slow submit by hours, and retries must stay inside
+  // the provider dedupe window measured from the browser twin's fire time).
+  const registrationEventAtRef = useRef(null);
   const viewContentFiredRef = useRef(false); // Meta ViewContent fire-once
   const ttViewContentFiredRef = useRef(false); // TikTok ViewContent fire-once
   const [campaign, setCampaign] = useState(null);
@@ -182,6 +188,10 @@ export default function LeadCapture() {
   // server-side CAPI CompleteRegistration (fired at submit) dedups against it.
   // Gated by shouldTrack / shouldTrackTikTok, so it never fires on preview pages.
   const handleQuizReveal = (result) => {
+    // Stamp the reveal time once, whether or not any pixel is configured —
+    // it records when the browser twin WOULD have fired, which is the
+    // conservative deadline anchor either way.
+    if (!registrationEventAtRef.current) registrationEventAtRef.current = new Date().toISOString();
     const trackCtx = { campaign, pathname: location.pathname, search: location.search };
     const status = result?.title || result?.profileId || undefined;
 
@@ -384,6 +394,9 @@ export default function LeadCapture() {
         // the server fire a CAPI CompleteRegistration that dedups against the
         // browser Pixel one fired at the reveal.
         registrationEventId: quizResult ? registrationEventIdRef.current : undefined,
+        // The reveal timestamp that anchors the server's CReg delivery
+        // deadline (clamped server-side; absent on legacy cached bundles).
+        registrationEventAt: quizResult ? registrationEventAtRef.current || undefined : undefined,
         // TikTok attribution identifiers (server-side Events API consumes these in
         // Phase 6). Captured from the landing URL / pixel cookie.
         ttclid: readTtclid() || undefined,


### PR DESCRIPTION
Implements **P2 of `docs/plans/ads-centralisation-levers.md` (FINAL v8, Codex-ACCEPTED 2026-08-19)** — the durable Meta/TikTok conversion-delivery outbox (§3), plus its §3.5 rider (Lyfe reconciler un-gated to credentials-based) and the §7.6 shared advisory-lock helper. **Ships completely dark**: `PLATFORM_DELIVERY_PLANNING_ENABLED` unset ⇒ zero rows are ever created and every send path is byte-equivalent legacy.

## What this adds

- **Migration 126 `platform_deliveries`** — §3.1 DDL verbatim (unique `(prospectId, platform, eventKey)`, partial due/pending/stale indexes, platform/state/eventKey CHECKs). Model + named export + `Prospect.hasMany` CASCADE.
- **`platformDeliveryService.js`** — the one state machine: fenced claim (`claimToken`, stale-lease reclaim at 10 min, claims never touch `sendAttempts`), rescreen → deadline (`min(anchor + keyHorizon, firstWireAt + 47h)`; CReg anchored on the browser reveal timestamp with a 24h capture-anchored fallback) → config check (`config_blocked`, zero attempt fields, only the deadline ends it) → consent snapshot (inline batch) / per-row (worker), fail-closed → final fresh `erased` SELECT → **pre-wire reservation CAS** (cap enforced in-CAS; reservation-miss ⇒ `failed_permanent/retry_cap`) → send through the **existing** senders with injected timeout fetch + Retry-After capture → settle CAS on the claim token (§3.3.4.7 taxonomy: transient/auth-ladder/permanent/logical-reject; outcome-key settles write the legacy `capi.{marker}` **in the settle transaction**).
- **Planning** — submit-time rows in the capture transaction (savepoint'd, enrichment-outbox template; failure ⇒ legacy senders for that prospect); the shared outcome planner re-reads **persisted facts in-txn** (no timestamp parameter; erased/absent-fact abort; exact-marker skip; `ON CONFLICT DO NOTHING`), called from the admin-edit transaction (savepoint'd) and from `processLeadOutcome`, whose facts-merge + planning now share **one managed transaction**.
- **Row-ownership routing (§3.2/§3.3.5)** — row in ANY state ⇒ ledger-owned; no row ⇒ the permanent legacy direct-send block. Submit dispatch replaces the four direct calls at the same statement position, fire-and-forget (zero new awaited work; `plannedOk=false` performs no queries at all). Outcome results map onto the legacy return contract (`sent→dispatched · config_blocked→guarded · retry_wait/paused/pending/held/claim-miss→transientFailed · terminal→permanentFailed`), preserving the external path's 503-on-transient.
- **Worker (§3.3.7)** — scheduled whenever the ledger exists (offset 210s, `PLATFORM_DELIVERY_WORKER_MINUTES`), under shared advisory lock `pd:worker`; scans the three indexed branches, concurrency 5; expiry pass transitions only unsent states + stale `sending` (never an active lease) and runs even when `PLATFORM_DELIVERY_PAUSED`; hourly §3.5 invariant sweep + daily §3.6 retention purge ride the tick.
- **Reconciler un-gating (§3.5)** — `reconcilerConfigured()` + its bootstrap schedule are now credentials-based (`LYFE_SUPABASE_URL` + service-role key), no longer behind `GOOGLE_ADS_UPLOADS_ENABLED`.
- **Intake** — server-generates a UUID `eventId` when the client omits one (persisted; no submit bypasses durability); new `registrationEventAt` field (Joi isoDate → clamped ≤ now → persisted to `sourceMetadata`; `LeadCapture.jsx` stamps it at quiz reveal). `registrationEventId` is never generated.
- **Erasure (§3.6/§7.1)** — in-txn `DELETE FROM platform_deliveries` joins the matrix; pre-wire erased re-check fences in-flight claims.
- **Env (§8)** — 10 new vars in `backend/env.example`; booleans (incl. the `GOOGLE_ADS_UPLOADS_ENABLED`/`GOOGLE_CM_SYNC_ENABLED` rider) in `envValidation.js` `booleanFlags`; bounded-numeric warnings for all 8 numerics.
- **`utils/advisoryLock.js` (§7.6)** — `withAdvisoryLock(key, fn)` (dedicated connection, `hashtext`, skip-if-held, finally-unlock) + the xact variant; P3–P5 consume it next.

## Flags (all dark)

`PLATFORM_DELIVERY_PLANNING_ENABLED` (sole row-creation control) · `PLATFORM_DELIVERY_PAUSED` (pauses sends, never expiry — pausing past deadlines expires events, stated plainly) · worker/attempt/timeout/horizon/retention numerics per §8. Rollback = §3.8 (pause → planning off → drain; the migration stays; never a pre-ledger binary with undrained rows).

## Tests (§3.7 — all green locally against Postgres)

- `test/unit/platformDeliveryService.test.js` — settle taxonomy, deadline math (per key incl. CReg anchor present/absent + wire anchor), backoff ladders + Retry-After floor, origin-vs-flag planning, §3.3.5 mapping (complete), outcome-vocabulary parity + env override.
- `test/platformDeliveries.test.js` (DB) — planning at both entry points; **facts+rows atomicity** (whole-txn rollback on the webhook path, savepoint isolation on the admin path); persisted-fact reads (admin replay can't retime CR); erased/absent-fact aborts; marker-aware skip; claim race (one winner, loser claim-miss); stale-lease reclaim + **ghost settle loses the CAS**; accept-then-crash resend inside the wire deadline / `expired` beyond it; in-CAS reservation cap; `config_blocked` non-terminal with zero attempt-field writes; destination pinned at planning survives campaign edit + env change; NULL destination blocks then pins; marker↔sent settle; erased fence between claim and wire; ownership routing (no dual send even when the ledger attempt blocks; mixed states; `plannedOk=false` ⇒ no queries + synchronous legacy closures); outcome-state mapping matrix incl. paused pending.
- `test/platformDeliveryWorker.test.js` (DB) — due-scan + concurrency ≤5; paused ⇒ no sends, expiry still runs; flags-off ⇒ `config_blocked` + expiry same tick; **expiry never touches an active lease**; CReg anchor-vs-fallback split read off the prospect; accept-then-disconnect provider fake (same event id resent); invariant sweep (young/marked/old/idempotent; planning-flag-off plans nothing); retention purge (terminal-only, window-only).
- `test/unit/googleOutcomesReconciler.test.js` — credentials-based gating; full run + fact write observed with the Google flag OFF.
- `test/integration/erasure.test.js` — two ledger rows join the full-matrix erasure; `report.platformDeliveries = 2`, table emptied in-txn.
- Updated: `leadOutcomeService.test.js` (DI seams pin the legacy/no-row path), `prospectServiceCapi.test.js` (6 assertions updated to the §3.3.1 always-present server-generated `eventId` contract), `prospectCreateStages.test.js` (planning deps + 2 new savepoint cases).

Local gates (after the review fold): unit **2476/2476** · integration **2847/2847** · migrations **23/23** · `npm run typecheck` clean · eslint (backend + root) clean.

## Rode-along: `retellRecordingScope` fixture repair (own commit)

Main's CI has been red since #470 (`52fb748a`): the recording endpoint's cache-hit now requires the `recordingMultiChannelUrl` KEY, so the pre-#470 fixture (mono URL, no key) always earns a live Retell refetch and 503s where no API exists — `retellRecordingScope.test.js` fails on main's own CI, not just locally. Test-only fix: the fixture gains `recordingMultiChannelUrl: null` (the "refetched, no split file" cached shape); the owner-scope assertions are untouched. (For awareness: main's CI additionally shows `redeemOpsAutosend`/`redeemOpsInboxLoop` reds and a failing Frontend job — all pre-existing, all pass locally here, none touched by this PR.)

## Codex adversarial review (gpt-5.6-sol, xhigh, read-only) — 9 findings, dispositions

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | P1 | Send timeout cleared at response headers, not after `res.json()`; injected `deps.fetch` bypassed the wrapper | **Accepted + fixed.** `makeDeliveryFetch` now patches `res.json()` so the abort timer lives until the body settles (self-fires harmlessly if never read), and the wrapper is applied over ANY base fetch, injected seams included. Stalled-body + timer-clear unit tests added. |
| 2 | P1 | Invariant sweep applied `LIMIT 200` before age/origin filters — permanently-ineligible facts could starve young ones | **Accepted + fixed.** Age (regex-guarded `::timestamptz` — every fact writer normalizes via `toISOString()`) and origin eligibility now filter in SQL before the LIMIT; JS re-checks stay as the belt. |
| 3 | P1 | Outcome planner read the prospect without a lock — the sweep could plan from pre-erasure facts after erasure committed | **Accepted + fixed.** The planner takes `SELECT … FOR UPDATE` on the prospect first. The admin/webhook callers already held that lock (their facts write took it), so only the sweep path changes; it now serializes behind erasure and sees the scrubbed row. |
| 4 | P1 | Outcome settle locked delivery→prospect while erasure locks prospect→delivery — AB-BA deadlock | **Accepted + fixed.** The marker-sharing settle transaction locks the prospect FIRST; combined with #3, every writer now uses prospect→delivery order. |
| 5 | P1 | Marker-dedup TOCTOU: a concurrently-written marker makes the planner skip the row and the stale caller re-sends via legacy | **Refuted (no change).** This window exists byte-identically in today's legacy code — two concurrent `processLeadOutcome` calls both see no marker and both send — and is the documented pre-existing contract: at-least-once with provider dedupe on the deterministic `key:prospectId` event id ("that IS our concurrency guard", leadOutcomeService header). Changing the legacy block is outside what §3 authorizes. |
| 6 | P1 | `numEnv` turned a BLANK env value into 0 and min-clamped it — a blank outcome horizon became 1h (mass expiry) | **Accepted + fixed.** Absent/blank/NaN all return the default, matching `envValidation.js`'s blank-is-absent stance. Unit test covers `''`, whitespace, and garbage. |
| 7 | P1 | Settle branches ignored whether their fenced CAS applied — a stale holder returned its own classification | **Accepted + fixed.** Every settle branch now checks the CAS; a lost claim reports `claim_miss` (→ `transientFailed` in the legacy mapping) and the reclaimer's attempt governs. Practically unreachable once #1 bounds attempts at 20s ≪ the 10-min lease — kept as the belt the state machine promises. |
| 8 | P2 | Auth-class classifications discarded `Retry-After`, defeating the backoff floor | **Accepted + fixed** (+ unit test). |
| 9 | P2 | Ledger retries multiplied the senders' per-attempt Sentry captures despite the once-per-row rule | **Accepted + fixed.** Senders gain an opt-in `options.suppressSentry` (default **off** — every legacy caller unchanged, logs retained); the ledger passes it and its once-per-row auth alert is authoritative. |

Two review-suggested tests were deliberately not written: a >200-blocker starvation fixture (#2 — the SQL-side filter makes the starving class structurally unmatchable, asserted instead by the young/marked/old matrix) and a live deadlock repro (#4 — timing-dependent; the fix is a total-order argument covered by the lock-order comments and the erasure suite).

Plan §13 governs design questions — none were relitigated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ast7umVC2D3W8vTySWSLGh
