### PR TITLE
fix(consent): agree-all era v2 — MKTR PTE. LTD. casing across customer copy

### DIFF
--- a/backend/src/services/consentCopyRegistry.js
+++ b/backend/src/services/consentCopyRegistry.js
@@ -1,6 +1,7 @@
 import { CONTACT_CONSENT_VERSIONS } from './contactConsent.js';
 import {
-  AGREE_ALL_THIRD_PARTY_VERSION, AGREE_ALL_THIRD_PARTY_COPY, THIRD_PARTY_CONSENT_CHANNELS,
+  AGREE_ALL_THIRD_PARTY_VERSION, AGREE_ALL_THIRD_PARTY_VERSION_V2,
+  AGREE_ALL_THIRD_PARTY_COPY, THIRD_PARTY_CONSENT_CHANNELS,
 } from './externalConsent.js';
 import DrawTermsVersion from '../models/DrawTermsVersion.js';
 
@@ -32,7 +33,7 @@ export async function resolveConsentCopy(version, deps = {}) {
       scope: contact.scope,
     });
   }
-  if (v === AGREE_ALL_THIRD_PARTY_VERSION) {
+  if (v === AGREE_ALL_THIRD_PARTY_VERSION || v === AGREE_ALL_THIRD_PARTY_VERSION_V2) {
     clauses.push({
       kind: 'third_party',
       label: 'Sponsor sharing',

--- a/backend/src/services/contactConsent.js
+++ b/backend/src/services/contactConsent.js
@@ -59,6 +59,16 @@ export const AGREE_ALL_CONTACT_COPY =
 export const AGREE_ALL_CONSENT_CHANNELS = Object.freeze(['phone', 'text', 'whatsapp', 'email']);
 
 /**
+ * AGREE-ALL v2 era (2026-08-19): wording identical to v1 except the legal
+ * entity casing — "MKTR Pte. Ltd." → "MKTR PTE. LTD." (ACRA style, matching
+ * the campaign T&Cs and the Prudential introducer clause). v1 is CLOSED —
+ * its bytes stay untouched so recorded evidence keeps meaning.
+ */
+export const AGREE_ALL_CONSENT_VERSION_V2 = '2026-08-19-agree-all-v2';
+export const AGREE_ALL_CONTACT_COPY_V2 =
+  "Contact from Redeem — this offer and future ones. MKTR PTE. LTD. (the company behind Redeem) may contact you by phone call, text message (SMS or WhatsApp) or email about your signup and reward, and about other Redeem offers, rewards and lucky draws. You can opt out anytime — every marketing email includes an unsubscribe link, or contact us using the details in our Personal Data Policy. Opting out later won't affect a reward you've already claimed.";
+
+/**
  * META LEAD ADS era (native instant forms — docs/plans/meta-lead-ads-native-pipe.md §5).
  * This copy is the EXACT custom-disclaimer checkbox text operators must put on
  * every Meta instant form (checkbox key `mktr_pdpa_consent`). Editing the
@@ -86,6 +96,12 @@ export const CONTACT_CONSENT_VERSIONS = Object.freeze({
   [AGREE_ALL_CONSENT_VERSION]: Object.freeze({
     copy: AGREE_ALL_CONTACT_COPY,
     copyHash: sha256(AGREE_ALL_CONTACT_COPY),
+    channels: AGREE_ALL_CONSENT_CHANNELS,
+    scope: 'brand',
+  }),
+  [AGREE_ALL_CONSENT_VERSION_V2]: Object.freeze({
+    copy: AGREE_ALL_CONTACT_COPY_V2,
+    copyHash: sha256(AGREE_ALL_CONTACT_COPY_V2),
     channels: AGREE_ALL_CONSENT_CHANNELS,
     scope: 'brand',
   }),

--- a/backend/src/services/externalConsent.js
+++ b/backend/src/services/externalConsent.js
@@ -85,10 +85,19 @@ export const AGREE_ALL_THIRD_PARTY_VERSION = '2026-07-21-agree-all-v1';
 export const AGREE_ALL_THIRD_PARTY_COPY =
   "Sharing with this campaign's sponsor. This campaign is sponsored: your name, contact details and form responses will be shared with the sponsoring licensed financial advisory representative (named on this page), who may contact you about your reward and relevant financial products and services.";
 
+/**
+ * AGREE-ALL v2 era label (2026-08-19): the casing era only changed the CONTACT
+ * clause ("MKTR Pte. Ltd." → "MKTR PTE. LTD."); this third-party clause is
+ * byte-identical across v1/v2 — the label exists so v2 captures stamp their
+ * own era instead of falling back to the legacy default.
+ */
+export const AGREE_ALL_THIRD_PARTY_VERSION_V2 = '2026-08-19-agree-all-v2';
+
 /** Version labels buildExternalConsentEvidence may stamp (unknown => default). */
 const KNOWN_THIRD_PARTY_VERSIONS = Object.freeze([
   THIRD_PARTY_CONSENT_VERSION,
   AGREE_ALL_THIRD_PARTY_VERSION,
+  AGREE_ALL_THIRD_PARTY_VERSION_V2,
 ]);
 
 /**

--- a/src/lib/__tests__/consentCopy.lockstep.test.js
+++ b/src/lib/__tests__/consentCopy.lockstep.test.js
@@ -12,9 +12,12 @@ import {
   CONTACT_CONSENT_VERSIONS,
   AGREE_ALL_CONSENT_VERSION,
   AGREE_ALL_CONTACT_COPY,
+  AGREE_ALL_CONSENT_VERSION_V2,
+  AGREE_ALL_CONTACT_COPY_V2,
 } from '../../../backend/src/services/contactConsent.js';
 import {
   AGREE_ALL_THIRD_PARTY_VERSION,
+  AGREE_ALL_THIRD_PARTY_VERSION_V2,
   AGREE_ALL_THIRD_PARTY_COPY,
 } from '../../../backend/src/services/externalConsent.js';
 
@@ -22,14 +25,25 @@ const sha256 = (s) => createHash('sha256').update(s).digest('hex');
 
 describe('agree-all consent copy — frontend/backend lock-step', () => {
   it('one era, one label: frontend version === both backend era labels', () => {
-    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_CONSENT_VERSION);
-    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_THIRD_PARTY_VERSION);
+    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_CONSENT_VERSION_V2);
+    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_THIRD_PARTY_VERSION_V2);
+  });
+
+  it('the CLOSED v1 era is still registered, byte-untouched (evidence keeps meaning)', () => {
+    const v1 = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION];
+    expect(v1.copy).toBe(AGREE_ALL_CONTACT_COPY);
+    expect(v1.copy).toContain('MKTR Pte. Ltd.');
+    expect(AGREE_ALL_THIRD_PARTY_VERSION).toBe('2026-07-21-agree-all-v1');
+  });
+
+  it('v2 changed ONLY the entity casing in the contact clause', () => {
+    expect(AGREE_ALL_CONTACT_COPY_V2).toBe(AGREE_ALL_CONTACT_COPY.replace('MKTR Pte. Ltd.', 'MKTR PTE. LTD.'));
   });
 
   it('contact clause (headline + body) is BYTE-IDENTICAL to the ledger-pinned backend copy', () => {
     const onScreen = `${CONSENT_COPY.clauseContactHeadline} ${CONSENT_COPY.clauseContactBody}`;
-    expect(AGREE_ALL_CONTACT_COPY).toBe(onScreen);
-    const era = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION];
+    expect(AGREE_ALL_CONTACT_COPY_V2).toBe(onScreen);
+    const era = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V2];
     expect(era.copy).toBe(onScreen);
     expect(era.copyHash).toBe(sha256(onScreen));
     expect(era.scope).toBe('brand');

--- a/src/lib/brandConfigs/mktr.js
+++ b/src/lib/brandConfigs/mktr.js
@@ -30,7 +30,7 @@ export default {
   contactWhatsapp: '',
   // Lead-capture defaults used by LeadCapture.jsx / LeadCaptureDemo.jsx.
   defaultRegulatory:
-    'MKTR Pte. Ltd. (UEN: 202507548M) operates this referral platform. Submitting this form does not establish any advisory relationship and is not a recommendation of any product. By submitting, you agree to be contacted using the particulars provided.',
+    'MKTR PTE. LTD. (UEN: 202507548M) operates this referral platform. Submitting this form does not establish any advisory relationship and is not a recommendation of any product. By submitting, you agree to be contacted using the particulars provided.',
   defaultPoweredBy: 'Powered by MKTR',
   // Marketing consent dialog references.
   partnersTerm: 'MKTR Partners',

--- a/src/lib/consentCopy.js
+++ b/src/lib/consentCopy.js
@@ -15,14 +15,17 @@
  * Editing ANY user-visible string here means a NEW era: bump the version
  * label AND add a new backend registry entry — never edit in place.
  */
-export const CONSENT_COPY_VERSION = '2026-07-21-agree-all-v1';
+// 2026-08-19-agree-all-v2: byte-identical to v1 except the legal-entity
+// casing in the contact clause ("MKTR Pte. Ltd." → "MKTR PTE. LTD.") —
+// consistent with the campaign T&Cs and the Prudential introducer clause.
+export const CONSENT_COPY_VERSION = '2026-08-19-agree-all-v2';
 
 export const CONSENT_COPY = Object.freeze({
   heading: 'One agreement — read once',
   intro: "By submitting this form, you agree to the following. It's short, and it's everything:",
   clauseContactHeadline: 'Contact from Redeem — this offer and future ones.',
   clauseContactBody:
-    "MKTR Pte. Ltd. (the company behind Redeem) may contact you by phone call, text message (SMS or WhatsApp) or email about your signup and reward, and about other Redeem offers, rewards and lucky draws. You can opt out anytime — every marketing email includes an unsubscribe link, or contact us using the details in our Personal Data Policy. Opting out later won't affect a reward you've already claimed.",
+    "MKTR PTE. LTD. (the company behind Redeem) may contact you by phone call, text message (SMS or WhatsApp) or email about your signup and reward, and about other Redeem offers, rewards and lucky draws. You can opt out anytime — every marketing email includes an unsubscribe link, or contact us using the details in our Personal Data Policy. Opting out later won't affect a reward you've already claimed.",
   // The terms clause body interleaves the T&C-modal link, so it ships in parts.
   clauseTermsHeadline: "This campaign's terms.",
   clauseTermsPrefix: "You agree to the campaign's ",

--- a/src/pages/ScreeningCallback.jsx
+++ b/src/pages/ScreeningCallback.jsx
@@ -208,7 +208,7 @@ export default function ScreeningCallback() {
         ))}
       </div>
       <p className="mt-4 text-[11px] leading-relaxed text-[#6B6558]">
-        By picking a time you&apos;re agreeing to a call from the Redeem draw team (MKTR Pte. Ltd.) about your
+        By picking a time you&apos;re agreeing to a call from the Redeem draw team (MKTR PTE. LTD.) about your
         entry — 10am–8pm Singapore time.
       </p>
     </>


### PR DESCRIPTION
## Why

The agreement dialog's summary clause said **"MKTR Pte. Ltd."** while the campaign T&Cs and the new Prudential introducer clause (#472) say **"MKTR PTE. LTD."** — the redeem brand config's documented D3 standard (ACRA style).

## How

The contact clause is **ledger-hashed consent evidence**, so this is a **new wording era**, not an edit: `2026-08-19-agree-all-v2`, byte-identical to v1 except the entity casing.

- `contactConsent.js`: v2 constants + registry entry; **v1 stays registered, bytes untouched** — recorded evidence keeps meaning
- `externalConsent.js`: v2 label registered (third-party clause has no entity name → same bytes as v1)
- `consentCopyRegistry.js`: resolver recognizes v2 for the third-party clause
- `consentCopy.js`: `CONSENT_COPY_VERSION` → v2, contact clause casing fixed — both funnels stamp the new label automatically
- Rode along (plain strings, no era): mktr brand regulatory footer + ScreeningCallback → `MKTR PTE. LTD.`
- Deliberately untouched: closed eras (legacy 2026-07-20, agree-all v1, meta-leadgen v1) — eras never edit in place

## Deploy skew

A new-frontend capture hitting a not-yet-deployed backend degrades to legacy attribution for the few-minute skew window — same behavior as the v1 rollout.

## Tests

Lockstep 7 (now also pins the closed v1 era and that v2 differs ONLY in casing) · backend consent suites 82 · frontend 2028 · backend unit 2438 · eslint clean both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW