### PR TITLE
fix(consent): agreement dialog heading → 'Terms and conditions'

### DIFF
--- a/src/lib/consentCopy.js
+++ b/src/lib/consentCopy.js
@@ -21,7 +21,7 @@
 export const CONSENT_COPY_VERSION = '2026-08-19-agree-all-v2';
 
 export const CONSENT_COPY = Object.freeze({
-  heading: 'One agreement — read once',
+  heading: 'Terms and conditions',
   intro: "By submitting this form, you agree to the following. It's short, and it's everything:",
   clauseContactHeadline: 'Contact from Redeem — this offer and future ones.',
   clauseContactBody:


### PR DESCRIPTION
Replaces the dialog title **"One agreement — read once"** with a simple **"Terms and conditions"** (Shawn's call, 2026-08-19).

Presentation-only: the heading is dialog chrome, not part of the ledger-hashed clause evidence — only the clause strings are registry-pinned — so the wording era stays `2026-08-19-agree-all-v2` and no backend entry changes. Clause bytes untouched.

Tests reference `CONSENT_COPY.heading` symbolically; 75 consent-surface tests green, lockstep untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW