### PR TITLE
test: kill the night-SGT reds (autosend clock pin + recording fixture)

### DIFF
--- a/backend/test/redeemOpsAutosend.test.js
+++ b/backend/test/redeemOpsAutosend.test.js
@@ -50,7 +50,16 @@ const mockClient = () => ({
   getThread: async () => ({ messages: google.threadMessages }),
   listMessages: async () => google.sentSearch,
 });
-const sender = makeOutreachSenderService({ makeClient: mockClient });
+// Pin the sender's clock to TODAY 12:00 SGT — inside the 07:00-21:00 send
+// window (the service reschedules outside it, so an unpinned suite goes red
+// on every night-SGT run: the 21:29/23:48/02:42-SGT CI failures). Row claiming
+// compares against DB NOW(), so the pin only steers window/cap/freshness math.
+const noonSgt = () => {
+  const t = new Date();
+  t.setUTCHours(4, 0, 0, 0); // 12:00 SGT
+  return t;
+};
+const sender = makeOutreachSenderService({ makeClient: mockClient, now: noonSgt });
 
 let phoneSeq = 82000000;
 const nextPhone = () => `+65${phoneSeq++}`;

--- a/backend/test/redeemOpsInboxLoop.test.js
+++ b/backend/test/redeemOpsInboxLoop.test.js
@@ -65,7 +65,16 @@ const mockClient = () => ({
   listMessages: async () => [],
 });
 const inbox = makeOutreachInboxService({ makeClient: mockClient });
-const sender = makeOutreachSenderService({ makeClient: mockClient });
+// Pin the sender's clock to TODAY 12:00 SGT — inside the 07:00-21:00 send
+// window (the service reschedules outside it, so an unpinned suite goes red
+// on every night-SGT run: the 21:29/23:48/02:42-SGT CI failures). Row claiming
+// compares against DB NOW(), so the pin only steers window/cap/freshness math.
+const noonSgt = () => {
+  const t = new Date();
+  t.setUTCHours(4, 0, 0, 0); // 12:00 SGT
+  return t;
+};
+const sender = makeOutreachSenderService({ makeClient: mockClient, now: noonSgt });
 
 let phoneSeq = 83000000;
 const nextPhone = () => `+65${phoneSeq++}`;


### PR DESCRIPTION
Main CI has been red since #470 on three suites — all three are **clock bugs in tests**, not product regressions:

- **redeemOpsAutosend + redeemOpsInboxLoop**: `outreachSenderService` reschedules sends outside 07:00–21:00 SGT. The suites tick with the wall clock, so every night-SGT run went red (21:29 / 23:48 / 02:42 SGT — the last four main runs) while daytime runs passed. Fix: inject the service's own `now()` seam pinned to TODAY 12:00 SGT. Row claiming compares against DB `NOW()`, so the pin steers only window/cap/freshness math.
- **retellRecordingScope**: fixture predates the #470 split-recording contract — no `recordingMultiChannelUrl` key ⇒ the endpoint attempts a live Retell refetch ⇒ 503 in tests. **Byte-identical to the repair riding in #471**, so that branch merges clean later.

Verified locally at **00:48 SGT** — inside the formerly-failing window: 41/41 across the three suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW