### PR TITLE
fix(legal): Prudential clause verbatim to template + byte-pin test

### DIFF
--- a/src/components/legal/PrudentialIntroducerClause.jsx
+++ b/src/components/legal/PrudentialIntroducerClause.jsx
@@ -8,11 +8,15 @@ import { useCampaignTheme } from '@/components/campaignPage/themeContext';
  * Prudential's compliance template, so it lives in exactly one place and every
  * toggled campaign renders the same bytes.
  *
- * `fbName` = the Facebook Business Name the ad runs under (Studio companion
- * field). Absent ⇒ the attribution line is omitted rather than guessed — never
- * invent a business identity in a regulatory disclosure.
+ * Substitutions per the template: [Partner] = MKTR PTE. LTD.;
+ * [Facebook Business Name] = `fbName` (Studio companion field). Absent ⇒ the
+ * attribution line is omitted rather than guessed — never invent a business
+ * identity in a regulatory disclosure.
  *
- * Text is verbatim from the template (2026-08-19). Do not editorialize it.
+ * TEXT IS VERBATIM from the template Shawn supplied 2026-08-20 — including
+ * the curly typographic quotes and the template's own mixed straight-open/
+ * curly-close pair on ("PFA”). Do not editorialize, re-quote, or "fix" it;
+ * a Prudential wording update replaces the whole block here, nowhere else.
  */
 export default function PrudentialIntroducerClause({ fbName }) {
   const { tokens: TOKENS } = useCampaignTheme();
@@ -29,14 +33,12 @@ export default function PrudentialIntroducerClause({ fbName }) {
   return (
     <div style={{ marginTop: 16, fontSize: 13, color: TOKENS.muted }}>
       {fbName ? (
-        <p style={pStyle}>
-          <strong style={{ color: TOKENS.ink }}>{fbName}</strong> belongs to MKTR PTE. LTD.
-        </p>
+        <p style={pStyle}>{fbName} belongs to MKTR PTE. LTD.</p>
       ) : null}
       <p style={pStyle}>
         MKTR PTE. LTD. is an introducer, carrying out introducing activities for Prudential
-        Assurance Company Singapore (Pte) Limited (&quot;Prudential&quot;) and Prudential Financial
-        Advisers Singapore Pte Ltd (&quot;PFA&quot;). MKTR PTE. LTD. is not allowed to give advice or
+        Assurance Company Singapore (Pte) Limited (“Prudential”) and Prudential Financial
+        Advisers Singapore Pte Ltd (&quot;PFA”). MKTR PTE. LTD. is not allowed to give advice or
         provide recommendations on any investment product, market any collective investment scheme
         or arrange any contract of insurance in respect of life policies, other than to the extent
         of carrying out introducing activities. MKTR PTE. LTD. receives a fee for carrying out
@@ -45,7 +47,7 @@ export default function PrudentialIntroducerClause({ fbName }) {
         the collection, use or disclosure of your personal data.
       </p>
       <p style={{ ...pStyle, marginBottom: 0 }}>
-        Prudential Assurance Company Singapore (Pte) Limited (or &quot;Prudential&quot;) is a life
+        Prudential Assurance Company Singapore (Pte) Limited (or “Prudential”) is a life
         insurance company that provides life and health insurance. You may refer to{' '}
         <a href="https://www.prudential.com.sg" target="_blank" rel="noopener noreferrer" style={linkStyle}>
           www.prudential.com.sg
@@ -55,8 +57,8 @@ export default function PrudentialIntroducerClause({ fbName }) {
         up, you also confirm that you have read, understood and given your consent for Prudential
         Assurance Company Singapore and its related corporations, respective representatives,
         agents, third party service providers, contractors and/or appointed distribution/business
-        partners (collectively referred to as &quot;Prudential and its authorised
-        representatives&quot;) to collect, use, disclose and/or process your personal data for the
+        partners (collectively referred to as “Prudential and its authorised
+        representatives”) to collect, use, disclose and/or process your personal data for the
         purpose of contacting you about products and services distributed, marketed and/or
         introduced by Prudential and its authorised representatives through marketing activities
         via all channels including but not limited to SMS, Social Media, In-app Push Notification,

--- a/src/components/legal/__tests__/PrudentialIntroducerClause.test.jsx
+++ b/src/components/legal/__tests__/PrudentialIntroducerClause.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+
+import PrudentialIntroducerClause from '../PrudentialIntroducerClause';
+
+/**
+ * VERBATIM pin for the Prudential introducer & consent disclosure (template
+ * Shawn supplied 2026-08-20, [Partner] = MKTR PTE. LTD.). The block is
+ * compliance wording: any drift — a word, a quote glyph, a "fixed" typo — is
+ * a regression. The template's own quirks are deliberately preserved and
+ * asserted here: curly “ ” quotes, the mixed straight-open/curly-close pair
+ * on ("PFA”), and the "and/ or" spacing. A genuine Prudential wording update
+ * means changing the component AND this fixture together.
+ */
+
+const PARA_1 =
+  'MKTR PTE. LTD. is an introducer, carrying out introducing activities for Prudential Assurance Company Singapore (Pte) Limited (“Prudential”) and Prudential Financial Advisers Singapore Pte Ltd ("PFA”). MKTR PTE. LTD. is not allowed to give advice or provide recommendations on any investment product, market any collective investment scheme or arrange any contract of insurance in respect of life policies, other than to the extent of carrying out introducing activities. MKTR PTE. LTD. receives a fee for carrying out introducing activities and will disclose the fee, if requested by you. You may contact MKTR PTE. LTD. on how you may access and correct your personal data or withdraw consent to the collection, use or disclosure of your personal data.';
+
+const PARA_2 =
+  'Prudential Assurance Company Singapore (Pte) Limited (or “Prudential”) is a life insurance company that provides life and health insurance. You may refer to www.prudential.com.sg for the list of Prudential products and services. Product(s) and/ or service(s) mentioned which are not listed in the Prudential website are not offered by Prudential. By signing up, you also confirm that you have read, understood and given your consent for Prudential Assurance Company Singapore and its related corporations, respective representatives, agents, third party service providers, contractors and/or appointed distribution/business partners (collectively referred to as “Prudential and its authorised representatives”) to collect, use, disclose and/or process your personal data for the purpose of contacting you about products and services distributed, marketed and/or introduced by Prudential and its authorised representatives through marketing activities via all channels including but not limited to SMS, Social Media, In-app Push Notification, Phone Call etc and perusing your contact details which Prudential and its authorised representatives has in its records from time to time and in accordance to the Prudential Data Privacy Notice, which is available at http://www.prudential.com.sg/Privacy-Notice. You hereby expressly understand and agree that your given consent(s) herein do not supersede or replace any other consents and/or previous consents which you may have previously given to Prudential and its authorised representatives in respect of your personal data and is without prejudice to any legal rights available to Prudential and its authorised representatives to collect, use or disclose your personal data. You understand that you can refer to Prudential Data Privacy, which is available at https://www.prudential.com.sg/Privacy-Notice for more information.';
+
+/** JSX collapses source-formatting whitespace; normalize runs of spaces the
+ * same way before comparing so the pin is about CHARACTERS, not indentation. */
+const textOf = (el) => el.textContent.replace(/\s+/g, ' ').trim();
+
+describe('PrudentialIntroducerClause — verbatim compliance template', () => {
+  it('renders the two template paragraphs byte-for-byte (quotes and quirks included)', () => {
+    const { container } = render(<PrudentialIntroducerClause fbName="Redeem SG" />);
+    const paras = [...container.querySelectorAll('p')].map(textOf);
+    expect(paras).toHaveLength(3);
+    expect(paras[0]).toBe('Redeem SG belongs to MKTR PTE. LTD.');
+    expect(paras[1]).toBe(PARA_1);
+    expect(paras[2]).toBe(PARA_2);
+  });
+
+  it('omits the attribution line when no Facebook Business Name is set — never guesses one', () => {
+    const { container } = render(<PrudentialIntroducerClause />);
+    const paras = [...container.querySelectorAll('p')].map(textOf);
+    expect(paras).toHaveLength(2);
+    expect(paras[0]).toBe(PARA_1);
+  });
+
+  it('links both Privacy-Notice URLs and the products page', () => {
+    const { container } = render(<PrudentialIntroducerClause fbName="Redeem SG" />);
+    const hrefs = [...container.querySelectorAll('a')].map((a) => a.getAttribute('href'));
+    expect(hrefs).toEqual([
+      'https://www.prudential.com.sg',
+      'http://www.prudential.com.sg/Privacy-Notice',
+      'https://www.prudential.com.sg/Privacy-Notice',
+    ]);
+    for (const a of container.querySelectorAll('a')) {
+      expect(a.getAttribute('rel')).toBe('noopener noreferrer');
+      expect(a.getAttribute('target')).toBe('_blank');
+    }
+  });
+});


### PR DESCRIPTION
Conforms `PrudentialIntroducerClause` to the template Shawn supplied 2026-08-20, **byte-for-byte**:

- Curly typographic quotes: `(“Prudential”)`, `(or “Prudential”)`, `“Prudential and its authorised representatives”`
- The template's own mixed pair `("PFA”)` — straight-open, curly-close — **preserved deliberately**, since verbatim means verbatim
- `and/ or` spacing kept
- Attribution line un-bolded: plain `Redeem SG belongs to MKTR PTE. LTD.`

New `PrudentialIntroducerClause.test.jsx` pins the rendered text of both paragraphs against the template fixture (whitespace-normalized), asserts the attribution line is omitted when no Facebook Business Name is set, and checks all three `prudential.com.sg` links. Any future drift — a word, a glyph — fails the build; a genuine Prudential wording update changes component + fixture together.

Frontend suite: 2031 green (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW