### PR TITLE
feat(ads): P3 — cross-channel touchpoint history (one 90d session id, locked beacon cap, ships dark)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,15 @@ VITE_ADROLL_PIX_ID=
 # opt-in. Any non-empty value enables it. Staging only; empty in production.
 VITE_ADROLL_DEV_MODE=
 
+# Touchpoint beacons (ads-centralisation §4) — durable session-keyed visit
+# rows behind the backend's TOUCHPOINTS_ENABLED. FLIP TOGETHER with it: this
+# flag also gates the X-Session-Id header on the prospect submit, which the
+# backend's CORS allow-list must already accept. Literal "true" to enable.
+VITE_TOUCH_ENABLED=false
+# Dev opt-in mirroring VITE_ADROLL_DEV_MODE — beacons only fire outside
+# production builds when this is set. Staging only; empty in production.
+VITE_TOUCH_DEV_MODE=
+
 # -----------------------------------------------------------------------------
 # Per-build page chrome & SEO (substituted into index.html)
 # -----------------------------------------------------------------------------

--- a/backend/env.example
+++ b/backend/env.example
@@ -795,3 +795,13 @@ PLATFORM_DELIVERY_CREG_FALLBACK_HORIZON_HOURS=24
 PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS=156
 # Terminal rows (sent/failed_permanent/expired/skipped) purge after this many days.
 PLATFORM_DELIVERY_RETENTION_DAYS=90
+
+# --- Touchpoint history (ads-centralisation §4) ---
+# Durable session-keyed visit rows on the allow-listed customer surfaces.
+# Ships dark; flip TOGETHER with the frontend's VITE_TOUCH_ENABLED (a
+# frontend-only flip would send beacons the backend skips, and vice versa).
+TOUCHPOINTS_ENABLED=false
+# Append-only rows purge after this many days (daily tick, 330s boot offset).
+TOUCHPOINT_RETENTION_DAYS=180
+# Per-session 24h insert cap, enforced atomically under the per-sid lock.
+TOUCHPOINTS_MAX_PER_SESSION_DAY=50

--- a/backend/src/config/envValidation.js
+++ b/backend/src/config/envValidation.js
@@ -150,6 +150,7 @@ export function validateEnv() {
     'META_LEAD_ADS_ENABLED', 'META_OAUTH_ENABLED',
     'GOOGLE_ADS_UPLOADS_ENABLED', 'GOOGLE_CM_SYNC_ENABLED',
     'PLATFORM_DELIVERY_PLANNING_ENABLED', 'PLATFORM_DELIVERY_PAUSED',
+    'TOUCHPOINTS_ENABLED',
   ];
   const mistyped = booleanFlags.filter((k) => {
     const v = process.env[k];
@@ -171,6 +172,8 @@ export function validateEnv() {
     ['PLATFORM_DELIVERY_CREG_FALLBACK_HORIZON_HOURS', 1, 24],
     ['PLATFORM_DELIVERY_OUTCOME_HORIZON_HOURS', 1, 160],
     ['PLATFORM_DELIVERY_RETENTION_DAYS', 7, 365],
+    ['TOUCHPOINT_RETENTION_DAYS', 7, 730],
+    ['TOUCHPOINTS_MAX_PER_SESSION_DAY', 5, 500],
   ];
   const badNumerics = numericBounds.filter(([k, min, max]) => {
     const v = process.env[k];

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -10,10 +10,25 @@ const allowedOrigins = new Set([
   'http://localhost:5173'
 ]);
 
+function originOf(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
 function assertAllowedOrigin(req) {
-  const origin = req.headers.origin || '';
-  const referer = req.headers.referer || '';
-  const allowed = [...allowedOrigins].some((o) => origin.startsWith(o) || referer.startsWith(o));
+  // EXACT-origin match (ads-centralisation §4.3). The old prefix test
+  // (`origin.startsWith(o)`) accepted lookalike hosts — a page on
+  // https://mktr.sg.evil.example passed a startsWith check against
+  // https://mktr.sg — for /events and /referrals alike. The Referer fallback
+  // compares its PARSED origin, never the raw string.
+  const origin = originOf(req.headers.origin || '');
+  const refererOrigin = originOf(req.headers.referer || '');
+  const allowed =
+    (origin !== null && allowedOrigins.has(origin)) ||
+    (refererOrigin !== null && allowedOrigins.has(refererOrigin));
   if (!allowed) {
     throw new AppError('Origin not allowed', 403);
   }

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -1,6 +1,8 @@
 import { asyncHandler, AppError } from '../middleware/errorHandler.js';
 import * as analyticsService from '../services/analyticsService.js';
 import * as prospectService from '../services/prospectService.js';
+import * as touchpointService from '../services/touchpointService.js';
+import { resolveSid, setSidCookie } from '../utils/sessionId.js';
 
 const allowedOrigins = new Set([
   'https://mktr.sg',
@@ -49,6 +51,45 @@ export const trackEvent = asyncHandler(async (req, res) => {
   const sid = getSessionId(req);
   await analyticsService.trackEvent(sid, type, meta);
   res.json({ success: true });
+});
+
+/**
+ * POST /touch — durable touchpoint beacon (ads-centralisation §4.3). Public
+ * + rate-limited; Joi-validated with stripUnknown at the route. Never 4xxes
+ * on session problems — the beacon is intentionally lossy, so gate misses
+ * degrade to a 200 with a `skipped` marker.
+ *
+ * Session contract (§4.2): validated cookie wins → validated X-Session-Id
+ * header adopts (the client can't read the httpOnly cookie) → no valid sid
+ * skips. Every hit re-issues the 90d cookie (rolling window).
+ */
+export const trackTouch = asyncHandler(async (req, res) => {
+  assertAllowedOrigin(req);
+  if (!touchpointService.touchpointsEnabled()) {
+    return res.json({ success: true, skipped: true });
+  }
+  const sid = resolveSid(req);
+  if (!sid) {
+    return res.json({ success: true, skipped: 'no_session' });
+  }
+  setSidCookie(req, res, sid);
+  const b = req.body || {};
+  const result = await touchpointService.recordTouch({
+    sid,
+    surface: b.surface,
+    landingPath: b.path || null,
+    referrer: b.referrer || null,
+    campaignId: b.campaignId || null,
+    utm: {
+      utmSource: b.utm_source,
+      utmMedium: b.utm_medium,
+      utmCampaign: b.utm_campaign,
+      utmTerm: b.utm_term,
+      utmContent: b.utm_content,
+    },
+    clickIds: { fbclid: b.fbclid, ttclid: b.ttclid, gclid: b.gclid, gbraid: b.gbraid, wbraid: b.wbraid },
+  });
+  return res.json(result.recorded ? { success: true } : { success: true, skipped: result.skipped });
 });
 
 export const trackReferral = asyncHandler(async (req, res) => {

--- a/backend/src/controllers/prospectController.js
+++ b/backend/src/controllers/prospectController.js
@@ -2,6 +2,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import { sendLeadAssignmentEmail, sendLeadConfirmationEmail } from '../services/mailer.js';
 import * as prospectService from '../services/prospectService.js';
 import { publicHostFromRequest } from '../utils/publicHost.js';
+import { resolveSid, mintSid, setSidCookie } from '../utils/sessionId.js';
 
 // Build a sensible CAPI event_source_url fallback when the SPA omits it.
 // Aggregated Event Measurement requires the URL to match where the Pixel
@@ -35,7 +36,14 @@ export const listHeldProspects = asyncHandler(async (req, res) => {
 
 export const createProspect = asyncHandler(async (req, res) => {
   const publicHost = publicHostFromRequest(req);
+  // One session id (ads-centralisation §4.5): validated cookie → validated
+  // X-Session-Id header (the client's boot id — it can't read the httpOnly
+  // cookie) → mint. Adopted/rolled on THIS response so even the fastest
+  // submit leaves the browser and the prospect on one converged sid.
+  const sid = resolveSid(req) || mintSid();
+  setSidCookie(req, res, sid);
   const meta = {
+    sessionId: sid,
     clientIp: req.ip,
     clientUserAgent: req.get('user-agent') || undefined,
     eventId: req.body?.eventId,

--- a/backend/src/controllers/trackerController.js
+++ b/backend/src/controllers/trackerController.js
@@ -2,7 +2,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import * as trackerService from '../services/trackerService.js';
 import { publicHostFromRequest, cookieDomainForPublicHost } from '../utils/publicHost.js';
 import { frontendBaseForHost } from '../utils/frontendBase.js';
-import { SID_COOKIE_MAX_AGE_MS } from '../utils/sessionId.js';
+import { SID_COOKIE_MAX_AGE_MS, validSid } from '../utils/sessionId.js';
 import { Campaign } from '../models/index.js';
 import { passesStaticGate } from '../services/marketplaceService.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
@@ -63,7 +63,10 @@ export const trackSlug = asyncHandler(async (req, res) => {
   // is correct — it's one session — but the latest scan must (re)bind it,
   // otherwise a subsequent scan of a different campaign is ignored and the
   // lead is mis-attributed to the first campaign ever scanned.
-  let sid = req.cookies?.sid;
+  // VALIDATED (§4.2): a malformed cookie is replaced with a fresh mint —
+  // /touch and /prospects ignore invalid sids, so an attribution bound to a
+  // garbage value could never converge with the session they key.
+  let sid = validSid(req.cookies?.sid);
   const isNewSid = !sid;
   if (isNewSid) sid = trackerService.generateSessionId();
 

--- a/backend/src/controllers/trackerController.js
+++ b/backend/src/controllers/trackerController.js
@@ -2,6 +2,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import * as trackerService from '../services/trackerService.js';
 import { publicHostFromRequest, cookieDomainForPublicHost } from '../utils/publicHost.js';
 import { frontendBaseForHost } from '../utils/frontendBase.js';
+import { SID_COOKIE_MAX_AGE_MS } from '../utils/sessionId.js';
 import { Campaign } from '../models/index.js';
 import { passesStaticGate } from '../services/marketplaceService.js';
 import { readLegacyViewSafe } from '../utils/designConfigV2Clamp.js';
@@ -78,12 +79,13 @@ export const trackSlug = asyncHandler(async (req, res) => {
   });
 
   if (isNewSid) {
+    // 90d — the one session horizon (ads-centralisation §4.2).
     res.cookie('sid', sid, {
       httpOnly: true,
       sameSite: 'lax',
       secure: isProd,
       domain: cookieDomain,
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: SID_COOKIE_MAX_AGE_MS,
       path: '/'
     });
   }

--- a/backend/src/database/bootstrap.js
+++ b/backend/src/database/bootstrap.js
@@ -386,6 +386,31 @@ export async function bootstrapDatabase() {
       logger.info(`[PlatformDelivery] worker scheduled (${pdMinutes}m interval, 210s offset)`);
     }
 
+    // Touchpoint maintenance (ads-centralisation §4.6): consumes the durable
+    // erased-session sweeps + the daily retention purge. Scheduled whenever
+    // the tables exist — NOT behind TOUCHPOINTS_ENABLED, because erasure
+    // sweeps must drain and retention must purge even after a rollback flip
+    // (§4.8: rows inert + purged). Advisory-locked in the service; offset
+    // 330s (§0 house cadences), then daily.
+    {
+      let tpInFlight = false;
+      const runTouchpointMaintenanceTick = async () => {
+        if (tpInFlight) return;
+        tpInFlight = true;
+        try {
+          const { runTouchpointMaintenance } = await import('../services/touchpointService.js');
+          await runTouchpointMaintenance();
+        } catch (err) {
+          logger.warn('[Touchpoints] maintenance tick failed (non-fatal)', { error: err?.message });
+        } finally {
+          tpInFlight = false;
+        }
+      };
+      setTimeout(runTouchpointMaintenanceTick, 330_000);
+      setInterval(runTouchpointMaintenanceTick, 24 * 60 * 60 * 1000);
+      logger.info('[Touchpoints] maintenance scheduled (330s offset, then daily)');
+    }
+
     // Redemption CAPI reconciliation sweep — the no-rescan safety net for
     // VoucherRedeemed sends lost between the redemption commit and the
     // fire-and-forget dispatch (process death). Marker-guarded + Meta event_id

--- a/backend/src/database/migrations/127-touchpoints.js
+++ b/backend/src/database/migrations/127-touchpoints.js
@@ -1,0 +1,63 @@
+/**
+ * 127 — touchpoints (+ erased_session_sweeps): cross-channel touchpoint
+ * history (ads-centralisation §4.1). Every allow-listed customer-surface
+ * visit leaves one append-only session-keyed row; first/last/multi-touch
+ * become SQL joins against prospects."sessionId" (session EVIDENCE, not
+ * identity truth — §4). The sid is never authorization material.
+ *
+ * erased_session_sweeps makes erasure durable against in-flight beacons: the
+ * erasure txn deletes the person's touchpoints AND upserts a 24h sweep row;
+ * the purge tick re-deletes under the same per-sid advisory lock the beacon
+ * insert takes, so a beacon that raced the erasure cannot survive it.
+ */
+
+export async function up(queryInterface, Sequelize) {
+  await queryInterface.createTable('touchpoints', {
+    id: { type: Sequelize.UUID, defaultValue: Sequelize.literal('gen_random_uuid()'), primaryKey: true },
+    sessionId: { type: Sequelize.STRING(64), allowNull: false },
+    occurredAt: { type: Sequelize.DATE, allowNull: false },
+    surface: { type: Sequelize.STRING(24), allowNull: false },
+    landingPath: { type: Sequelize.STRING(512), allowNull: true },
+    // ORIGIN only — the full referrer URL is parsed and discarded server-side.
+    referrerOrigin: { type: Sequelize.STRING(255), allowNull: true },
+    campaignId: {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: { model: 'campaigns', key: 'id' },
+      onDelete: 'SET NULL',
+    },
+    utmSource: { type: Sequelize.STRING(128), allowNull: true },
+    utmMedium: { type: Sequelize.STRING(128), allowNull: true },
+    utmCampaign: { type: Sequelize.STRING(190), allowNull: true },
+    utmTerm: { type: Sequelize.STRING(190), allowNull: true },
+    utmContent: { type: Sequelize.STRING(190), allowNull: true },
+    fbclid: { type: Sequelize.STRING(512), allowNull: true },
+    ttclid: { type: Sequelize.STRING(512), allowNull: true },
+    gclid: { type: Sequelize.STRING(512), allowNull: true },
+    gbraid: { type: Sequelize.STRING(512), allowNull: true },
+    wbraid: { type: Sequelize.STRING(512), allowNull: true },
+    createdAt: { type: Sequelize.DATE, allowNull: false },
+    updatedAt: { type: Sequelize.DATE, allowNull: false },
+  });
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_tp_session_time ON touchpoints ("sessionId", "occurredAt")`
+  );
+  await queryInterface.sequelize.query(
+    `CREATE INDEX IF NOT EXISTS idx_tp_occurred ON touchpoints ("occurredAt")`
+  );
+  await queryInterface.sequelize.query(
+    `ALTER TABLE touchpoints ADD CONSTRAINT chk_tp_surface CHECK (surface IN ('leadcapture','offer','flow','browse'))`
+  );
+
+  await queryInterface.createTable('erased_session_sweeps', {
+    sessionId: { type: Sequelize.STRING(64), primaryKey: true },
+    sweepUntil: { type: Sequelize.DATE, allowNull: false },
+    createdAt: { type: Sequelize.DATE, allowNull: false },
+    updatedAt: { type: Sequelize.DATE, allowNull: false },
+  });
+}
+
+export async function down(queryInterface) {
+  await queryInterface.dropTable('erased_session_sweeps');
+  await queryInterface.dropTable('touchpoints');
+}

--- a/backend/src/middleware/validation.js
+++ b/backend/src/middleware/validation.js
@@ -56,6 +56,28 @@ export const validate = (schema, options = {}) => {
 
 // Common validation schemas
 export const schemas = {
+  // Touchpoint beacon (ads-centralisation §4.3). Client timestamps are
+  // ignored BY CONSTRUCTION — no time field exists here and the route runs
+  // stripUnknown, so occurredAt can only ever be the server clock. The full
+  // referrer comes in; only its ORIGIN is stored. utm/click-id bounds mirror
+  // prospectCreate (and the touchpoints column widths).
+  analyticsTouch: Joi.object({
+    surface: Joi.string().valid('leadcapture', 'offer', 'flow', 'browse').required(),
+    path: Joi.string().max(512).allow('').optional(),
+    referrer: Joi.string().max(2048).allow('').optional(),
+    campaignId: Joi.alternatives().try(Joi.string().uuid(), Joi.valid(null)).optional(),
+    utm_source: Joi.string().max(128).optional(),
+    utm_medium: Joi.string().max(128).optional(),
+    utm_campaign: Joi.string().max(190).optional(),
+    utm_term: Joi.string().max(190).optional(),
+    utm_content: Joi.string().max(190).optional(),
+    fbclid: Joi.string().max(512).optional(),
+    ttclid: Joi.string().max(512).optional(),
+    gclid: Joi.string().max(512).optional(),
+    gbraid: Joi.string().max(512).optional(),
+    wbraid: Joi.string().max(512).optional(),
+  }),
+
   // User schemas
   userRegister: Joi.object({
     email: Joi.string().email().required(),

--- a/backend/src/models/ErasedSessionSweep.js
+++ b/backend/src/models/ErasedSessionSweep.js
@@ -1,0 +1,19 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Durable erasure sweep marker for a session id (migration 127,
+ * ads-centralisation §4.6). Upserted in the erasure transaction with
+ * sweepUntil = now()+24h; the purge tick re-deletes that sid's touchpoints
+ * (occurredAt <= sweepUntil, shared-session-guarded) under the same per-sid
+ * advisory lock the beacon insert takes, then drops the row once the window
+ * has passed. Replaces any setTimeout — survives restarts.
+ */
+const ErasedSessionSweep = sequelize.define('ErasedSessionSweep', {
+  sessionId: { type: DataTypes.STRING(64), primaryKey: true },
+  sweepUntil: { type: DataTypes.DATE, allowNull: false },
+}, {
+  tableName: 'erased_session_sweeps',
+});
+
+export default ErasedSessionSweep;

--- a/backend/src/models/Touchpoint.js
+++ b/backend/src/models/Touchpoint.js
@@ -1,0 +1,33 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../database/connection.js';
+
+/**
+ * Append-only customer-surface visit row (migration 127, ads-centralisation
+ * §4). Session-keyed EVIDENCE — joins to prospects."sessionId" are per-brand,
+ * same-browser attribution hints, never identity truth. Written only by the
+ * /touch beacon (inside its per-sid advisory-locked transaction); deleted
+ * only by erasure, the erased-session sweeps, and the retention purge.
+ */
+const Touchpoint = sequelize.define('Touchpoint', {
+  id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+  sessionId: { type: DataTypes.STRING(64), allowNull: false },
+  occurredAt: { type: DataTypes.DATE, allowNull: false },
+  surface: { type: DataTypes.STRING(24), allowNull: false },
+  landingPath: { type: DataTypes.STRING(512), allowNull: true },
+  referrerOrigin: { type: DataTypes.STRING(255), allowNull: true },
+  campaignId: { type: DataTypes.UUID, allowNull: true },
+  utmSource: { type: DataTypes.STRING(128), allowNull: true },
+  utmMedium: { type: DataTypes.STRING(128), allowNull: true },
+  utmCampaign: { type: DataTypes.STRING(190), allowNull: true },
+  utmTerm: { type: DataTypes.STRING(190), allowNull: true },
+  utmContent: { type: DataTypes.STRING(190), allowNull: true },
+  fbclid: { type: DataTypes.STRING(512), allowNull: true },
+  ttclid: { type: DataTypes.STRING(512), allowNull: true },
+  gclid: { type: DataTypes.STRING(512), allowNull: true },
+  gbraid: { type: DataTypes.STRING(512), allowNull: true },
+  wbraid: { type: DataTypes.STRING(512), allowNull: true },
+}, {
+  tableName: 'touchpoints',
+});
+
+export default Touchpoint;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -410,7 +410,7 @@ export const {
   EnrichmentScoringConfig, EnrichmentSweepRun,
   MetaPage, MetaFormMapping, MetaLeadgenEvent, MetaAgentConnection,
   OutreachAccount, OutreachPersona, OutreachEmail, TimelineHiddenEntry,
-  PlatformDelivery
+  PlatformDelivery, Touchpoint, ErasedSessionSweep
 } = models;
 
 export { sequelize };

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -34,6 +34,11 @@ const touchLimit = makeLimiter({
 
 router.post('/events', analyticsLimit, ctrl.trackEvent);
 router.post('/referrals', analyticsLimit, ctrl.trackReferral);
-router.post('/touch', touchLimit, validate(schemas.analyticsTouch, { stripUnknown: true }), ctrl.trackTouch);
+// The feature gate runs BEFORE Joi (§4.3): with TOUCHPOINTS_ENABLED off the
+// beacon is a pure {skipped:true} no-op whatever the body looks like — a
+// schema-skewed cached bundle must not turn a dark feature into 400 noise.
+const touchGate = (req, res, next) =>
+  (process.env.TOUCHPOINTS_ENABLED !== 'true' ? res.json({ success: true, skipped: true }) : next());
+router.post('/touch', touchLimit, touchGate, validate(schemas.analyticsTouch, { stripUnknown: true }), ctrl.trackTouch);
 
 export default router;

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import { makeLimiter } from '../middleware/rateLimiters.js';
+import { validate, schemas } from '../middleware/validation.js';
 import * as ctrl from '../controllers/analyticsController.js';
 
 export const meta = {
   // Public routes (default-deny routing): browser tracking beacons from the public funnel
-  public: ['POST /events', 'POST /referrals'],
+  public: ['POST /events', 'POST /referrals', 'POST /touch'],
   mounts: [
     { path: '/api/analytics' },
     { path: '/api/adtech/analytics', flag: 'ENABLE_DOMAIN_PREFIXES' },
@@ -21,7 +22,18 @@ const analyticsLimit = makeLimiter({
   message: 'Too many requests.',
 });
 
+// The touchpoint beacon gets its OWN bucket (ads-centralisation §4.3): a
+// browse session legitimately emits several touches, and sharing the
+// analytics bucket would let route-tracking starve the referral badge.
+const touchLimit = makeLimiter({
+  prefix: 'rl:touch',
+  windowMs: 60 * 1000,
+  max: 30,
+  message: 'Too many requests.',
+});
+
 router.post('/events', analyticsLimit, ctrl.trackEvent);
 router.post('/referrals', analyticsLimit, ctrl.trackReferral);
+router.post('/touch', touchLimit, validate(schemas.analyticsTouch, { stripUnknown: true }), ctrl.trackTouch);
 
 export default router;

--- a/backend/src/routes/leadCaptureBind.js
+++ b/backend/src/routes/leadCaptureBind.js
@@ -4,6 +4,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import { Attribution } from '../models/index.js';
 import { publicHostFromRequest, cookieDomainForPublicHost } from '../utils/publicHost.js';
 import { frontendBaseForHost } from '../utils/frontendBase.js';
+import { SID_COOKIE_MAX_AGE_MS } from '../utils/sessionId.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 if (isProd && !process.env.ATTRIB_SECRET) {
@@ -19,7 +20,7 @@ router.get('/lead-capture', asyncHandler(async (req, res, next) => {
   const isProdReq = process.env.NODE_ENV === 'production';
   const publicHost = publicHostFromRequest(req);
   const cookieDomain = isProdReq ? cookieDomainForPublicHost(publicHost) : undefined;
-  // Ensure sid cookie exists
+  // Ensure sid cookie exists (90d — the one session horizon, ads-centralisation §4.2)
   let sid = req.cookies?.sid;
   if (!sid) {
     sid = crypto.randomBytes(16).toString('hex');
@@ -28,7 +29,7 @@ router.get('/lead-capture', asyncHandler(async (req, res, next) => {
       sameSite: 'lax',
       secure: isProdReq,
       domain: cookieDomain,
-      maxAge: 7 * 24 * 60 * 60 * 1000,
+      maxAge: SID_COOKIE_MAX_AGE_MS,
       path: '/'
     });
   }

--- a/backend/src/routes/leadCaptureBind.js
+++ b/backend/src/routes/leadCaptureBind.js
@@ -4,7 +4,7 @@ import { asyncHandler } from '../middleware/errorHandler.js';
 import { Attribution } from '../models/index.js';
 import { publicHostFromRequest, cookieDomainForPublicHost } from '../utils/publicHost.js';
 import { frontendBaseForHost } from '../utils/frontendBase.js';
-import { SID_COOKIE_MAX_AGE_MS } from '../utils/sessionId.js';
+import { SID_COOKIE_MAX_AGE_MS, validSid } from '../utils/sessionId.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 if (isProd && !process.env.ATTRIB_SECRET) {
@@ -20,8 +20,11 @@ router.get('/lead-capture', asyncHandler(async (req, res, next) => {
   const isProdReq = process.env.NODE_ENV === 'production';
   const publicHost = publicHostFromRequest(req);
   const cookieDomain = isProdReq ? cookieDomainForPublicHost(publicHost) : undefined;
-  // Ensure sid cookie exists (90d — the one session horizon, ads-centralisation §4.2)
-  let sid = req.cookies?.sid;
+  // Ensure a VALID sid cookie exists (90d — the one session horizon, §4.2).
+  // A malformed cookie is replaced, not propagated: /touch and /prospects
+  // validate both sid sources, so binding attribution to a garbage sid would
+  // split the identity they converge on.
+  let sid = validSid(req.cookies?.sid);
   if (!sid) {
     sid = crypto.randomBytes(16).toString('hex');
     res.cookie('sid', sid, {

--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -93,7 +93,10 @@ export const init = async (app) => {
       origin: corsOrigins,
       credentials: true,
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
-      allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+      // X-Session-Id: the client-side boot session id ridden by the /touch
+      // beacon and the prospect submit (ads-centralisation §4.2) — the SPA
+      // can't read the httpOnly sid cookie, so the header carries it.
+      allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With', 'X-Session-Id'],
       preflightContinue: false,
       optionsSuccessStatus: 204,
     })

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -74,6 +74,12 @@ const defaultDeps = {
     const m = await import('./googleCustomerMatchService.js');
     return m.removeAudienceMembers(m.buildRemovalIdentifiers(pairs));
   },
+  // Touchpoint sweep upsert (ads-centralisation §4.6) — lazy for the same
+  // import-graph reason; the maintenance tick consumes what this writes.
+  upsertErasedSessionSweepsTx: async (t, sids) => {
+    const m = await import('./touchpointService.js');
+    return m.upsertErasedSessionSweepsTx(t, sids);
+  },
 };
 
 export function makeErasureService(overrides = {}) {
@@ -447,16 +453,7 @@ export function makeErasureService(overrides = {}) {
             { replacements: { sessionIds }, transaction: t }
           );
           report.touchpoints = rowCount(tpMeta);
-          await d.sequelize.query(
-            `INSERT INTO erased_session_sweeps ("sessionId", "sweepUntil", "createdAt", "updatedAt")
-             SELECT sid, now() + interval '24 hours', now(), now()
-               FROM unnest(ARRAY[:sessionIds]::text[]) AS sid
-             ON CONFLICT ("sessionId") DO UPDATE
-               SET "sweepUntil" = GREATEST(erased_session_sweeps."sweepUntil", excluded."sweepUntil"),
-                   "updatedAt" = now()`,
-            { replacements: { sessionIds }, transaction: t }
-          );
-          report.erasedSessionSweeps = sessionIds.length;
+          report.erasedSessionSweeps = await d.upsertErasedSessionSweepsTx(t, sessionIds);
         }
         if (attributionIds.length) {
           const [, atMeta] = await d.sequelize.query(

--- a/backend/src/services/erasureService.js
+++ b/backend/src/services/erasureService.js
@@ -433,6 +433,30 @@ export function makeErasureService(overrides = {}) {
             { replacements: { sessionIds }, transaction: t }
           );
           report.sessionVisits = rowCount(svMeta);
+
+          // Touchpoints (ads-centralisation §4.6): guarded delete NOW, plus a
+          // durable 24h sweep row per sid — the maintenance tick re-applies
+          // the delete under the same per-sid advisory lock the beacon insert
+          // takes, so a beacon racing this transaction cannot outlive the
+          // erasure. The shared-session guard mirrors session_visits: a sid
+          // shared with a SURVIVING prospect is never swept.
+          const [, tpMeta] = await d.sequelize.query(
+            `DELETE FROM touchpoints tp
+              WHERE tp."sessionId" IN (:sessionIds)
+                AND NOT EXISTS (SELECT 1 FROM prospects p2 WHERE p2."sessionId" = tp."sessionId")`,
+            { replacements: { sessionIds }, transaction: t }
+          );
+          report.touchpoints = rowCount(tpMeta);
+          await d.sequelize.query(
+            `INSERT INTO erased_session_sweeps ("sessionId", "sweepUntil", "createdAt", "updatedAt")
+             SELECT sid, now() + interval '24 hours', now(), now()
+               FROM unnest(ARRAY[:sessionIds]::text[]) AS sid
+             ON CONFLICT ("sessionId") DO UPDATE
+               SET "sweepUntil" = GREATEST(erased_session_sweeps."sweepUntil", excluded."sweepUntil"),
+                   "updatedAt" = now()`,
+            { replacements: { sessionIds }, transaction: t }
+          );
+          report.erasedSessionSweeps = sessionIds.length;
         }
         if (attributionIds.length) {
           const [, atMeta] = await d.sequelize.query(

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -77,6 +77,7 @@ import {
   getProspectOutcomes,
 } from './leadProfileService.js';
 import { customerHostOrigin, normalizeCustomerHostChoice } from '../utils/customerHost.js';
+import { validSid } from '../utils/sessionId.js';
 import { sgtDayEndExclusiveMs, cleanYmd, sgtAgeFromDob } from '../utils/sgtTime.js';
 
 // Redeem Ops capture hook (docs/redeem-ops/MKTR_INTEGRATION.md §2): a
@@ -367,11 +368,18 @@ export function makeProspectService(overrides = {}) {
     // /LeadCapture?campaign_id=X link) BEFORE we derive one from a QR tag.
     const explicitCampaignId = incoming.campaignId != null ? incoming.campaignId : null;
 
-    // Bind attribution by session cookie (sid). Most-recently-touched wins
-    // (last-touch); createdAt then id DESC are deterministic tiebreakers for a
-    // same-millisecond lastTouchAt tie.
-    const sid = cookies?.sid || headers?.['x-session-id'];
+    // One session id (ads-centralisation §4.5): the controller resolves/mints
+    // the sid (validated cookie → validated X-Session-Id header → mint) and
+    // passes it as meta.sessionId; direct service callers fall back to the
+    // same validated raw sources. The prospect binds the sid WHENEVER one
+    // exists — first/last-touch joins need every web prospect session-keyed,
+    // even on the fastest submit. Attribution rows only add QR/campaign
+    // context on top (most-recently-touched wins; createdAt then id DESC are
+    // deterministic tiebreakers for a same-millisecond lastTouchAt tie).
+    // The sid is never authorization material.
+    const sid = meta?.sessionId ?? (validSid(cookies?.sid) || validSid(headers?.['x-session-id']));
     if (sid) {
+      incoming.sessionId = sid;
       const attribution = await m.Attribution.findOne({
         where: { sessionId: sid },
         order: [['lastTouchAt', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
@@ -379,7 +387,6 @@ export function makeProspectService(overrides = {}) {
       if (attribution) {
         incoming.attributionId = attribution.id;
         incoming.qrTagId = attribution.qrTagId || incoming.qrTagId;
-        incoming.sessionId = sid;
       }
     }
 
@@ -405,9 +412,12 @@ export function makeProspectService(overrides = {}) {
         boundQr.campaignId != null &&
         String(boundQr.campaignId) === String(explicitCampaignId);
       if (!qrBelongsToExplicitCampaign) {
+        // Drop the foreign QR + its attribution — but KEEP the sessionId
+        // (ads-centralisation §4.5): the session is the person's browsing
+        // identity for touchpoint joins, not a routing input; only the
+        // qr/attribution pair could skew agent routing.
         delete incoming.qrTagId;
         delete incoming.attributionId;
-        delete incoming.sessionId;
         incoming.campaignId = explicitCampaignId;
       }
     }

--- a/backend/src/services/touchpointService.js
+++ b/backend/src/services/touchpointService.js
@@ -102,6 +102,25 @@ export async function recordTouch({ sid, surface, landingPath, referrer, campaig
 }
 
 /**
+ * Upsert the durable erased-session sweep rows (§4.6) — called INSIDE the
+ * erasure transaction. `GREATEST` on conflict: a repeat erasure (repair run)
+ * EXTENDS an open window and can never shrink one another erasure set later.
+ */
+export async function upsertErasedSessionSweepsTx(t, sessionIds) {
+  if (!sessionIds?.length) return 0;
+  await sequelize.query(
+    `INSERT INTO erased_session_sweeps ("sessionId", "sweepUntil", "createdAt", "updatedAt")
+     SELECT sid, now() + interval '24 hours', now(), now()
+       FROM unnest(ARRAY[:sessionIds]::text[]) AS sid
+     ON CONFLICT ("sessionId") DO UPDATE
+       SET "sweepUntil" = GREATEST(erased_session_sweeps."sweepUntil", excluded."sweepUntil"),
+           "updatedAt" = now()`,
+    { replacements: { sessionIds }, transaction: t }
+  );
+  return sessionIds.length;
+}
+
+/**
  * Consume the durable erased-session sweeps (§4.6): per sid, one transaction
  * taking the SAME per-sid lock the beacon insert holds, re-applying the
  * shared-session guard (a session shared with a SURVIVING prospect is never

--- a/backend/src/services/touchpointService.js
+++ b/backend/src/services/touchpointService.js
@@ -1,0 +1,176 @@
+import { sequelize, Campaign } from '../models/index.js';
+import { advisoryXactLock, withAdvisoryLock } from '../utils/advisoryLock.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * touchpointService — cross-channel touchpoint history (ads-centralisation
+ * §4). Append-only, session-keyed EVIDENCE rows for the allow-listed customer
+ * surfaces; the joins against prospects."sessionId" are per-brand, same-
+ * browser attribution hints, never identity truth.
+ *
+ * Concurrency contract (§4.3/§4.6): every beacon insert runs in ONE
+ * transaction holding pg_advisory_xact_lock(hashtext('tp:' || sid)) — the
+ * per-day cap count, the occurredAt stamp (clock_timestamp(), taken AFTER the
+ * lock is granted), and the insert are atomic under it. The erased-session
+ * sweep takes the SAME lock before re-deleting, so stamp-vs-delete is fully
+ * serialized: any row stamped ≤ sweepUntil is caught by a later sweep pass;
+ * rows stamped after the window are genuinely post-erasure anonymous data.
+ */
+
+function numEnv(name, def, min, max) {
+  const raw = process.env[name];
+  if (raw === undefined || String(raw).trim() === '') return def;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return def;
+  return Math.min(max, Math.max(min, n));
+}
+
+export function touchpointsEnabled() {
+  return process.env.TOUCHPOINTS_ENABLED === 'true';
+}
+
+const maxPerSessionDay = () => numEnv('TOUCHPOINTS_MAX_PER_SESSION_DAY', 50, 5, 500);
+const retentionDays = () => numEnv('TOUCHPOINT_RETENTION_DAYS', 180, 7, 730);
+
+/** Full referrer URL in, ORIGIN only out — the path/query never persist. */
+export function referrerOriginOf(referrer) {
+  if (!referrer || typeof referrer !== 'string') return null;
+  try {
+    return new URL(referrer).origin.slice(0, 255);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record ONE touchpoint under the per-sid lock: atomic 24h cap → campaign
+ * existence check (a bogus uuid must not abort on the FK) → insert with the
+ * server clock stamped inside the locked txn. Client timestamps are ignored
+ * by construction — there is no timestamp parameter.
+ */
+export async function recordTouch({ sid, surface, landingPath, referrer, campaignId, utm = {}, clickIds = {} }) {
+  return sequelize.transaction(async (t) => {
+    await advisoryXactLock(t, `tp:${sid}`);
+    const [cnt] = await sequelize.query(
+      `SELECT count(*)::int AS n FROM touchpoints
+        WHERE "sessionId" = :sid AND "createdAt" > now() - interval '24 hours'`,
+      { replacements: { sid }, transaction: t }
+    );
+    if ((cnt?.[0]?.n ?? 0) >= maxPerSessionDay()) {
+      return { recorded: false, skipped: 'capped' };
+    }
+    let campaignRow = null;
+    if (campaignId) {
+      campaignRow = await Campaign.findByPk(campaignId, { attributes: ['id'], transaction: t, raw: true });
+    }
+    // clock_timestamp(), NOT now(): now() is transaction-start time, which
+    // predates the advisory-lock grant when the lock had to wait — the stamp
+    // must postdate the lock for the sweep serialization argument to hold.
+    const [rows] = await sequelize.query(
+      `INSERT INTO touchpoints
+         (id, "sessionId", "occurredAt", surface, "landingPath", "referrerOrigin", "campaignId",
+          "utmSource", "utmMedium", "utmCampaign", "utmTerm", "utmContent",
+          fbclid, ttclid, gclid, gbraid, wbraid, "createdAt", "updatedAt")
+       VALUES
+         (gen_random_uuid(), :sid, clock_timestamp(), :surface, :landingPath, :referrerOrigin, :campaignId,
+          :utmSource, :utmMedium, :utmCampaign, :utmTerm, :utmContent,
+          :fbclid, :ttclid, :gclid, :gbraid, :wbraid, clock_timestamp(), clock_timestamp())
+       RETURNING id`,
+      {
+        replacements: {
+          sid,
+          surface,
+          landingPath: landingPath || null,
+          referrerOrigin: referrerOriginOf(referrer),
+          campaignId: campaignRow?.id || null,
+          utmSource: utm.utmSource || null,
+          utmMedium: utm.utmMedium || null,
+          utmCampaign: utm.utmCampaign || null,
+          utmTerm: utm.utmTerm || null,
+          utmContent: utm.utmContent || null,
+          fbclid: clickIds.fbclid || null,
+          ttclid: clickIds.ttclid || null,
+          gclid: clickIds.gclid || null,
+          gbraid: clickIds.gbraid || null,
+          wbraid: clickIds.wbraid || null,
+        },
+        transaction: t,
+      }
+    );
+    return { recorded: true, id: rows?.[0]?.id || null };
+  });
+}
+
+/**
+ * Consume the durable erased-session sweeps (§4.6): per sid, one transaction
+ * taking the SAME per-sid lock the beacon insert holds, re-applying the
+ * shared-session guard (a session shared with a SURVIVING prospect is never
+ * swept), deleting rows stamped inside the window, and dropping the sweep row
+ * in the same transaction once the window has passed.
+ */
+export async function consumeErasedSessionSweeps() {
+  const [sweeps] = await sequelize.query(
+    `SELECT "sessionId", "sweepUntil" FROM erased_session_sweeps LIMIT 500`
+  );
+  let deleted = 0;
+  let dropped = 0;
+  for (const s of sweeps || []) {
+    try {
+      await sequelize.transaction(async (t) => {
+        await advisoryXactLock(t, `tp:${s.sessionId}`);
+        const [, delMeta] = await sequelize.query(
+          `DELETE FROM touchpoints tp
+            WHERE tp."sessionId" = :sid
+              AND tp."occurredAt" <= :sweepUntil
+              AND NOT EXISTS (SELECT 1 FROM prospects p2 WHERE p2."sessionId" = :sid)`,
+          { replacements: { sid: s.sessionId, sweepUntil: s.sweepUntil }, transaction: t }
+        );
+        deleted += delMeta?.rowCount ?? 0;
+        const [, dropMeta] = await sequelize.query(
+          `DELETE FROM erased_session_sweeps WHERE "sessionId" = :sid AND "sweepUntil" < now()`,
+          { replacements: { sid: s.sessionId }, transaction: t }
+        );
+        dropped += dropMeta?.rowCount ?? 0;
+      });
+    } catch (err) {
+      logger.warn({ sessionId: s.sessionId, error: err?.message || String(err) }, 'touchpoints.sweep_failed');
+    }
+  }
+  return { sweeps: sweeps?.length ?? 0, deleted, dropped };
+}
+
+/** Retention purge (§4.6): rows older than TOUCHPOINT_RETENTION_DAYS, bounded batches. */
+export async function purgeOldTouchpoints() {
+  const days = retentionDays();
+  let total = 0;
+  for (let i = 0; i < 20; i++) {
+    const [, meta] = await sequelize.query(
+      `DELETE FROM touchpoints WHERE id IN (
+         SELECT id FROM touchpoints
+          WHERE "occurredAt" < now() - make_interval(days => :days)
+          LIMIT 1000)`,
+      { replacements: { days } }
+    );
+    const n = meta?.rowCount ?? 0;
+    total += n;
+    if (n < 1000) break;
+  }
+  return total;
+}
+
+/**
+ * The daily maintenance tick (offset 330s — §0 house cadences), advisory-
+ * locked. Runs regardless of TOUCHPOINTS_ENABLED: erasure sweeps must drain
+ * and retention must purge even after a rollback flip (§4.8 — rows inert +
+ * purged).
+ */
+export async function runTouchpointMaintenance() {
+  return withAdvisoryLock('tp:maintenance', async () => {
+    const sweeps = await consumeErasedSessionSweeps();
+    const purged = await purgeOldTouchpoints();
+    if (sweeps.deleted || sweeps.dropped || purged) {
+      logger.info({ ...sweeps, purged }, 'touchpoints.maintenance_tick');
+    }
+    return { ...sweeps, purged };
+  });
+}

--- a/backend/src/utils/sessionId.js
+++ b/backend/src/utils/sessionId.js
@@ -1,0 +1,62 @@
+import crypto from 'crypto';
+import { publicHostFromRequest, cookieDomainForPublicHost } from './publicHost.js';
+
+/**
+ * ONE first-party session id (ads-centralisation §4.2), shared by the QR
+ * redirect, /lead-capture bind, the /touch beacon, and the prospect submit.
+ *
+ * - Format: 32 lowercase hex chars (crypto.randomBytes(16)) — the historical
+ *   sid shape. BOTH sources (cookie and the X-Session-Id header the client
+ *   sends because it cannot read the httpOnly cookie) are validated against
+ *   it; an invalid value is IGNORED, never a 400. A validated cookie always
+ *   wins over the header.
+ * - Horizon: 90 days everywhere (the old 7d mint sites moved here); /touch
+ *   and the submit response re-issue the cookie, so the window is rolling.
+ * - The sid is NEVER authorization material — it keys browsing evidence only.
+ */
+export const SID_RE = /^[a-f0-9]{32}$/;
+export const SID_COOKIE_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** @param {unknown} value */
+export function validSid(value) {
+  return typeof value === 'string' && SID_RE.test(value) ? value : null;
+}
+
+export function mintSid() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * validated cookie → validated header → null. Invalid values are ignored.
+ * @param {{ cookies?: Record<string, string>, headers?: Record<string, unknown> }} req
+ */
+export function resolveSid(req) {
+  return validSid(req.cookies?.sid) || validSid(req.headers?.['x-session-id']) || null;
+}
+
+/**
+ * The leadCaptureBind cookie recipe, centralized at the 90-day horizon.
+ * @param {import('express').Request} req
+ */
+export function sidCookieOptions(req) {
+  const isProd = process.env.NODE_ENV === 'production';
+  const domain = isProd ? cookieDomainForPublicHost(publicHostFromRequest(req)) : undefined;
+  return {
+    httpOnly: true,
+    sameSite: /** @type {const} */ ('lax'),
+    secure: isProd,
+    domain,
+    maxAge: SID_COOKIE_MAX_AGE_MS,
+    path: '/',
+  };
+}
+
+/**
+ * Adopt (header-only sid) or roll (existing cookie) the sid onto the response.
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {string} sid
+ */
+export function setSidCookie(req, res, sid) {
+  res.cookie('sid', sid, sidCookieOptions(req));
+}

--- a/backend/test/analytics.test.js
+++ b/backend/test/analytics.test.js
@@ -94,6 +94,35 @@ describe('POST /api/analytics/events', () => {
 
     expect(res.status).toBe(403)
   })
+
+  // Exact-origin matrix (ads-centralisation §4.3): the old prefix match let a
+  // lookalike host through — https://mktr.sg.evil.example startsWith
+  // https://mktr.sg. Origin AND the Referer fallback must both compare exactly.
+  it('rejects lookalike-host origins the old prefix match accepted', async () => {
+    for (const evil of ['https://mktr.sg.evil.example', 'https://redeem.sg.evil.example']) {
+      const res = await request(app)
+        .post('/api/analytics/events')
+        .set('Origin', evil)
+        .set('x-session-id', 'test-sid-lookalike')
+        .send({ type: 'page_view' })
+      expect(res.status).toBe(403)
+    }
+    const viaReferer = await request(app)
+      .post('/api/analytics/events')
+      .set('Referer', 'https://redeem.sg.evil.example/offers/x')
+      .set('x-session-id', 'test-sid-lookalike')
+      .send({ type: 'page_view' })
+    expect(viaReferer.status).toBe(403)
+  })
+
+  it('still accepts a genuine Referer-only request (no Origin header)', async () => {
+    const res = await request(app)
+      .post('/api/analytics/events')
+      .set('Referer', 'https://redeem.sg/offers/airpods')
+      .set('x-session-id', 'test-sid-referer-ok')
+      .send({ type: 'page_view' })
+    expect(res.status).toBe(200)
+  })
 })
 
 describe('POST /api/analytics/referrals', () => {

--- a/backend/test/integration/erasure.test.js
+++ b/backend/test/integration/erasure.test.js
@@ -18,7 +18,7 @@ import {
   RewardEntitlement, RedemptionEvent, Redemption, Draw, DrawEntry, DrawAttempt,
   ShortLink, WebhookSubscriber, WebhookDelivery, Verification, WaitlistSignup,
   ConsentEvent, ConsumerSuppression, PartnerOrganisation, RewardOffer, Activation,
-  SessionVisit, IdempotencyKey, PlatformDelivery,
+  SessionVisit, IdempotencyKey, PlatformDelivery, Touchpoint, ErasedSessionSweep,
 } from '../../src/models/index.js';
 import { markPhoneVerified, isPhoneRecentlyVerified } from '../../src/services/verifiedPhoneStore.js';
 import { phoneHashOf } from '../../src/services/consumerService.js';
@@ -155,6 +155,16 @@ describe('PDPA erasure — full matrix', () => {
     sessionVisit = await SessionVisit.create({
       sessionId: `sess-${RUN}`, landingPath: '/lead-capture', utmSource: 'fb',
       eventsJson: [{ type: 'form_view', ts: new Date().toISOString() }],
+    });
+    // Touchpoint rows on the same session (ads-centralisation §4.6): both must
+    // be deleted in the erasure txn, and a durable sweep row must be minted so
+    // the maintenance tick re-deletes in-flight stragglers.
+    await Touchpoint.create({
+      sessionId: `sess-${RUN}`, occurredAt: new Date(), surface: 'browse', landingPath: '/explore',
+    });
+    await Touchpoint.create({
+      sessionId: `sess-${RUN}`, occurredAt: new Date(), surface: 'leadcapture',
+      landingPath: '/leadcapture', campaignId: campaign1.id, utmSource: 'fb',
     });
     attribution = await createTestAttribution(qrTag.id, `sess-${RUN}`);
     await sequelize.query(
@@ -372,6 +382,12 @@ describe('PDPA erasure — full matrix', () => {
     expect(report.referralCopiesScrubbed).toBe(1);
     expect(report.sessionVisits).toBe(1);
     expect(report.attributions).toBe(1);
+    expect(report.touchpoints).toBe(2);
+    expect(await Touchpoint.count({ where: { sessionId: `sess-${RUN}` } })).toBe(0);
+    // The durable 24h sweep row exists for the maintenance tick to consume.
+    const sweep = await ErasedSessionSweep.findByPk(`sess-${RUN}`);
+    expect(sweep).not.toBeNull();
+    expect(new Date(sweep.sweepUntil).getTime()).toBeGreaterThan(Date.now());
     expect(report.platformDeliveries).toBe(2);
     expect(await PlatformDelivery.count({ where: { prospectId: [prospect1.id, prospect2.id] } })).toBe(0);
     expect(report.idempotencyKeys).toBe(1);

--- a/backend/test/leadCaptureBind.test.js
+++ b/backend/test/leadCaptureBind.test.js
@@ -134,21 +134,32 @@ describe('GET /lead-capture', () => {
     expect(res.status).toBe(302)
   })
 
-  it('reuses sid cookie when already present', async () => {
-    const existingSid = 'existing-session-id-12345678'
+  it('reuses a VALID sid cookie when already present (no re-mint)', async () => {
+    // 32-hex — the validated sid shape (ads-centralisation §4.2).
+    const existingSid = 'ab12ab12ab12ab12ab12ab12ab12ab12'
     const res = await request(app)
       .get('/lead-capture')
       .set('Cookie', `sid=${existingSid}`)
 
     expect(res.status).toBe(302)
-    // Should NOT set a new sid cookie since one already exists
+    // A valid sid is reused as-is — the mint branch (and its Set-Cookie) is skipped.
     const cookies = res.headers['set-cookie'] || []
     const cookieArr = Array.isArray(cookies) ? cookies : [cookies]
-    const newSid = cookieArr.find(c => c.startsWith('sid='))
-    // Either no sid cookie set, or it should not override
-    if (newSid) {
-      // If framework re-sets it, that is okay as long as it does not crash
-      expect(res.status).toBe(302)
-    }
+    expect(cookieArr.find(c => c.startsWith('sid='))).toBeUndefined()
+  })
+
+  it('REPLACES a malformed sid cookie with a fresh 32-hex mint (§4.2 validation)', async () => {
+    // /touch and /prospects ignore invalid sids, so propagating one here would
+    // bind attribution to an identity nothing else can ever converge on.
+    const res = await request(app)
+      .get('/lead-capture')
+      .set('Cookie', 'sid=existing-session-id-12345678')
+
+    expect(res.status).toBe(302)
+    const cookies = res.headers['set-cookie'] || []
+    const cookieArr = Array.isArray(cookies) ? cookies : [cookies]
+    const minted = cookieArr.find(c => c.startsWith('sid='))
+    expect(minted).toBeTruthy()
+    expect(minted).toMatch(/^sid=[a-f0-9]{32};/)
   })
 })

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -715,7 +715,9 @@ describe('Attribution binding', () => {
   })
 
   it('binds attributionId and qrTagId from x-session-id header', async () => {
-    const sessionId = `test-session-${Date.now()}`
+    // 32-hex — the shape every mint site produces and both sid sources are
+    // validated against since ads-centralisation §4.2.
+    const sessionId = Date.now().toString(16).padStart(32, 'f').slice(-32)
     const attribution = await createTestAttribution(qrTag.id, sessionId)
 
     const res = await request(app)

--- a/backend/test/routeGateAudit.test.js
+++ b/backend/test/routeGateAudit.test.js
@@ -23,7 +23,11 @@ const routesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '../sr
 const PUBLIC_SURFACE = {
   "analytics.js": [
     "POST /events",
-    "POST /referrals"
+    "POST /referrals",
+    // Touchpoint beacon (ads-centralisation §4.3): public browser beacon,
+    // own rate bucket, Joi-validated, flag-gated skip, session-id only —
+    // never authorization material.
+    "POST /touch"
   ],
   "auth.js": [
     "GET /google/config",

--- a/backend/test/touchpoints.test.js
+++ b/backend/test/touchpoints.test.js
@@ -1,0 +1,257 @@
+/**
+ * DB-backed coverage for the touchpoint arc (ads-centralisation §4.8):
+ * the /touch beacon (flag gate, dual-source sid validation, adoption +
+ * rolling 90d cookie, server-stamped occurredAt, referrer-origin stripping,
+ * bogus-campaign tolerance), the per-sid locked cap under concurrency, the
+ * erased-session sweep upsert/consumption (shared-session guard, bounded,
+ * window-dropped), retention purging, and the §4.5 binding (every submit
+ * binds a session; the explicit-campaign guard drops qr/attribution but
+ * KEEPS the session).
+ */
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
+import { sequelize, Touchpoint, ErasedSessionSweep, Prospect } from '../src/models/index.js';
+import { recordTouch, consumeErasedSessionSweeps, purgeOldTouchpoints } from '../src/services/touchpointService.js';
+import { makeProspectService } from '../src/services/prospectService.js';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+const ORIGIN = 'http://localhost:5173';
+const sidOf = (n) => n.toString(16).padStart(32, '0');
+
+let app;
+let admin;
+let campaign;
+
+beforeAll(async () => {
+  app = await getApp();
+  ({ user: admin } = await createTestUser({ role: 'admin' }));
+  campaign = await createTestCampaign(admin.id);
+});
+
+afterAll(async () => {
+  await closeDb();
+});
+
+afterEach(() => {
+  delete process.env.TOUCHPOINTS_ENABLED;
+  delete process.env.TOUCHPOINTS_MAX_PER_SESSION_DAY;
+  delete process.env.TOUCHPOINT_RETENTION_DAYS;
+  jest.restoreAllMocks();
+});
+
+const touchOn = () => { process.env.TOUCHPOINTS_ENABLED = 'true'; };
+
+const postTouch = (body = {}, set = {}) => {
+  let req = request(app).post('/api/analytics/touch').set('Origin', ORIGIN);
+  for (const [k, v] of Object.entries(set)) req = req.set(k, v);
+  return req.send({ surface: 'browse', ...body });
+};
+
+describe('POST /api/analytics/touch', () => {
+  it('skips (200) with the flag off — no row, no cookie', async () => {
+    const res = await postTouch({}, { 'X-Session-Id': sidOf(0xa1) });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, skipped: true });
+    expect(res.headers['set-cookie']).toBeUndefined();
+    expect(await Touchpoint.count({ where: { sessionId: sidOf(0xa1) } })).toBe(0);
+  });
+
+  it('adopts a valid header sid: records the row and sets the 90d httpOnly cookie', async () => {
+    touchOn();
+    const sid = sidOf(0xa2);
+    const res = await postTouch(
+      {
+        path: '/explore?utm_source=fb',
+        referrer: 'https://www.facebook.com/some/long/path?with=query',
+        utm_source: 'fb',
+        fbclid: 'click-123',
+      },
+      { 'X-Session-Id': sid }
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    const cookie = (res.headers['set-cookie'] || []).find((c) => c.startsWith('sid='));
+    expect(cookie).toContain(`sid=${sid}`);
+    expect(cookie).toContain('Max-Age=7776000'); // 90 days
+    expect(cookie).toContain('HttpOnly');
+    const row = await Touchpoint.findOne({ where: { sessionId: sid }, raw: true });
+    expect(row.surface).toBe('browse');
+    expect(row.landingPath).toBe('/explore?utm_source=fb');
+    // Full referrer in, ORIGIN only stored.
+    expect(row.referrerOrigin).toBe('https://www.facebook.com');
+    expect(row.utmSource).toBe('fb');
+    expect(row.fbclid).toBe('click-123');
+    // occurredAt is the SERVER clock (client timestamps are unrepresentable —
+    // stripUnknown drops any body time field before the controller sees it).
+    expect(Math.abs(Date.now() - new Date(row.occurredAt).getTime())).toBeLessThan(10_000);
+  });
+
+  it('validated cookie WINS over a different header sid, and the cookie re-issues (rolling)', async () => {
+    touchOn();
+    const cookieSid = sidOf(0xa3);
+    const headerSid = sidOf(0xa4);
+    const res = await postTouch({}, { Cookie: `sid=${cookieSid}`, 'X-Session-Id': headerSid });
+    expect(res.status).toBe(200);
+    const cookie = (res.headers['set-cookie'] || []).find((c) => c.startsWith('sid='));
+    expect(cookie).toContain(`sid=${cookieSid}`);
+    expect(await Touchpoint.count({ where: { sessionId: cookieSid } })).toBe(1);
+    expect(await Touchpoint.count({ where: { sessionId: headerSid } })).toBe(0);
+  });
+
+  it('ignores INVALID sids from both sources (skip, never 400) and falls back cookie→header', async () => {
+    touchOn();
+    const bad = await postTouch({}, { Cookie: 'sid=not-a-sid', 'X-Session-Id': 'ALSO-BAD' });
+    expect(bad.status).toBe(200);
+    expect(bad.body.skipped).toBe('no_session');
+
+    const headerSid = sidOf(0xa5);
+    const mixed = await postTouch({}, { Cookie: 'sid=not-a-sid', 'X-Session-Id': headerSid });
+    expect(mixed.status).toBe(200);
+    expect(await Touchpoint.count({ where: { sessionId: headerSid } })).toBe(1);
+  });
+
+  it('nulls a well-formed but NONEXISTENT campaignId instead of failing the insert', async () => {
+    touchOn();
+    const sid = sidOf(0xa6);
+    const res = await postTouch(
+      { surface: 'leadcapture', campaignId: '00000000-0000-4000-8000-00000000dead' },
+      { 'X-Session-Id': sid }
+    );
+    expect(res.status).toBe(200);
+    const row = await Touchpoint.findOne({ where: { sessionId: sid }, raw: true });
+    expect(row.campaignId).toBeNull();
+
+    const real = await postTouch({ surface: 'offer', campaignId: campaign.id }, { 'X-Session-Id': sid });
+    expect(real.status).toBe(200);
+    const rows = await Touchpoint.findAll({ where: { sessionId: sid }, raw: true });
+    expect(rows.find((r) => r.surface === 'offer').campaignId).toBe(campaign.id);
+  });
+
+  it('rejects an unknown surface (Joi enum) — the one hard 400', async () => {
+    touchOn();
+    const res = await postTouch({ surface: 'admin' }, { 'X-Session-Id': sidOf(0xa7) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('the per-sid locked cap (§4.3)', () => {
+  it('holds the 24h cap exactly under concurrency', async () => {
+    process.env.TOUCHPOINTS_MAX_PER_SESSION_DAY = '5';
+    const sid = sidOf(0xb1);
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => recordTouch({ sid, surface: 'browse', landingPath: '/x' }))
+    );
+    expect(results.filter((r) => r.recorded)).toHaveLength(5);
+    expect(results.filter((r) => r.skipped === 'capped')).toHaveLength(7);
+    expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(5);
+  });
+});
+
+describe('erased-session sweeps (§4.6)', () => {
+  it('deletes only in-window rows for swept sids, honours the shared-session guard, and drops rows past the window', async () => {
+    const sweptSid = sidOf(0xc1);
+    const sharedSid = sidOf(0xc2);
+    // Swept sid: one row inside the window, one stamped after sweepUntil.
+    await recordTouch({ sid: sweptSid, surface: 'browse', landingPath: '/in-window' });
+    await ErasedSessionSweep.create({ sessionId: sweptSid, sweepUntil: new Date(Date.now() + 3600_000) });
+    const late = await Touchpoint.create({
+      sessionId: sweptSid, occurredAt: new Date(Date.now() + 7200_000), surface: 'browse',
+    });
+    // Shared sid: a SURVIVING prospect still references it — never swept.
+    await createTestProspect(campaign.id, { leadSource: 'website', sessionId: sharedSid });
+    await recordTouch({ sid: sharedSid, surface: 'browse', landingPath: '/shared' });
+    await ErasedSessionSweep.create({ sessionId: sharedSid, sweepUntil: new Date(Date.now() + 3600_000) });
+
+    const pass1 = await consumeErasedSessionSweeps();
+    expect(pass1.deleted).toBeGreaterThanOrEqual(1);
+    expect(await Touchpoint.count({ where: { sessionId: sweptSid } })).toBe(1); // only the post-window row survives
+    expect((await Touchpoint.findOne({ where: { sessionId: sweptSid }, raw: true })).id).toBe(late.id);
+    expect(await Touchpoint.count({ where: { sessionId: sharedSid } })).toBe(1); // guard held
+    // Windows are still open ⇒ both sweep rows remain for the next pass.
+    expect(await ErasedSessionSweep.count({ where: { sessionId: [sweptSid, sharedSid] } })).toBe(2);
+
+    // Age the swept sid's window out ⇒ the next pass drops its row in-txn.
+    await sequelize.query(
+      `UPDATE erased_session_sweeps SET "sweepUntil" = now() - interval '1 minute' WHERE "sessionId" = :sid`,
+      { replacements: { sid: sweptSid } }
+    );
+    await consumeErasedSessionSweeps();
+    expect(await ErasedSessionSweep.count({ where: { sessionId: sweptSid } })).toBe(0);
+    expect(await ErasedSessionSweep.count({ where: { sessionId: sharedSid } })).toBe(1);
+  });
+});
+
+describe('retention purge (§4.6)', () => {
+  it('purges only rows past TOUCHPOINT_RETENTION_DAYS, in bounded batches', async () => {
+    const sid = sidOf(0xd1);
+    await recordTouch({ sid, surface: 'browse', landingPath: '/fresh' });
+    const old = await Touchpoint.create({
+      sessionId: sid, occurredAt: new Date(Date.now() - 200 * 24 * 3600_000), surface: 'browse',
+    });
+    const purged = await purgeOldTouchpoints();
+    expect(purged).toBeGreaterThanOrEqual(1);
+    expect(await Touchpoint.findByPk(old.id)).toBeNull();
+    expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(1);
+  });
+});
+
+describe('§4.5 binding — every web submit carries the session', () => {
+  function captureService(overrides = {}) {
+    return makeProspectService({
+      dispatchEvent: jest.fn(async () => {}),
+      canMarketTo: async () => false,
+      sendLeadEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendCompleteRegistrationEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendTikTokLeadEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      sendTikTokCompleteRegistrationEvent: jest.fn(async () => ({ sent: false, reason: 'guarded' })),
+      logger: silentLogger,
+    });
+  }
+  let seq = 0;
+  const body = (extra = {}) => ({
+    firstName: 'Touch', lastName: 'Bind',
+    phone: `+65${String(10000000 + Math.floor(Math.random() * 89999999))}`,
+    leadSource: 'website', campaignId: campaign.id, ...extra,
+  });
+
+  it('binds the header sid WITHOUT any attribution row (fastest-submit case) — and a /touch with the same header converges', async () => {
+    touchOn();
+    const sid = sidOf(0xe1 + (seq += 1));
+    await postTouch({}, { 'X-Session-Id': sid });
+    const svc = captureService();
+    const { prospect } = await svc.createProspect(body(), null, { headers: { 'x-session-id': sid } });
+    const fresh = await Prospect.findByPk(prospect.id, { raw: true });
+    expect(fresh.sessionId).toBe(sid);
+    expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(1); // same key joins them
+  });
+
+  it('ignores an INVALID raw header sid (validation is the §4.2 contract)', async () => {
+    const svc = captureService();
+    const { prospect } = await svc.createProspect(body(), null, { headers: { 'x-session-id': 'garbage' } });
+    const fresh = await Prospect.findByPk(prospect.id, { raw: true });
+    expect(fresh.sessionId).toBeNull();
+  });
+
+  it('the explicit-campaign guard drops a foreign QR + attribution but KEEPS the sessionId', async () => {
+    const { user: owner } = await createTestUser({ role: 'admin' });
+    const otherCampaign = await createTestCampaign(owner.id);
+    const { QrTag } = await import('../src/models/index.js');
+    const foreignQr = await QrTag.create({
+      name: `guard-split-${Date.now()}`, slug: `guard-split-${Date.now()}`,
+      campaignId: otherCampaign.id, type: 'campaign', destinationUrl: 'https://redeem.sg/x',
+    });
+    const sid = sidOf(0xf1);
+    const svc = captureService();
+    const { prospect } = await svc.createProspect(
+      body({ qrTagId: foreignQr.id }), // explicit campaign ≠ the QR's campaign
+      null,
+      { headers: { 'x-session-id': sid } }
+    );
+    const fresh = await Prospect.findByPk(prospect.id, { raw: true });
+    expect(fresh.sessionId).toBe(sid); // kept — browsing identity, not a routing input
+    expect(fresh.qrTagId).toBeNull(); // dropped — could skew routing
+    expect(fresh.attributionId).toBeNull();
+    expect(fresh.campaignId).toBe(campaign.id);
+  });
+});

--- a/backend/test/touchpoints.test.js
+++ b/backend/test/touchpoints.test.js
@@ -12,7 +12,8 @@ import { jest } from '@jest/globals';
 import request from 'supertest';
 import { getApp, closeDb, createTestUser, createTestCampaign, createTestProspect } from './helpers.js';
 import { sequelize, Touchpoint, ErasedSessionSweep, Prospect } from '../src/models/index.js';
-import { recordTouch, consumeErasedSessionSweeps, purgeOldTouchpoints } from '../src/services/touchpointService.js';
+import { recordTouch, consumeErasedSessionSweeps, purgeOldTouchpoints, upsertErasedSessionSweepsTx } from '../src/services/touchpointService.js';
+import { advisoryXactLock } from '../src/utils/advisoryLock.js';
 import { makeProspectService } from '../src/services/prospectService.js';
 
 const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
@@ -136,6 +137,24 @@ describe('POST /api/analytics/touch', () => {
 });
 
 describe('the per-sid locked cap (§4.3)', () => {
+  it('a beacon insert WAITS for a held per-sid lock (stamp-vs-sweep serialization)', async () => {
+    const sid = sidOf(0xb0);
+    let resolvedWhileHeld = false;
+    let touchPromise;
+    await sequelize.transaction(async (t) => {
+      await advisoryXactLock(t, `tp:${sid}`);
+      touchPromise = recordTouch({ sid, surface: 'browse', landingPath: '/blocked' }).then((r) => {
+        resolvedWhileHeld = true;
+        return r;
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      expect(resolvedWhileHeld).toBe(false); // serialized behind our lock
+    });
+    const result = await touchPromise; // lock released at commit ⇒ proceeds
+    expect(result.recorded).toBe(true);
+    expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(1);
+  });
+
   it('holds the 24h cap exactly under concurrency', async () => {
     process.env.TOUCHPOINTS_MAX_PER_SESSION_DAY = '5';
     const sid = sidOf(0xb1);
@@ -149,6 +168,27 @@ describe('the per-sid locked cap (§4.3)', () => {
 });
 
 describe('erased-session sweeps (§4.6)', () => {
+  it('the upsert EXTENDS an open window on repeat erasure and never shrinks one (GREATEST)', async () => {
+    const sid = sidOf(0xc0);
+    await sequelize.transaction(async (t) => upsertErasedSessionSweepsTx(t, [sid]));
+    // Shrink the row by hand, re-upsert ⇒ back out to ~now+24h.
+    await sequelize.query(
+      `UPDATE erased_session_sweeps SET "sweepUntil" = now() + interval '1 hour' WHERE "sessionId" = :sid`,
+      { replacements: { sid } }
+    );
+    await sequelize.transaction(async (t) => upsertErasedSessionSweepsTx(t, [sid]));
+    let row = await ErasedSessionSweep.findByPk(sid);
+    expect(new Date(row.sweepUntil).getTime()).toBeGreaterThan(Date.now() + 23 * 3600_000);
+    // Widen it beyond 24h, re-upsert ⇒ GREATEST keeps the wider window.
+    await sequelize.query(
+      `UPDATE erased_session_sweeps SET "sweepUntil" = now() + interval '48 hours' WHERE "sessionId" = :sid`,
+      { replacements: { sid } }
+    );
+    await sequelize.transaction(async (t) => upsertErasedSessionSweepsTx(t, [sid]));
+    row = await ErasedSessionSweep.findByPk(sid);
+    expect(new Date(row.sweepUntil).getTime()).toBeGreaterThan(Date.now() + 47 * 3600_000);
+  });
+
   it('deletes only in-window rows for swept sids, honours the shared-session guard, and drops rows past the window', async () => {
     const sweptSid = sidOf(0xc1);
     const sharedSid = sidOf(0xc2);
@@ -194,6 +234,20 @@ describe('retention purge (§4.6)', () => {
     expect(await Touchpoint.findByPk(old.id)).toBeNull();
     expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(1);
   });
+
+  it('drains MORE than one 1000-row batch in a single pass', async () => {
+    const sid = sidOf(0xd2);
+    // 1500 past-retention rows in one INSERT — two purge batches.
+    await sequelize.query(
+      `INSERT INTO touchpoints (id, "sessionId", "occurredAt", surface, "createdAt", "updatedAt")
+       SELECT gen_random_uuid(), :sid, now() - interval '200 days', 'browse', now(), now()
+         FROM generate_series(1, 1500)`,
+      { replacements: { sid } }
+    );
+    const purged = await purgeOldTouchpoints();
+    expect(purged).toBeGreaterThanOrEqual(1500);
+    expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(0);
+  });
 });
 
 describe('§4.5 binding — every web submit carries the session', () => {
@@ -224,6 +278,29 @@ describe('§4.5 binding — every web submit carries the session', () => {
     const fresh = await Prospect.findByPk(prospect.id, { raw: true });
     expect(fresh.sessionId).toBe(sid);
     expect(await Touchpoint.count({ where: { sessionId: sid } })).toBe(1); // same key joins them
+  });
+
+  it('CONCURRENT touch + submit on the same boot header converge on one sid (§4.8)', async () => {
+    touchOn();
+    const sid = sidOf(0xe8);
+    const svc = captureService();
+    const [touchRes, submitRes] = await Promise.all([
+      postTouch({ path: '/leadcapture' }, { 'X-Session-Id': sid }),
+      svc.createProspect(body(), null, { headers: { 'x-session-id': sid } }),
+    ]);
+    expect(touchRes.status).toBe(200);
+    const fresh = await Prospect.findByPk(submitRes.prospect.id, { raw: true });
+    expect(fresh.sessionId).toBe(sid);
+    const tps = await Touchpoint.findAll({ where: { sessionId: sid }, raw: true });
+    expect(tps).toHaveLength(1);
+    // §4.7 works by construction: the prospect and the touch share one key.
+    const [joined] = await sequelize.query(
+      `SELECT count(*)::int AS n FROM prospects p
+         JOIN touchpoints t ON t."sessionId" = p."sessionId"
+        WHERE p.id = :pid`,
+      { replacements: { pid: submitRes.prospect.id } }
+    );
+    expect(joined[0].n).toBe(1);
   });
 
   it('ignores an INVALID raw header sid (validation is the §4.2 contract)', async () => {

--- a/backend/test/unit/prospectService.test.js
+++ b/backend/test/unit/prospectService.test.js
@@ -265,40 +265,43 @@ describe('prospectService (unit)', () => {
       }
     });
 
+    // Fixture sids are 32-hex — the shape every real mint site has always
+    // produced, and since ads-centralisation §4.2 the shape both sid sources
+    // are VALIDATED against (invalid values are ignored, not bound).
     it('resolves attribution from session ID (cookie sid)', async () => {
       const mockAttribution = {
         id: 'attr-1',
-        sessionId: 'sess-abc',
+        sessionId: 'abababababababababababababababab',
         qrTagId: 'qr-attr',
       };
       mocks.models.Attribution.findOne.mockResolvedValue(mockAttribution);
 
       const body = { firstName: 'Test', campaignId: 'camp-1' };
-      const cookies = { sid: 'sess-abc' };
+      const cookies = { sid: 'abababababababababababababababab' };
 
       await service.createProspect(body, user, { cookies });
 
       expect(mocks.models.Attribution.findOne).toHaveBeenCalledWith({
-        where: { sessionId: 'sess-abc' },
+        where: { sessionId: 'abababababababababababababababab' },
         order: [['lastTouchAt', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
       });
 
       const createArg = mocks.models.Prospect.create.mock.calls[0][0];
       expect(createArg.attributionId).toBe('attr-1');
-      expect(createArg.sessionId).toBe('sess-abc');
+      expect(createArg.sessionId).toBe('abababababababababababababababab');
     });
 
     it('resolves attribution from x-session-id header when no cookie', async () => {
-      const mockAttribution = { id: 'attr-2', sessionId: 'sess-xyz', qrTagId: null };
+      const mockAttribution = { id: 'attr-2', sessionId: 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd', qrTagId: null };
       mocks.models.Attribution.findOne.mockResolvedValue(mockAttribution);
 
       const body = { firstName: 'Test', campaignId: 'camp-1' };
-      const headers = { 'x-session-id': 'sess-xyz' };
+      const headers = { 'x-session-id': 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' };
 
       await service.createProspect(body, user, { headers });
 
       expect(mocks.models.Attribution.findOne).toHaveBeenCalledWith({
-        where: { sessionId: 'sess-xyz' },
+        where: { sessionId: 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd' },
         order: [['lastTouchAt', 'DESC'], ['createdAt', 'DESC'], ['id', 'DESC']],
       });
     });
@@ -348,13 +351,13 @@ describe('prospectService (unit)', () => {
       it('binds a signup to the most recently scanned campaign (A then B -> B)', async () => {
         wireTwoCampaignQrTags();
         // A scanned first (older lastTouchAt), B scanned second (newer).
-        const attrA = { id: 'attr-A', sessionId: 'sess-1', qrTagId: 'qr-A', lastTouchAt: new Date('2026-05-29T10:00:00Z') };
-        const attrB = { id: 'attr-B', sessionId: 'sess-1', qrTagId: 'qr-B', lastTouchAt: new Date('2026-05-29T10:05:00Z') };
+        const attrA = { id: 'attr-A', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-A', lastTouchAt: new Date('2026-05-29T10:00:00Z') };
+        const attrB = { id: 'attr-B', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-B', lastTouchAt: new Date('2026-05-29T10:05:00Z') };
         mocks.models.Attribution.findOne = orderedFindOne([attrA, attrB]);
 
         // No campaignId in body — it must be derived from the bound attribution's QR tag.
         const body = { firstName: 'Test', phone: '91234567' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.attributionId).toBe('attr-B');
@@ -368,12 +371,12 @@ describe('prospectService (unit)', () => {
         wireTwoCampaignQrTags();
         // Equal lastTouchAt; the more recently created attribution must win.
         const sameTs = new Date('2026-05-29T10:00:00Z');
-        const attrOld = { id: 'attr-A', sessionId: 'sess-1', qrTagId: 'qr-A', lastTouchAt: sameTs, createdAt: new Date('2026-05-29T09:00:00Z') };
-        const attrNew = { id: 'attr-B', sessionId: 'sess-1', qrTagId: 'qr-B', lastTouchAt: sameTs, createdAt: new Date('2026-05-29T09:30:00Z') };
+        const attrOld = { id: 'attr-A', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-A', lastTouchAt: sameTs, createdAt: new Date('2026-05-29T09:00:00Z') };
+        const attrNew = { id: 'attr-B', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-B', lastTouchAt: sameTs, createdAt: new Date('2026-05-29T09:30:00Z') };
         mocks.models.Attribution.findOne = orderedFindOne([attrOld, attrNew]);
 
         const body = { firstName: 'Test', phone: '91234569' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.attributionId).toBe('attr-B');
@@ -385,13 +388,13 @@ describe('prospectService (unit)', () => {
         // Identical lastTouchAt AND createdAt; the id DESC final key must decide.
         const sameTs = new Date('2026-05-29T10:00:00Z');
         const sameCreated = new Date('2026-05-29T09:00:00Z');
-        const attrLow = { id: 'attr-aaa', sessionId: 'sess-1', qrTagId: 'qr-A', lastTouchAt: sameTs, createdAt: sameCreated };
-        const attrHigh = { id: 'attr-bbb', sessionId: 'sess-1', qrTagId: 'qr-B', lastTouchAt: sameTs, createdAt: sameCreated };
+        const attrLow = { id: 'attr-aaa', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-A', lastTouchAt: sameTs, createdAt: sameCreated };
+        const attrHigh = { id: 'attr-bbb', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-B', lastTouchAt: sameTs, createdAt: sameCreated };
         // Low id inserted first: without the id tiebreaker a stable sort would pick A.
         mocks.models.Attribution.findOne = orderedFindOne([attrLow, attrHigh]);
 
         const body = { firstName: 'Test', phone: '91234568' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.attributionId).toBe('attr-bbb');
@@ -411,27 +414,29 @@ describe('prospectService (unit)', () => {
 
       it('ignores a stale session attribution when body campaignId names a different campaign', async () => {
         // Session bound to campaign Y's QR; submit explicitly targets campaign X.
-        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-Y', sessionId: 'sess-1', qrTagId: 'qr-Y' });
+        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-Y', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-Y' });
         mocks.models.QrTag.findByPk.mockImplementation(async (id) =>
           id === 'qr-Y' ? wireQrTag('qr-Y', 'camp-Y') : wireQrTag(id, 'camp-X')
         );
 
         const body = { firstName: 'Test', phone: '91234500', campaignId: 'camp-X' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.campaignId).toBe('camp-X');      // explicit campaign stands
         expect(createArg.attributionId).toBeUndefined();  // stale attribution not bound
         expect(createArg.qrTagId).toBeUndefined();         // no stale QR -> campaign-level routing
-        expect(createArg.sessionId).toBeUndefined();
+        // sessionId SURVIVES the guard (ads-centralisation §4.5): the session
+        // is browsing identity for touchpoint joins, not a routing input.
+        expect(createArg.sessionId).toBe('e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1');
       });
 
       it('still binds the session attribution when its campaign matches the explicit body campaignId', async () => {
-        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-X', sessionId: 'sess-1', qrTagId: 'qr-X' });
+        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-X', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-X' });
         mocks.models.QrTag.findByPk.mockImplementation(async (id) => wireQrTag(id, 'camp-X'));
 
         const body = { firstName: 'Test', phone: '91234501', campaignId: 'camp-X' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.attributionId).toBe('attr-X');
@@ -442,19 +447,20 @@ describe('prospectService (unit)', () => {
       it('drops a stale body qrTagId (and session linkage) that names a different campaign', async () => {
         // Direct/partial payload: body explicitly targets camp-X but carries a
         // stale qrTagId for camp-Y, and the session is also bound to camp-Y.
-        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-Y', sessionId: 'sess-1', qrTagId: 'qr-Y' });
+        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-Y', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-Y' });
         mocks.models.QrTag.findByPk.mockImplementation(async (id) =>
           id === 'qr-Y' ? wireQrTag('qr-Y', 'camp-Y') : wireQrTag(id, 'camp-X')
         );
 
         const body = { firstName: 'Test', phone: '91234502', campaignId: 'camp-X', qrTagId: 'qr-Y' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.campaignId).toBe('camp-X');
         expect(createArg.qrTagId).toBeUndefined();
         expect(createArg.attributionId).toBeUndefined();
-        expect(createArg.sessionId).toBeUndefined();
+        // Kept since ads-centralisation §4.5 — session ≠ routing input.
+        expect(createArg.sessionId).toBe('e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1');
         // Agent routing must use campaign X, not Y's QR.
         expect(mocks.resolveLeadRouting).toHaveBeenCalledWith(
           expect.objectContaining({ campaignId: 'camp-X', qrTagId: undefined })
@@ -464,19 +470,20 @@ describe('prospectService (unit)', () => {
       it('drops a stale session QR whose campaignId is null when an explicit campaign is given', async () => {
         // Prior scan of a no-campaign QR; a bare submit explicitly targets camp-X.
         // A null-campaign QR does not belong to camp-X, so it must not skew routing.
-        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-null', sessionId: 'sess-1', qrTagId: 'qr-null' });
+        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-null', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-null' });
         mocks.models.QrTag.findByPk.mockImplementation(async (id) =>
           id === 'qr-null' ? wireQrTag('qr-null', null) : wireQrTag(id, 'camp-X')
         );
 
         const body = { firstName: 'Test', phone: '91234503', campaignId: 'camp-X' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.campaignId).toBe('camp-X');
         expect(createArg.qrTagId).toBeUndefined();
         expect(createArg.attributionId).toBeUndefined();
-        expect(createArg.sessionId).toBeUndefined();
+        // Kept since ads-centralisation §4.5 — session ≠ routing input.
+        expect(createArg.sessionId).toBe('e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1');
         expect(mocks.resolveLeadRouting).toHaveBeenCalledWith(
           expect.objectContaining({ campaignId: 'camp-X', qrTagId: undefined })
         );
@@ -501,11 +508,11 @@ describe('prospectService (unit)', () => {
       });
 
       it('keeps the QR and attribution (and routes by QR) when the bound QR campaign matches', async () => {
-        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-X', sessionId: 'sess-1', qrTagId: 'qr-X' });
+        mocks.models.Attribution.findOne.mockResolvedValue({ id: 'attr-X', sessionId: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1', qrTagId: 'qr-X' });
         mocks.models.QrTag.findByPk.mockImplementation(async (id) => wireQrTag(id, 'camp-X'));
 
         const body = { firstName: 'Test', phone: '91234505', campaignId: 'camp-X' };
-        await service.createProspect(body, user, { cookies: { sid: 'sess-1' } });
+        await service.createProspect(body, user, { cookies: { sid: 'e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1' } });
 
         const createArg = mocks.models.Prospect.create.mock.calls[0][0];
         expect(createArg.campaignId).toBe('camp-X');

--- a/src/api/__tests__/client.test.js
+++ b/src/api/__tests__/client.test.js
@@ -158,3 +158,36 @@ describe('APIClient 401 handling', () => {
  expect(localStorageMock.removeItem).toHaveBeenCalledWith('mktr_user');
  });
 });
+
+describe('APIClient custom headers EXTEND the defaults (ads-centralisation P3 review #1)', () => {
+ beforeEach(() => {
+ localStorageMock.clear();
+ vi.clearAllMocks();
+ });
+
+ it('keeps Content-Type when options.headers is passed (the X-Session-Id submit shape)', async () => {
+ fetchMock.mockResolvedValueOnce(fakeResponse({ success: true }));
+
+ await apiClient.post('/prospects', { firstName: 'A' }, {
+ skipAuth: true,
+ headers: { 'X-Session-Id': 'ab12ab12ab12ab12ab12ab12ab12ab12' },
+ });
+
+ const [, requestInit] = fetchMock.mock.calls[0];
+ // The old trailing `...options` spread REPLACED the whole headers object,
+ // dropping Content-Type and breaking body parsing for every such submit.
+ expect(requestInit.headers['Content-Type']).toBe('application/json');
+ expect(requestInit.headers['X-Session-Id']).toBe('ab12ab12ab12ab12ab12ab12ab12ab12');
+ expect(requestInit.method).toBe('POST');
+ });
+
+ it('an EMPTY headers object (touch flag off) leaves the defaults fully intact', async () => {
+ fetchMock.mockResolvedValueOnce(fakeResponse({ success: true }));
+
+ await apiClient.post('/prospects', { firstName: 'A' }, { skipAuth: true, headers: {} });
+
+ const [, requestInit] = fetchMock.mock.calls[0];
+ expect(requestInit.headers['Content-Type']).toBe('application/json');
+ expect(requestInit.headers['X-Session-Id']).toBeUndefined();
+ });
+});

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -68,15 +68,21 @@ class APIClient {
  const url = `${this.baseURL}${endpoint}`;
  const token = this.getToken();
 
+ // Caller-supplied headers EXTEND the defaults. The old shape spread
+ // `...options` AFTER the headers object, so an options.headers REPLACED the
+ // whole thing — silently dropping Content-Type (and Authorization) for any
+ // caller that passed one (ads-centralisation P3 review #1; the X-Session-Id
+ // submit header was the first such caller).
+ const { headers: optionHeaders, ...restOptions } = options;
  const config = {
  method: 'GET',
+ credentials: 'include',
+ ...restOptions,
  headers: {
  'Content-Type': 'application/json',
  ...(token && !options.skipAuth && { Authorization: `Bearer ${token}` }),
- ...options.headers,
+ ...optionHeaders,
  },
- credentials: 'include',
- ...options,
  };
 
  // Add body for POST/PUT/PATCH requests

--- a/src/components/TouchRouteTracker.jsx
+++ b/src/components/TouchRouteTracker.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { isAdRollCampaignSurface, isAdRollSurface } from '@/lib/adroll';
+import { beaconTouch } from '@/lib/touch';
+
+/**
+ * Fires a durable touchpoint beacon on the public browse surfaces as the SPA
+ * navigates (ads-centralisation §4.4). Renders nothing; mounts once beside
+ * AdRollRouteTracker (pages/index.jsx, never on the ops surface).
+ *
+ * The allow-list IS adroll.js's — campaign funnel ∪ public browse; everything
+ * else (admin, redeem-ops, auth, token-bearing reward/callback links) never
+ * beacons (change one list, check the other — the AdRoll header notes this
+ * cross-reference too). The campaign funnel pages are skipped HERE for the
+ * same reason AdRoll skips them: each fires its own beacon after its campaign
+ * loads, with the campaign id and the test-data suppression gate applied.
+ */
+export default function TouchRouteTracker() {
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    if (isAdRollCampaignSurface(pathname)) return;
+    if (!isAdRollSurface(pathname)) return;
+    beaconTouch({ surface: 'browse' });
+  }, [pathname, search]);
+
+  return null;
+}

--- a/src/lib/__tests__/touch.test.js
+++ b/src/lib/__tests__/touch.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getBootSessionId, touchGatesPass, beaconTouch, sessionSubmitHeaders } from '../touch.js';
+
+const BOOT_KEY = '_mktr_sid_boot';
+const SID_RE = /^[a-f0-9]{32}$/;
+
+function stubTouchOn() {
+  vi.stubEnv('VITE_TOUCH_ENABLED', 'true');
+  vi.stubEnv('MODE', 'production');
+  vi.stubEnv('PROD', true);
+  vi.stubEnv('DEV', false);
+}
+
+function setPath(pathname, search = '') {
+  window.history.replaceState({}, '', pathname + search);
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+  sessionStorage.clear();
+  setPath('/explore');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  delete navigator.locks;
+});
+
+describe('getBootSessionId — the §4.2 boot id', () => {
+  it('mints a 32-hex id with a 90d expiry and reuses it', async () => {
+    const first = await getBootSessionId();
+    expect(first).toMatch(SID_RE);
+    const stored = JSON.parse(localStorage.getItem(BOOT_KEY));
+    expect(stored.id).toBe(first);
+    expect(stored.expiresAt).toBeGreaterThan(Date.now() + 89 * 24 * 3600 * 1000);
+    expect(await getBootSessionId()).toBe(first);
+  });
+
+  it('regenerates past expiry and on a malformed record', async () => {
+    localStorage.setItem(BOOT_KEY, JSON.stringify({ id: 'a'.repeat(32), expiresAt: Date.now() - 1000 }));
+    const regen = await getBootSessionId();
+    expect(regen).toMatch(SID_RE);
+    expect(regen).not.toBe('a'.repeat(32));
+
+    localStorage.setItem(BOOT_KEY, JSON.stringify({ id: 'NOT-HEX', expiresAt: Date.now() + 1000000 }));
+    expect(await getBootSessionId()).toMatch(SID_RE);
+  });
+
+  it('serializes creation through the Web Lock and re-reads inside it (other tab wins)', async () => {
+    const winner = { id: 'b'.repeat(32), expiresAt: Date.now() + 1000000 };
+    const request = vi.fn(async (name, fn) => {
+      expect(name).toBe('mktr_sid_boot');
+      // Simulate the OTHER tab writing while we waited on the lock.
+      localStorage.setItem(BOOT_KEY, JSON.stringify(winner));
+      return fn();
+    });
+    navigator.locks = { request };
+    const id = await getBootSessionId();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(id).toBe(winner.id); // the in-lock re-read adopted the winner
+  });
+
+  it('falls back to last-writer-wins without Web Locks (documented best-effort)', async () => {
+    delete navigator.locks;
+    expect(await getBootSessionId()).toMatch(SID_RE);
+  });
+});
+
+describe('touchGatesPass — the §4.4 gates', () => {
+  it('requires the literal "true" flag', () => {
+    vi.stubEnv('VITE_TOUCH_ENABLED', '1');
+    vi.stubEnv('PROD', true);
+    expect(touchGatesPass({ pathname: '/explore', search: '' })).toBe(false);
+    stubTouchOn();
+    expect(touchGatesPass({ pathname: '/explore', search: '' })).toBe(true);
+  });
+
+  it('blocks dev builds without the dev opt-in', () => {
+    vi.stubEnv('VITE_TOUCH_ENABLED', 'true');
+    vi.stubEnv('PROD', false);
+    expect(touchGatesPass({ pathname: '/explore', search: '' })).toBe(false);
+    vi.stubEnv('VITE_TOUCH_DEV_MODE', '1');
+    expect(touchGatesPass({ pathname: '/explore', search: '' })).toBe(true);
+  });
+
+  it('suppresses preview surfaces and test-data campaigns via the shared pixelSuppression gate', () => {
+    stubTouchOn();
+    expect(touchGatesPass({ pathname: '/explore', search: '?preview=true' })).toBe(false);
+    expect(touchGatesPass({ pathname: '/preview/some-proto', search: '' })).toBe(false);
+    expect(touchGatesPass({ pathname: '/leadcapture', search: '', campaign: { is_test_data: true } })).toBe(false);
+  });
+});
+
+describe('beaconTouch — lossy, throttled, keepalive', () => {
+  it('POSTs with keepalive, credentials, the X-Session-Id boot header, and whitelisted params only', async () => {
+    stubTouchOn();
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    setPath('/explore', '?utm_source=fb&fbclid=abc123&token=SECRET&junk=1');
+
+    await beaconTouch({ surface: 'browse' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toMatch(/\/analytics\/touch$/);
+    expect(opts.keepalive).toBe(true);
+    expect(opts.credentials).toBe('include');
+    expect(opts.headers['X-Session-Id']).toMatch(SID_RE);
+    const body = JSON.parse(opts.body);
+    expect(body.surface).toBe('browse');
+    expect(body.path).toBe('/explore?utm_source=fb&fbclid=abc123'); // token/junk stripped
+    expect(body.utm_source).toBe('fb');
+    expect(body.fbclid).toBe('abc123');
+    expect(body.token).toBeUndefined();
+  });
+
+  it('throttles repeat beacons for the same URL within 30 minutes', async () => {
+    stubTouchOn();
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    await beaconTouch({ surface: 'browse' });
+    await beaconTouch({ surface: 'browse' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    setPath('/winners');
+    await beaconTouch({ surface: 'browse' });
+    expect(fetchMock).toHaveBeenCalledTimes(2); // a different URL is a different touch
+  });
+
+  it('is silent when the gates fail and swallows network errors', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    await beaconTouch({ surface: 'browse' }); // flag off
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    stubTouchOn();
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('offline'); }));
+    await expect(beaconTouch({ surface: 'browse' })).resolves.toBeUndefined();
+  });
+});
+
+describe('sessionSubmitHeaders — the submit-side boot header (§4.2)', () => {
+  it('is EMPTY until the touch flag flips (backend CORS must accept the header first)', async () => {
+    expect(await sessionSubmitHeaders()).toEqual({});
+    stubTouchOn();
+    const headers = await sessionSubmitHeaders();
+    expect(headers['X-Session-Id']).toMatch(SID_RE);
+  });
+});

--- a/src/lib/adroll.js
+++ b/src/lib/adroll.js
@@ -83,7 +83,12 @@ const BROWSE_PATTERNS = [
   /^\/legal\/[^/]+$/, // marketplace legal docs
 ];
 
-/** Every route AdRoll is allowed on: campaign funnel ∪ public browse. */
+/**
+ * Every route AdRoll is allowed on: campaign funnel ∪ public browse.
+ * ALSO the touchpoint-beacon allow-list (TouchRouteTracker + lib/touch,
+ * ads-centralisation §4.4) — the two features deliberately share ONE surface
+ * definition, so a route added or removed here changes both.
+ */
 export function isAdRollSurface(pathname) {
   const path = (pathname || '').toLowerCase();
   if (isAdRollCampaignSurface(path)) return true;

--- a/src/lib/touch.js
+++ b/src/lib/touch.js
@@ -1,0 +1,173 @@
+import { isSuppressedSurface } from './pixelSuppression';
+
+/**
+ * Touchpoint beacons (ads-centralisation §4.2/§4.4) — the client half of the
+ * durable cross-channel visit history.
+ *
+ * ONE boot session id: `_mktr_sid_boot` in localStorage as
+ * `{ id: <32-hex>, expiresAt: now+90d }`, regenerated past expiry. Creation is
+ * serialized across tabs with the Web Locks API where available (re-read
+ * inside the lock — the other tab may have won); without Web Locks,
+ * last-writer-wins is accepted and the cross-tab guarantee is explicitly
+ * best-effort — the server's httpOnly cookie converges every tab after the
+ * first response, so a brief two-sid split can lose at most the first seconds
+ * of one tab's touches. The header `X-Session-Id: <boot id>` rides every
+ * touch beacon and the prospect submit because the client cannot read the
+ * httpOnly cookie; the server prefers its validated cookie when both exist.
+ *
+ * Beacons are INTENTIONALLY LOSSY: keepalive fetch, every failure swallowed,
+ * a 30-minute per-URL sessionStorage throttle, and the server enforces its
+ * own per-session cap. The sid is never authorization material.
+ */
+
+const BOOT_KEY = '_mktr_sid_boot';
+const BOOT_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+const THROTTLE_PREFIX = '_mktr_touch:';
+const THROTTLE_TTL_MS = 30 * 60 * 1000;
+const SID_RE = /^[a-f0-9]{32}$/;
+
+// Query params that may ride into landingPath / the beacon body — attribution
+// material only, never tokens (the token routes are outside the allow-list
+// anyway, but the whitelist keeps a pasted URL's junk out of the row too).
+const WHITELISTED_PARAMS = [
+  'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content',
+  'fbclid', 'ttclid', 'gclid', 'gbraid', 'wbraid', 'campaign_id', 'ref',
+];
+
+function randomSid() {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function readBoot() {
+  try {
+    const raw = localStorage.getItem(BOOT_KEY);
+    if (!raw) return null;
+    const rec = JSON.parse(raw);
+    if (!rec || typeof rec.id !== 'string' || !SID_RE.test(rec.id)) return null;
+    if (typeof rec.expiresAt !== 'number' || rec.expiresAt <= Date.now()) return null;
+    return rec;
+  } catch {
+    return null;
+  }
+}
+
+function mintBoot() {
+  const rec = { id: randomSid(), expiresAt: Date.now() + BOOT_TTL_MS };
+  try {
+    localStorage.setItem(BOOT_KEY, JSON.stringify(rec));
+  } catch {
+    /* storage unavailable (private mode) — the id still serves this page */
+  }
+  return rec.id;
+}
+
+/** The boot session id — minted once, 90-day expiry, cross-tab-serialized where possible. */
+export async function getBootSessionId() {
+  if (typeof window === 'undefined') return null;
+  const existing = readBoot();
+  if (existing) return existing.id;
+  if (navigator.locks?.request) {
+    try {
+      return await navigator.locks.request('mktr_sid_boot', async () => readBoot()?.id || mintBoot());
+    } catch {
+      return readBoot()?.id || mintBoot();
+    }
+  }
+  return mintBoot();
+}
+
+/** The §4.4 gates: env flag ∧ not a suppressed surface ∧ (prod || dev opt-in). */
+export function touchGatesPass({ campaign, pathname, search } = {}) {
+  if (import.meta.env.VITE_TOUCH_ENABLED !== 'true') return false;
+  if (!import.meta.env.PROD && !import.meta.env.VITE_TOUCH_DEV_MODE) return false;
+  if (isSuppressedSurface({ campaign, pathname, search })) return false;
+  return true;
+}
+
+function throttled(key) {
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (raw) {
+      const at = Number(raw);
+      if (Number.isFinite(at) && Date.now() - at < THROTTLE_TTL_MS) return true;
+    }
+    sessionStorage.setItem(key, String(Date.now()));
+  } catch {
+    /* storage unavailable — fall through unthrottled, the server caps */
+  }
+  return false;
+}
+
+function apiBase() {
+  return import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+}
+
+/**
+ * Fire one touch beacon for the current URL. Fire-and-forget; every failure
+ * is swallowed. `campaign` (when the surface has one loaded) feeds the
+ * test-data suppression gate; `campaignId` rides to the server.
+ */
+export async function beaconTouch({ campaign, campaignId, surface } = {}) {
+  try {
+    if (typeof window === 'undefined' || !surface) return;
+    const pathname = window.location.pathname;
+    const search = window.location.search;
+    if (!touchGatesPass({ campaign, pathname, search })) return;
+    if (throttled(THROTTLE_PREFIX + pathname + search)) return;
+
+    const params = new URLSearchParams(search);
+    const kept = new URLSearchParams();
+    for (const name of WHITELISTED_PARAMS) {
+      const value = params.get(name);
+      if (value) kept.set(name, value);
+    }
+    const qs = kept.toString();
+    const bootId = await getBootSessionId();
+    if (!bootId) return;
+
+    const body = {
+      surface,
+      path: (pathname + (qs ? `?${qs}` : '')).slice(0, 512),
+      ...(document.referrer ? { referrer: document.referrer.slice(0, 2048) } : {}),
+      ...(campaignId ? { campaignId } : {}),
+      ...(params.get('utm_source') ? { utm_source: params.get('utm_source').slice(0, 128) } : {}),
+      ...(params.get('utm_medium') ? { utm_medium: params.get('utm_medium').slice(0, 128) } : {}),
+      ...(params.get('utm_campaign') ? { utm_campaign: params.get('utm_campaign').slice(0, 190) } : {}),
+      ...(params.get('utm_term') ? { utm_term: params.get('utm_term').slice(0, 190) } : {}),
+      ...(params.get('utm_content') ? { utm_content: params.get('utm_content').slice(0, 190) } : {}),
+      ...(params.get('fbclid') ? { fbclid: params.get('fbclid').slice(0, 512) } : {}),
+      ...(params.get('ttclid') ? { ttclid: params.get('ttclid').slice(0, 512) } : {}),
+      ...(params.get('gclid') ? { gclid: params.get('gclid').slice(0, 512) } : {}),
+      ...(params.get('gbraid') ? { gbraid: params.get('gbraid').slice(0, 512) } : {}),
+      ...(params.get('wbraid') ? { wbraid: params.get('wbraid').slice(0, 512) } : {}),
+    };
+
+    await fetch(`${apiBase()}/analytics/touch`, {
+      method: 'POST',
+      keepalive: true,
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-Session-Id': bootId },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    /* intentionally lossy */
+  }
+}
+
+/**
+ * Headers for the prospect submit (§4.2): the boot id rides X-Session-Id so
+ * the fastest submit still binds a session. Gated on VITE_TOUCH_ENABLED —
+ * flipped together with the backend, whose CORS allow-list must already
+ * accept the header (a lone frontend flip would fail every submit preflight).
+ */
+export async function sessionSubmitHeaders() {
+  try {
+    if (import.meta.env.VITE_TOUCH_ENABLED !== 'true') return {};
+    const bootId = await getBootSessionId();
+    return bootId ? { 'X-Session-Id': bootId } : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/pages/LeadCapture.jsx
+++ b/src/pages/LeadCapture.jsx
@@ -51,6 +51,7 @@ import {
   captureGclFromUrl, readGcl,
 } from '../lib/googleAds';
 import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '../lib/adroll';
+import { beaconTouch, sessionSubmitHeaders } from '../lib/touch';
 import { trackFunnelEvent } from '../lib/pixelCustom';
 
 export default function LeadCapture() {
@@ -181,6 +182,13 @@ export default function LeadCapture() {
       initAdRoll();
       trackAdRollPageView();
     }
+
+    // Durable touchpoint (ads-centralisation §4.4): fires here (not in
+    // TouchRouteTracker) for the same reason AdRoll does — the loaded
+    // campaign feeds the test-data suppression gate and rides as campaignId.
+    // Own 30-min URL throttle; intentionally lossy; dark unless
+    // VITE_TOUCH_ENABLED.
+    beaconTouch({ campaign, campaignId: campaign.id, surface: 'leadcapture' });
   }, [campaign, location.pathname, location.search]);
 
   // Quiz result reveal → fire CompleteRegistration on both platforms (strongest
@@ -411,7 +419,9 @@ export default function LeadCapture() {
         })
       );
 
-      const result = await apiClient.post('/prospects', payload, { skipAuth: true });
+      // X-Session-Id (ads-centralisation §4.2): the boot id rides the submit so
+      // even the fastest capture binds a session — empty until the touch flags flip.
+      const result = await apiClient.post('/prospects', payload, { skipAuth: true, headers: await sessionSubmitHeaders() });
       if (result?.success) {
         // Keep the new prospect's id so this submitter's share links carry
         // their identity (?ref={id}) instead of the anonymous ref=1.

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,6 +5,7 @@ import DashboardLayout from '@/components/layout/DashboardLayout';
 import RedeemOpsLayout from '@/components/redeemops/RedeemOpsLayout';
 import RouteErrorBoundary from '@/components/RouteErrorBoundary';
 import AdRollRouteTracker from '@/components/AdRollRouteTracker';
+import TouchRouteTracker from '@/components/TouchRouteTracker';
 import { BrowserRouter as Router, Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import ErrorBoundary from './ErrorBoundary';
 import { brand } from '@/lib/brand';
@@ -220,6 +221,9 @@ function PagesContent() {
  {/* AdRoll retargeting pageViews on the public browse surfaces. No-op unless
      the build carries the AdRoll ids; never mounted on the ops surface. */}
  {!IS_OPS_SURFACE && <AdRollRouteTracker />}
+ {/* Durable touchpoint beacons on the same browse allow-list (ads-centralisation §4.4).
+     Dark unless VITE_TOUCH_ENABLED; never mounted on the ops surface. */}
+ {!IS_OPS_SURFACE && <TouchRouteTracker />}
  <Suspense
  fallback={
  <div className="min-h-screen flex items-center justify-center">

--- a/src/pages/marketplace/MarketplaceFlow.jsx
+++ b/src/pages/marketplace/MarketplaceFlow.jsx
@@ -26,6 +26,7 @@ import {
   captureGclFromUrl, readGcl,
 } from '@/lib/googleAds';
 import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '@/lib/adroll';
+import { beaconTouch, sessionSubmitHeaders } from '@/lib/touch';
 import { trackFunnelEvent } from '@/lib/pixelCustom';
 import {
   shouldTrackTikTok, captureTtclidFromUrl, readTtclid, readTtp,
@@ -205,6 +206,10 @@ export default function MarketplaceFlow() {
       initAdRoll();
       trackAdRollPageView();
     }
+
+    // Durable touchpoint (ads-centralisation §4.4) — campaign-aware like the
+    // AdRoll fire above; own throttle; dark unless VITE_TOUCH_ENABLED.
+    beaconTouch({ campaign, campaignId: campaign.id, surface: 'flow' });
   }, [campaign]);
 
   // OTP resend cooldown tick
@@ -409,7 +414,9 @@ export default function MarketplaceFlow() {
         })
       );
 
-      const resp = await apiClient.post('/prospects', payload, { skipAuth: true });
+      // X-Session-Id (ads-centralisation §4.2): the boot id rides the submit so
+      // even the fastest capture binds a session — empty until the touch flags flip.
+      const resp = await apiClient.post('/prospects', payload, { skipAuth: true, headers: await sessionSubmitHeaders() });
       if (resp?.success) {
         const trackCtx = { campaign, pathname: window.location.pathname, search: window.location.search };
         if (shouldTrack({ ...trackCtx, pixelId: resolveMetaPixelId(campaign) })) {

--- a/src/pages/marketplace/MarketplaceOffer.jsx
+++ b/src/pages/marketplace/MarketplaceOffer.jsx
@@ -12,6 +12,7 @@ import { getOrCreateVcState, markVcFired } from '@/lib/pixelSession';
 import { resolveMetaPixelId, resolveTikTokPixelId, resolveGoogleAdsConversionId } from '@/lib/pixelIds';
 import { shouldTrackGoogle, initGoogleAds, captureGclFromUrl } from '@/lib/googleAds';
 import { shouldTrackAdRoll, initAdRoll, trackAdRollPageView } from '@/lib/adroll';
+import { beaconTouch } from '@/lib/touch';
 
 /**
  * Offer detail (/offers/:slug) — the FIRST public content surface for
@@ -100,6 +101,10 @@ export default function MarketplaceOffer() {
       initAdRoll();
       trackAdRollPageView();
     }
+
+    // Durable touchpoint (ads-centralisation §4.4) — campaign-aware like the
+    // AdRoll fire above; own throttle; dark unless VITE_TOUCH_ENABLED.
+    beaconTouch({ campaign, campaignId: campaign.id, surface: 'offer' });
   }, [campaign]);
 
   if (campaign === undefined) {


### PR DESCRIPTION
Implements **P3 of `docs/plans/ads-centralisation-levers.md` (FINAL v8)** — cross-channel touchpoint history (§4). **Ships dark**: `TOUCHPOINTS_ENABLED` / `VITE_TOUCH_ENABLED` unset ⇒ no rows, no beacons, no submit headers; existing behaviour is unchanged except the two deliberate §4 riders called out below.

> **Stacked on #471 (P2).** This branch builds on `feat/p2-platform-delivery-outbox` because P3 consumes P2's §7.6 advisory-lock helper. Merge #471 first; this PR then rebases clean onto main. Plan §0 allows P3 to overlap P2 in review.

## What this adds

- **Migration 127** — `touchpoints` (append-only, session-keyed, §4.1 DDL: allow-listed surface enum, landingPath ≤512, referrer stored as ORIGIN only, campaign FK SET NULL, utm/click-id columns) + `erased_session_sweeps` (durable 24h re-delete markers). Models + named exports.
- **One session id (§4.2)** — `utils/sessionId.js`: 32-hex validation for BOTH sources (invalid ⇒ ignored, never 400; validated cookie always wins over the `X-Session-Id` header the client sends because it can't read the httpOnly cookie), 90-day horizon everywhere (the two 7d mint sites — QR redirect, `/lead-capture` bind — moved to it), rolling re-issue on `/touch` and the submit response. CORS `allowedHeaders` gains `X-Session-Id`.
- **`POST /api/analytics/touch` (§4.3)** — own `rl:touch` limiter, Joi `analyticsTouch` with `stripUnknown` (client timestamps are unrepresentable by construction), flag-gated skip, and the atomic cap: ONE transaction takes `pg_advisory_xact_lock(hashtext('tp:'||sid))` (P2's shared helper), counts the 24h window, and inserts with `clock_timestamp()` — stamped AFTER the lock grant, which is what makes the stamp-vs-sweep serialization argument airtight (txn-start `now()` would predate a waited-on lock). A well-formed but nonexistent campaignId nulls instead of exploding on the FK.
- **Binding (§4.5)** — the controller resolves/mints the sid pre-service and sets the cookie on the submit response; the service binds `sessionId` WHENEVER a sid exists (previously only when an attribution row matched — the fastest submit now still session-keys), and the explicit-campaign guard keeps dropping `qrTagId`/`attributionId` but **no longer deletes `sessionId`** (browsing identity, not a routing input).
- **Erasure (§4.6)** — in the erasure transaction: shared-session-guarded touchpoint delete + `erased_session_sweeps` upsert (`GREATEST` on conflict). The daily maintenance tick (330s boot offset, advisory-locked, runs regardless of the feature flag so a rollback still drains) consumes sweeps under the SAME per-sid lock the beacon takes, re-applies the shared-session guard, drops each sweep row in-txn once its window passed, and runs the bounded retention purge (`TOUCHPOINT_RETENTION_DAYS`, 180).
- **Frontend (§4.4)** — `lib/touch.js`: `_mktr_sid_boot` (32-hex, 90d expiry, creation serialized via Web Locks with an in-lock re-read; documented last-writer-wins fallback), gates (`VITE_TOUCH_ENABLED` ∧ shared `isSuppressedSurface` ∧ prod-or-dev-opt-in), 30-min per-URL sessionStorage throttle, whitelisted-params-only landingPath, keepalive+credentials fetch with the boot header. `TouchRouteTracker` mounts beside `AdRollRouteTracker` on the SAME allow-list (cross-referenced in `adroll.js`); the three funnel pages beacon after campaign load with the campaign (test-data suppression) and campaignId. The prospect submits carry `X-Session-Id` **only when `VITE_TOUCH_ENABLED`** — a lone frontend flip can't break submit preflights against a backend whose CORS doesn't yet allow the header; the §4.8 flip-together contract stays enforceable.
- **Env (§8)** — `TOUCHPOINTS_ENABLED` (+ booleanFlags), `TOUCHPOINT_RETENTION_DAYS` 7–730, `TOUCHPOINTS_MAX_PER_SESSION_DAY` 5–500 (+ bounded-numeric warnings), `VITE_TOUCH_ENABLED`/`VITE_TOUCH_DEV_MODE` in the root `.env.example`.

## Standalone commit: exact-origin analytics check (§4.3 rider)

`assertAllowedOrigin` used `startsWith`, so `https://mktr.sg.evil.example` passed against `https://mktr.sg` — for the existing `/events` and `/referrals` too. Both the Origin header and the Referer fallback now compare their PARSED origin against the allow-set exactly. Regression matrix added (lookalike hosts via both headers 403; genuine Referer-only still 200).

## Deliberate behaviour changes (each is a named §4 item)

1. Every web submit with a valid sid binds `prospects.sessionId` (was: only when an attribution row existed).
2. The explicit-campaign guard preserves `sessionId` (was: deleted with the QR/attribution pair).
3. Both sid sources are validated 32-hex before use (was: any string bound attribution).
4. sid cookies live 90d rolling (was: 7d) — QR redirect + bind route + new re-issue points.
5. Lookalike-host origins are rejected on all three analytics beacons (was: prefix match).

Three pre-existing unit suites asserted the OLD contracts (non-hex fixture sids; guard deleting sessionId) — their fixtures/assertions were updated to the new contracts with comments naming the §4 items.

## §4.7 works by construction

`SELECT … ARRAY_AGG(t."utmSource" ORDER BY t."occurredAt")… FROM prospects p JOIN touchpoints t ON t."sessionId" = p."sessionId" WHERE t."occurredAt" <= p."createdAt"` — every web prospect now has a `sessionId` and every allow-listed visit a row keyed the same way, indexed by `(sessionId, occurredAt)`.

## Tests (§4.8)

- `test/touchpoints.test.js` (DB): flag-off skip; header adoption + 90d httpOnly Set-Cookie; cookie-beats-header; invalid-both ⇒ `no_session` skip (never 400); server-stamped `occurredAt`; referrer-origin stripping; bogus-campaign nulling; surface-enum 400; **locked cap exact under 12-way concurrency**; sweep consumption (in-window rows deleted, post-window row survives, shared-session guard holds, sweep row dropped only past its window); retention purge (old gone, fresh kept); §4.5 binding (fastest-submit binds + converges with a `/touch` on the same header sid; invalid raw sid ignored; **guard-split: QR/attribution dropped, sessionId kept**).
- `test/analytics.test.js` — exact-origin matrix added (lookalike via Origin AND Referer ⇒ 403; genuine Referer-only ⇒ 200).
- `test/integration/erasure.test.js` — two touchpoint rows join the full matrix: `report.touchpoints = 2`, table emptied in-txn, durable sweep row minted with a future window.
- `src/lib/__tests__/touch.test.js` (vitest) — boot id mint/shape/90d/regeneration; **Web Locks serialization with the in-lock re-read (other tab wins)**; no-Locks fallback; gate matrix incl. the shared suppression rules; keepalive/credentials/header/whitelist on the wire; 30-min throttle (same URL throttled, different URL not); gates-off silence + network errors swallowed; submit headers empty until the flag flips.

Local gates (after the review fold): backend unit **2476/2476** · integration **2866/2866 (174 suites)** · migrations **23/23** · frontend vitest **2039/2039 (157 files)** · typecheck clean · eslint (backend + root) clean.

## Codex adversarial review (gpt-5.6-sol, xhigh, read-only) — 4 findings, all accepted + fixed

| # | Sev | Finding | Disposition |
|---|---|---|---|
| 1 | **P0** | `APIClient.request` spread `...options` AFTER the merged headers object, so any caller passing `options.headers` REPLACED the defaults — dropping `Content-Type` and breaking **every prospect submit** once the X-Session-Id call sites landed, flag on or off | **Fixed.** Headers are destructured out of options and always EXTEND the defaults (no existing caller passed headers, so this is behaviour-neutral elsewhere). Vitest regressions cover both flag states. This was a genuine ship-blocker the review caught — my local suites mock the client, so only a real-browser submit would have surfaced it. |
| 2 | P1 | The QR-redirect and `/lead-capture` mint sites accepted ANY nonempty cookie sid, so a malformed value could be bound into attribution while `/touch` + `/prospects` (validated) key a different identity | **Fixed.** Both mint sites validate and REPLACE malformed cookies with a fresh mint. Tests: valid 32-hex reuse = no re-mint; malformed = replaced with a fresh 32-hex Set-Cookie. |
| 3 | P2 | Joi ran before the feature gate, so schema-skewed beacons 400'd while the feature was dark instead of `{skipped:true}` | **Fixed.** A gate middleware runs before validation; dark = pure no-op whatever the body. |
| 4 | P1 | §4.8 coverage gaps: sequential (not concurrent) touch+submit, hand-created sweep rows (upsert untested), single-row "batching" | **Fixed.** Added: concurrent HTTP touch + submit converging on one sid with the §4.7 join asserted; beacon-blocks-behind-a-held-per-sid-lock serialization test; sweep upsert extracted to `upsertErasedSessionSweepsTx` (erasure + tests share one seam) with GREATEST extend/never-shrink cases; 1500-row two-batch purge. |

Rollback (§4.8): flip both flags (frontend via redeploy); cookies expire naturally; rows inert and purged; the maintenance tick keeps draining sweeps regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ast7umVC2D3W8vTySWSLGh

---

*Rebased onto main @ `5c6a8683` (post-#471 squash; #473/#474/#475/#477 also in — #477 pins the redeemOps autosend clocks, whose unpinned night-SGT window reds failed this PR's first CI run at 00:47 SGT on code P3 does not touch) — conflict-free replay of the 4 P3 commits; post-rebase smoke green: touchpoints/prospects/routeGateAudit/analytics DB suites 148/148, prospectService+platformDeliveryService unit 100/100, vitest touch+client 23/23.*
