### PR TITLE
feat(studio): Prudential Ad toggle — appends introducer & consent disclosure to campaign T&Cs

### DIFF
--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -238,7 +238,7 @@ export const V1_CONSUMED_KEYS = [
   'formHeadline', 'formSubheadline', 'brandWordmark', 'storyText', 'storyEmphasis',
   'heroCtaLabel', 'ctaText', 'regulatoryFooter', 'brandFooter',
   'imageUrl', 'videoUrl', 'mediaType', 'themeColor', 'heroFont', 'formWidth',
-  'termsContent', 'customerHost', 'otpChannel',
+  'termsContent', 'customerHost', 'otpChannel', 'prudentialAd', 'prudentialFbName',
   'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'screeningCallAtSubmit',
   'visibleFields', 'requiredFields', 'fieldOrder',
   'featuredDrop', 'marketplaceListed',
@@ -616,8 +616,20 @@ export function upgradeDesignConfig(doc) {
       dncCheck: dc.dncCheckAtSubmit === true,
       screeningCall: dc.screeningCallAtSubmit === true,
     },
-    ...(dc.termsContent !== undefined
-      ? { terms: { template: 'default', html: clone(dc.termsContent) } }
+    ...(dc.termsContent !== undefined || dc.prudentialAd === true
+      ? {
+        terms: {
+          template: 'default',
+          ...(dc.termsContent !== undefined ? { html: clone(dc.termsContent) } : {}),
+          // Prudential introducer disclosure flag — the block itself is a
+          // frontend constant appended at RENDER time (never stored in html,
+          // so campaigns can't drift when the template text changes).
+          ...(dc.prudentialAd === true ? { prudentialAd: true } : {}),
+          ...(dc.prudentialAd === true && typeof dc.prudentialFbName === 'string' && dc.prudentialFbName
+            ? { prudentialFbName: clone(dc.prudentialFbName) }
+            : {}),
+        },
+      }
       : {}),
   };
 
@@ -712,6 +724,12 @@ export function downgradeDesignConfig(doc) {
   out.dncCheckAtSubmit = gates.dncCheck === true;
   out.screeningCallAtSubmit = gates.screeningCall === true;
   if (isPlainObject(form.terms) && form.terms.html !== undefined) out.termsContent = clone(form.terms.html);
+  if (isPlainObject(form.terms) && form.terms.prudentialAd === true) {
+    out.prudentialAd = true;
+    if (typeof form.terms.prudentialFbName === 'string' && form.terms.prudentialFbName) {
+      out.prudentialFbName = clone(form.terms.prudentialFbName);
+    }
+  }
 
   const distribution = isPlainObject(doc.distribution) ? doc.distribution : {};
   out.customerHost = distribution.host === 'mktr' ? 'mktr' : 'redeem';

--- a/backend/src/utils/designConfigV2Clamp.js
+++ b/backend/src/utils/designConfigV2Clamp.js
@@ -425,11 +425,19 @@ function clampForm(raw) {
   };
   if (isPlainObject(f.terms)) {
     const html = cleanString(f.terms.html, LIMITS.terms);
-    if (html !== undefined) {
+    const prudentialAd = f.terms.prudentialAd === true;
+    if (html !== undefined || prudentialAd) {
       out.terms = {
         template: cleanEnum(f.terms.template, ['default', 'privacy', 'marketing'], 'default'),
-        html,
+        ...(html !== undefined ? { html } : {}),
+        // Prudential introducer disclosure (Studio "Prudential Ad" toggle) —
+        // flag only; the block text is a frontend constant appended at render.
+        ...(prudentialAd ? { prudentialAd: true } : {}),
       };
+      if (prudentialAd) {
+        const fb = cleanString(f.terms.prudentialFbName, 80);
+        if (fb !== undefined && fb.trim()) out.terms.prudentialFbName = fb.trim();
+      }
     }
   }
   return out;

--- a/backend/src/utils/publicDesignConfig.js
+++ b/backend/src/utils/publicDesignConfig.js
@@ -28,6 +28,8 @@ const PUBLIC_PASSTHROUGH_KEYS = [
   // Flow gates + channel (thirdPartyDisclosure: agree-all consent block's
   // sponsored-campaign clause toggle — default ON, so only `false` matters)
   'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'otpChannel', 'thirdPartyDisclosure',
+  // Prudential introducer disclosure (rendered into the agreement dialog)
+  'prudentialAd', 'prudentialFbName',
   // Funnel variants (public quiz/guided-review campaigns render from these)
   'quiz', 'guidedReview',
   // Marketplace content (clamped on save by normalizeMarketplaceContent)
@@ -152,7 +154,7 @@ function buildPublicDesignConfigV2(dc) {
   }
   const gates = pick(dc.form?.gates, ['sgPr', 'advisorExclusion', 'dncCheck']);
   if (gates) form.gates = gates;
-  const terms = pick(dc.form?.terms, ['template', 'html']);
+  const terms = pick(dc.form?.terms, ['template', 'html', 'prudentialAd', 'prudentialFbName']);
   if (terms) form.terms = terms;
   if (Object.keys(form).length) out.form = form;
 

--- a/backend/test/designConfigV2StudioClamp.test.js
+++ b/backend/test/designConfigV2StudioClamp.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect } from '@jest/globals';
 import { clampDesignConfigV2 } from '../src/utils/designConfigV2Clamp.js';
-import { upgradeDesignConfig } from '../src/utils/designConfigV2.js';
+import { upgradeDesignConfig, readLegacyView } from '../src/utils/designConfigV2.js';
 
 // A Studio-authored doc: migrated v1 base + edits across every rail section,
 // plus admin subtrees and a future unknown key.
@@ -343,5 +343,50 @@ describe('clampProfileQuestions — custom questions (studio-custom-questions §
     const once = clampDesignConfigV2(doc, undefined, 'admin');
     const twice = clampDesignConfigV2(once, undefined, 'admin');
     expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+  });
+});
+
+describe('form.terms.prudentialAd — Prudential introducer disclosure toggle', () => {
+  const v2terms = (terms) => ({
+    version: 2,
+    template: { id: 'express', params: {} },
+    theme: { preset: 'warm-cream' },
+    content: {},
+    form: { terms },
+  });
+
+  it('survives the clamp with a trimmed, capped Facebook Business Name', () => {
+    const out = clampDesignConfigV2(
+      v2terms({ template: 'marketing', html: '<p>T</p>', prudentialAd: true, prudentialFbName: `  Redeem SG${'x'.repeat(200)}  ` }),
+      undefined, 'admin'
+    );
+    expect(out.form.terms.prudentialAd).toBe(true);
+    expect(out.form.terms.prudentialFbName.length).toBeLessThanOrEqual(80);
+    expect(out.form.terms.prudentialFbName.startsWith('Redeem SG')).toBe(true);
+    expect(out.form.terms.html).toBe('<p>T</p>');
+  });
+
+  it('OFF (or junk) strips both keys — fbName never rides without the flag', () => {
+    const out = clampDesignConfigV2(
+      v2terms({ template: 'default', html: '<p>T</p>', prudentialAd: 'yes', prudentialFbName: 'Redeem SG' }),
+      undefined, 'admin'
+    );
+    expect(out.form.terms.prudentialAd).toBeUndefined();
+    expect(out.form.terms.prudentialFbName).toBeUndefined();
+  });
+
+  it('keeps terms alive when the flag is on with NO custom html', () => {
+    const out = clampDesignConfigV2(v2terms({ prudentialAd: true }), undefined, 'admin');
+    expect(out.form.terms).toEqual({ template: 'default', prudentialAd: true });
+  });
+
+  it('round-trips v1 → v2 → v1 (legacy view feeds the funnel dialog)', () => {
+    const doc = upgradeDesignConfig({ termsContent: '<p>T</p>', prudentialAd: true, prudentialFbName: 'Redeem SG' });
+    expect(doc.form.terms).toMatchObject({ html: '<p>T</p>', prudentialAd: true, prudentialFbName: 'Redeem SG' });
+    expect(doc.prudentialAd).toBeUndefined(); // consumed, not top-level residue
+    const legacy = readLegacyView(doc);
+    expect(legacy.prudentialAd).toBe(true);
+    expect(legacy.prudentialFbName).toBe('Redeem SG');
+    expect(readLegacyView(upgradeDesignConfig({ termsContent: '<p>T</p>' })).prudentialAd).toBeUndefined();
   });
 });

--- a/src/components/campaigns/signup/ConsentAgreementDialog.jsx
+++ b/src/components/campaigns/signup/ConsentAgreementDialog.jsx
@@ -3,6 +3,7 @@ import DOMPurify from 'dompurify';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useCampaignTheme } from '@/components/campaignPage/themeContext';
 import DefaultTermsCopy from '@/components/legal/DefaultTermsCopy';
+import PrudentialIntroducerClause from '@/components/legal/PrudentialIntroducerClause';
 import {
   CONSENT_COPY, CONSENT_INLINE, isSponsoredCampaign, sponsorNameLine,
 } from '@/lib/consentCopy';
@@ -152,6 +153,12 @@ export default function ConsentAgreementDialog({
               <div dangerouslySetInnerHTML={{ __html: sanitized }} />
             ) : (
               <DefaultTermsCopy />
+            )}
+            {/* Prudential introducer disclosure — APPENDED to the campaign
+                T&Cs when the Studio "Prudential Ad" toggle is on. Part of the
+                same agreement, never a second checkbox. */}
+            {designConfig?.prudentialAd === true && (
+              <PrudentialIntroducerClause fbName={designConfig?.prudentialFbName} />
             )}
           </div>
         </div>

--- a/src/components/legal/PrudentialIntroducerClause.jsx
+++ b/src/components/legal/PrudentialIntroducerClause.jsx
@@ -1,0 +1,82 @@
+import { useCampaignTheme } from '@/components/campaignPage/themeContext';
+
+/**
+ * Prudential introducer & consent disclosure — appended to the campaign
+ * T&Cs section of ConsentAgreementDialog when design_config.prudentialAd is
+ * on (Studio Form panel → "Prudential Ad" toggle). It is deliberately NOT a
+ * separate consent checkbox and NOT stored in form.terms.html: the wording is
+ * Prudential's compliance template, so it lives in exactly one place and every
+ * toggled campaign renders the same bytes.
+ *
+ * `fbName` = the Facebook Business Name the ad runs under (Studio companion
+ * field). Absent ⇒ the attribution line is omitted rather than guessed — never
+ * invent a business identity in a regulatory disclosure.
+ *
+ * Text is verbatim from the template (2026-08-19). Do not editorialize it.
+ */
+export default function PrudentialIntroducerClause({ fbName }) {
+  const { tokens: TOKENS } = useCampaignTheme();
+
+  const linkStyle = {
+    color: TOKENS.body,
+    fontWeight: 600,
+    textDecoration: 'underline',
+    textUnderlineOffset: 3,
+    overflowWrap: 'anywhere',
+  };
+  const pStyle = { margin: '0 0 12px' };
+
+  return (
+    <div style={{ marginTop: 16, fontSize: 13, color: TOKENS.muted }}>
+      {fbName ? (
+        <p style={pStyle}>
+          <strong style={{ color: TOKENS.ink }}>{fbName}</strong> belongs to MKTR PTE. LTD.
+        </p>
+      ) : null}
+      <p style={pStyle}>
+        MKTR PTE. LTD. is an introducer, carrying out introducing activities for Prudential
+        Assurance Company Singapore (Pte) Limited (&quot;Prudential&quot;) and Prudential Financial
+        Advisers Singapore Pte Ltd (&quot;PFA&quot;). MKTR PTE. LTD. is not allowed to give advice or
+        provide recommendations on any investment product, market any collective investment scheme
+        or arrange any contract of insurance in respect of life policies, other than to the extent
+        of carrying out introducing activities. MKTR PTE. LTD. receives a fee for carrying out
+        introducing activities and will disclose the fee, if requested by you. You may contact
+        MKTR PTE. LTD. on how you may access and correct your personal data or withdraw consent to
+        the collection, use or disclosure of your personal data.
+      </p>
+      <p style={{ ...pStyle, marginBottom: 0 }}>
+        Prudential Assurance Company Singapore (Pte) Limited (or &quot;Prudential&quot;) is a life
+        insurance company that provides life and health insurance. You may refer to{' '}
+        <a href="https://www.prudential.com.sg" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          www.prudential.com.sg
+        </a>{' '}
+        for the list of Prudential products and services. Product(s) and/ or service(s) mentioned
+        which are not listed in the Prudential website are not offered by Prudential. By signing
+        up, you also confirm that you have read, understood and given your consent for Prudential
+        Assurance Company Singapore and its related corporations, respective representatives,
+        agents, third party service providers, contractors and/or appointed distribution/business
+        partners (collectively referred to as &quot;Prudential and its authorised
+        representatives&quot;) to collect, use, disclose and/or process your personal data for the
+        purpose of contacting you about products and services distributed, marketed and/or
+        introduced by Prudential and its authorised representatives through marketing activities
+        via all channels including but not limited to SMS, Social Media, In-app Push Notification,
+        Phone Call etc and perusing your contact details which Prudential and its authorised
+        representatives has in its records from time to time and in accordance to the Prudential
+        Data Privacy Notice, which is available at{' '}
+        <a href="http://www.prudential.com.sg/Privacy-Notice" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          http://www.prudential.com.sg/Privacy-Notice
+        </a>
+        . You hereby expressly understand and agree that your given consent(s) herein do not
+        supersede or replace any other consents and/or previous consents which you may have
+        previously given to Prudential and its authorised representatives in respect of your
+        personal data and is without prejudice to any legal rights available to Prudential and its
+        authorised representatives to collect, use or disclose your personal data. You understand
+        that you can refer to Prudential Data Privacy, which is available at{' '}
+        <a href="https://www.prudential.com.sg/Privacy-Notice" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+          https://www.prudential.com.sg/Privacy-Notice
+        </a>{' '}
+        for more information.
+      </p>
+    </div>
+  );
+}

--- a/src/components/studio/panels/FormPanel.jsx
+++ b/src/components/studio/panels/FormPanel.jsx
@@ -394,6 +394,32 @@ export default function FormPanel({ doc, setPath, mut, whatsappOtpConfigured, ca
           }
         />
         <TextAreaField id="studio-terms-html" label="Campaign T&Cs (HTML)" bind={bind('form.terms.html', 10000)} rows={7} />
+        {/* Prudential introducer disclosure — appends the compliance block
+            (one frontend constant) to the rendered T&Cs. No extra checkbox. */}
+        <ToggleRow
+          id="studio-prudential-ad"
+          label="Prudential Ad"
+          hint="Appends the Prudential introducer & consent disclosure to the campaign T&Cs — same agreement, no extra checkbox"
+          checked={doc.form?.terms?.prudentialAd === true}
+          onChange={(v) =>
+            mut((d) => {
+              const t = d.form.terms && typeof d.form.terms === 'object' ? d.form.terms : {};
+              d.form.terms = { template: t.template || 'default', html: t.html ?? '' };
+              if (v) {
+                d.form.terms.prudentialAd = true;
+                if (t.prudentialFbName) d.form.terms.prudentialFbName = t.prudentialFbName;
+              }
+            })
+          }
+        />
+        {doc.form?.terms?.prudentialAd === true ? (
+          <TextField
+            id="studio-prudential-fbname"
+            label="Facebook Business Name"
+            bind={bind('form.terms.prudentialFbName', 80)}
+            placeholder="Page the ad runs under — renders as “… belongs to MKTR PTE. LTD.”"
+          />
+        ) : null}
         {doc.luckyDraw?.enabled === true && !(doc.form?.terms?.html || '').trim() ? (
           <WarnNote tone="bad">Lucky-draw campaigns cannot save without T&Cs (server invariant).</WarnNote>
         ) : null}

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -213,7 +213,7 @@ export const V1_CONSUMED_KEYS = [
   'formHeadline', 'formSubheadline', 'brandWordmark', 'storyText', 'storyEmphasis',
   'heroCtaLabel', 'ctaText', 'regulatoryFooter', 'brandFooter',
   'imageUrl', 'videoUrl', 'mediaType', 'themeColor', 'heroFont', 'formWidth',
-  'termsContent', 'customerHost', 'otpChannel',
+  'termsContent', 'customerHost', 'otpChannel', 'prudentialAd', 'prudentialFbName',
   'sgPrOnly', 'excludeAdvisors', 'dncCheckAtSubmit', 'screeningCallAtSubmit',
   'visibleFields', 'requiredFields', 'fieldOrder',
   'featuredDrop', 'marketplaceListed',
@@ -591,8 +591,20 @@ export function upgradeDesignConfig(doc) {
       dncCheck: dc.dncCheckAtSubmit === true,
       screeningCall: dc.screeningCallAtSubmit === true,
     },
-    ...(dc.termsContent !== undefined
-      ? { terms: { template: 'default', html: clone(dc.termsContent) } }
+    ...(dc.termsContent !== undefined || dc.prudentialAd === true
+      ? {
+        terms: {
+          template: 'default',
+          ...(dc.termsContent !== undefined ? { html: clone(dc.termsContent) } : {}),
+          // Prudential introducer disclosure flag — the block itself is a
+          // frontend constant appended at RENDER time (never stored in html,
+          // so campaigns can't drift when the template text changes).
+          ...(dc.prudentialAd === true ? { prudentialAd: true } : {}),
+          ...(dc.prudentialAd === true && typeof dc.prudentialFbName === 'string' && dc.prudentialFbName
+            ? { prudentialFbName: clone(dc.prudentialFbName) }
+            : {}),
+        },
+      }
       : {}),
   };
 
@@ -687,6 +699,12 @@ export function downgradeDesignConfig(doc) {
   out.dncCheckAtSubmit = gates.dncCheck === true;
   out.screeningCallAtSubmit = gates.screeningCall === true;
   if (isPlainObject(form.terms) && form.terms.html !== undefined) out.termsContent = clone(form.terms.html);
+  if (isPlainObject(form.terms) && form.terms.prudentialAd === true) {
+    out.prudentialAd = true;
+    if (typeof form.terms.prudentialFbName === 'string' && form.terms.prudentialFbName) {
+      out.prudentialFbName = clone(form.terms.prudentialFbName);
+    }
+  }
 
   const distribution = isPlainObject(doc.distribution) ? doc.distribution : {};
   out.customerHost = distribution.host === 'mktr' ? 'mktr' : 'redeem';


### PR DESCRIPTION
## What

A per-campaign compliance switch in **Studio → Form panel → Terms & Conditions**: **"Prudential Ad"**. When ON, the Prudential introducer & consent disclosure is **appended to the rendered campaign T&Cs** (the full-agreement dialog) — same agreement, **no extra consent checkbox**.

- Block text lives in ONE constant — `src/components/legal/PrudentialIntroducerClause.jsx` (verbatim Prudential template, 2026-08-19). Toggled campaigns can never drift; a template update lands everywhere at once.
- `design_config` stores only the flag: `form.terms.prudentialAd` + optional `form.terms.prudentialFbName` (the Facebook Business Name, rendered as **"<name> belongs to MKTR PTE. LTD."**; when blank the line is omitted — a regulatory disclosure never guesses an identity).

## Plumbing

- **v2 twins** (`designConfigV2.js` ×2): upgrade consumes legacy `prudentialAd`/`prudentialFbName` into `form.terms`; downgrade emits them back so the legacy view feeds `ConsentAgreementDialog` via the existing `designConfig` prop. Keys added to `V1_CONSUMED_KEYS` (migration consumes; clamp scrubs top-level residue).
- **Clamp**: keeps the flag; keeps `terms` alive flag-only (no html); trims/caps fbName at 80; strips fbName whenever the flag is off/junk.
- **Public serializer**: v1 passthrough + v2 leaf-pick allowlists, so the anonymous campaign endpoints carry the flag to the funnel.

## Tests

- New: clamp survival / strip / flag-only-terms / v1→v2→legacy round-trip (`designConfigV2StudioClamp.test.js`)
- Green: lockstep (53), clamp+public+golden+util (88), campaign DB suites (259), backend unit (2438), frontend vitest (2026), `npm run typecheck`, eslint both sides

## After merge

Flip the toggle on the Prudential campaign(s) in Studio and fill **Facebook Business Name**. Until deploy, the flag would be stripped by the old clamp — do not pre-set it via JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW