### PR TITLE
feat(form): date of birth defaults to required — and every designed campaign flips with it

### DIFF
--- a/backend/src/database/migrations/129-dob-required-backfill.js
+++ b/backend/src/database/migrations/129-dob-required-backfill.js
@@ -1,0 +1,50 @@
+/**
+ * 129 — every designed campaign asks for date of birth, required.
+ *
+ * DOB drives the age gate (min_age/max_age, enforced in SGT server-side) and
+ * the 18+ cohort floor — a lead with no recorded age is permanently
+ * unmarketable. The field was visible-but-optional by default, so live
+ * funnels kept accepting blank DOBs (Diaper Discovery, Pet Hotel, [Retell]
+ * Luggage; Tokyo Getaway had it hidden outright). The code default flips to
+ * required in the same release (designConfigV2 twins); this backfills the
+ * campaigns that already exist: every v2 design_config gets its dob field
+ * entry set visible + required.
+ *
+ * Scoped to v2 docs with a real form.fields array — the two Meta lead-ads
+ * campaigns carry no designed web form (native ingestion bypasses the
+ * createProspect gate entirely) and are deliberately untouched. Setting
+ * visible alongside required also dissolves the poison combo the server gate
+ * now guards against: required-but-hidden would 422 every submission.
+ *
+ * Down is a no-op: "restore optional" would restore the compliance gap, and
+ * the pre-migration state was not uniform anyway.
+ */
+
+export async function up(queryInterface) {
+  await queryInterface.sequelize.query(`
+    UPDATE campaigns
+       SET design_config = (
+         jsonb_set(
+           design_config::jsonb,
+           '{form,fields}',
+           (SELECT jsonb_agg(
+                     CASE WHEN f->>'id' = 'dob'
+                          THEN f || '{"visible": true, "required": true}'::jsonb
+                          ELSE f END)
+              FROM jsonb_array_elements(design_config::jsonb#>'{form,fields}') f)
+         )
+       )::json
+     WHERE design_config::jsonb->>'version' = '2'
+       AND jsonb_typeof(design_config::jsonb#>'{form,fields}') = 'array'
+       AND EXISTS (
+         SELECT 1
+           FROM jsonb_array_elements(design_config::jsonb#>'{form,fields}') f
+          WHERE f->>'id' = 'dob'
+            AND (COALESCE(f->>'required', '') <> 'true'
+              OR COALESCE(f->>'visible', '') <> 'true'))
+  `);
+}
+
+export async function down() {
+  // Deliberate no-op — see header.
+}

--- a/backend/src/services/consentCopyRegistry.js
+++ b/backend/src/services/consentCopyRegistry.js
@@ -1,6 +1,7 @@
 import { CONTACT_CONSENT_VERSIONS } from './contactConsent.js';
 import {
   AGREE_ALL_THIRD_PARTY_VERSION, AGREE_ALL_THIRD_PARTY_VERSION_V2,
+  AGREE_ALL_THIRD_PARTY_VERSION_V3,
   AGREE_ALL_THIRD_PARTY_COPY, THIRD_PARTY_CONSENT_CHANNELS,
 } from './externalConsent.js';
 import DrawTermsVersion from '../models/DrawTermsVersion.js';
@@ -33,7 +34,8 @@ export async function resolveConsentCopy(version, deps = {}) {
       scope: contact.scope,
     });
   }
-  if (v === AGREE_ALL_THIRD_PARTY_VERSION || v === AGREE_ALL_THIRD_PARTY_VERSION_V2) {
+  if (v === AGREE_ALL_THIRD_PARTY_VERSION || v === AGREE_ALL_THIRD_PARTY_VERSION_V2
+    || v === AGREE_ALL_THIRD_PARTY_VERSION_V3) {
     clauses.push({
       kind: 'third_party',
       label: 'Sponsor sharing',

--- a/backend/src/services/contactConsent.js
+++ b/backend/src/services/contactConsent.js
@@ -69,6 +69,16 @@ export const AGREE_ALL_CONTACT_COPY_V2 =
   "Contact from Redeem — this offer and future ones. MKTR PTE. LTD. (the company behind Redeem) may contact you by phone call, text message (SMS or WhatsApp) or email about your signup and reward, and about other Redeem offers, rewards and lucky draws. You can opt out anytime — every marketing email includes an unsubscribe link, or contact us using the details in our Personal Data Policy. Opting out later won't affect a reward you've already claimed.";
 
 /**
+ * AGREE-ALL v3 era (2026-08-20): the agreement dialog's INTRO changed ("It's
+ * short, and it's everything" removed) — the contact clause itself is
+ * byte-identical to v2, so the registry entry below reuses V2's copy constant.
+ * A new label is still minted: the era records which agreement block the
+ * person read, and ANY user-visible edit to that block closes the old era
+ * (consentCopy.js header rule). v2 is CLOSED — bytes stay untouched.
+ */
+export const AGREE_ALL_CONSENT_VERSION_V3 = '2026-08-20-agree-all-v3';
+
+/**
  * META LEAD ADS era (native instant forms — docs/plans/meta-lead-ads-native-pipe.md §5).
  * This copy is the EXACT custom-disclaimer checkbox text operators must put on
  * every Meta instant form (checkbox key `mktr_pdpa_consent`). Editing the
@@ -101,6 +111,12 @@ export const CONTACT_CONSENT_VERSIONS = Object.freeze({
   }),
   [AGREE_ALL_CONSENT_VERSION_V2]: Object.freeze({
     copy: AGREE_ALL_CONTACT_COPY_V2,
+    copyHash: sha256(AGREE_ALL_CONTACT_COPY_V2),
+    channels: AGREE_ALL_CONSENT_CHANNELS,
+    scope: 'brand',
+  }),
+  [AGREE_ALL_CONSENT_VERSION_V3]: Object.freeze({
+    copy: AGREE_ALL_CONTACT_COPY_V2, // clause bytes unchanged in v3 (intro-only era)
     copyHash: sha256(AGREE_ALL_CONTACT_COPY_V2),
     channels: AGREE_ALL_CONSENT_CHANNELS,
     scope: 'brand',

--- a/backend/src/services/externalConsent.js
+++ b/backend/src/services/externalConsent.js
@@ -93,11 +93,19 @@ export const AGREE_ALL_THIRD_PARTY_COPY =
  */
 export const AGREE_ALL_THIRD_PARTY_VERSION_V2 = '2026-08-19-agree-all-v2';
 
+/**
+ * AGREE-ALL v3 era label (2026-08-20): the dialog-intro era — this clause is
+ * byte-identical across v1/v2/v3; the label exists so v3 captures stamp their
+ * own era instead of falling back to the legacy default.
+ */
+export const AGREE_ALL_THIRD_PARTY_VERSION_V3 = '2026-08-20-agree-all-v3';
+
 /** Version labels buildExternalConsentEvidence may stamp (unknown => default). */
 const KNOWN_THIRD_PARTY_VERSIONS = Object.freeze([
   THIRD_PARTY_CONSENT_VERSION,
   AGREE_ALL_THIRD_PARTY_VERSION,
   AGREE_ALL_THIRD_PARTY_VERSION_V2,
+  AGREE_ALL_THIRD_PARTY_VERSION_V3,
 ]);
 
 /**

--- a/backend/src/services/prospectService.js
+++ b/backend/src/services/prospectService.js
@@ -708,7 +708,12 @@ export function makeProspectService(overrides = {}) {
     // Deliberately scoped to the operator's own form config: campaigns that
     // leave dob optional keep behaving exactly as before, so this can never
     // start rejecting entrants on a live funnel that was set up to allow them.
-    const dobRequired = sourceDesign.requiredFields?.dob === true;
+    // Visibility-guarded like the client gate: a HIDDEN dob is never enforced —
+    // the form doesn't collect it, so requiring it server-side would 422 every
+    // submission on that funnel (required now defaults ON, making the hidden+
+    // required combo reachable from the Form panel with two ticks).
+    const dobRequired = sourceDesign.requiredFields?.dob === true
+      && sourceDesign.visibleFields?.dob !== false;
     // M8: STRICT calendar date, evaluated on the SINGAPORE calendar. The old
     // gate parsed arbitrary strings with new Date() and compared server-LOCAL
     // Y/M/D — on the UTC prod host an applicant whose birthday began at 00:00

--- a/backend/src/utils/designConfigV2.js
+++ b/backend/src/utils/designConfigV2.js
@@ -215,7 +215,7 @@ export function defaultFields() {
     { id: 'name', visible: true, required: true, row: null },
     { id: 'email', visible: true, required: true, row: null },
     { id: 'phone', visible: true, required: true, row: null },
-    { id: 'dob', visible: true, required: false, row: null },
+    { id: 'dob', visible: true, required: true, row: null },
     { id: 'postal', visible: true, required: false, row: null },
     { id: 'education', visible: false, required: false, row: null },
     { id: 'salary', visible: false, required: false, row: null },

--- a/backend/test/consumerEnrichment.test.js
+++ b/backend/test/consumerEnrichment.test.js
@@ -603,6 +603,7 @@ describe('custom questions (studio-custom-questions §6–§7) — display-only 
       firstName: 'Forge', lastName: 'Case',
       email: `forge-${phoneSeq}@example.com`, phone: phoneFor(phoneSeq),
       leadSource: 'website', campaignId: cqCampaign.id,
+      date_of_birth: '1988-06-15', // dob defaults to REQUIRED now; V2_CQ has no fields[] so canonical defaults apply
       sourceMetadata: {
         customAnswers: [{ qid: 'x', prompt: 'Forged', values: ['x'] }],
         profileAnswers: { language: 'zh' },

--- a/backend/test/prospects.test.js
+++ b/backend/test/prospects.test.js
@@ -334,6 +334,21 @@ describe('DOB and postal code mapping', () => {
     expect(res.body.message).toMatch(/Date of birth is required/i)
   })
 
+  it('a required-but-HIDDEN dob is NOT enforced — the form never collects what the gate would demand', async () => {
+    const misconfigured = await createTestCampaign(adminUser.id, {
+      design_config: { requiredFields: { dob: true }, visibleFields: { dob: false } },
+    })
+    const res = await postProspect({
+      firstName: 'HiddenDob',
+      lastName: 'User',
+      email: `hiddendob-${Date.now()}@test.com`,
+      phone: `+65${Date.now().toString().slice(-8)}`,
+      leadSource: 'qr_code',
+      campaignId: misconfigured.id,
+    })
+    expect(res.status).toBe(201)
+  })
+
   it('an OPTIONAL dob that is missing still passes — no new friction on funnels set up to allow it', async () => {
     const open = await createTestCampaign(adminUser.id, { min_age: 21, max_age: 65 })
     const res = await postProspect({

--- a/backend/test/unit/marketplaceIntake.test.js
+++ b/backend/test/unit/marketplaceIntake.test.js
@@ -137,7 +137,9 @@ describe('marketplace metadata intake — v2 documents', () => {
     status: 'active',
     design_config: {
       version: 2,
-      form: { gates: {}, fields: [] },
+      // dob explicitly optional: an empty fields[] falls back to the canonical
+      // defaults, which since the dob-required release would 422 this intake.
+      form: { gates: {}, fields: [{ id: 'dob', visible: true, required: false, row: null }] },
       distribution: {
         host: 'redeem',
         marketplace: {

--- a/src/lib/__tests__/consentCopy.lockstep.test.js
+++ b/src/lib/__tests__/consentCopy.lockstep.test.js
@@ -14,10 +14,12 @@ import {
   AGREE_ALL_CONTACT_COPY,
   AGREE_ALL_CONSENT_VERSION_V2,
   AGREE_ALL_CONTACT_COPY_V2,
+  AGREE_ALL_CONSENT_VERSION_V3,
 } from '../../../backend/src/services/contactConsent.js';
 import {
   AGREE_ALL_THIRD_PARTY_VERSION,
   AGREE_ALL_THIRD_PARTY_VERSION_V2,
+  AGREE_ALL_THIRD_PARTY_VERSION_V3,
   AGREE_ALL_THIRD_PARTY_COPY,
 } from '../../../backend/src/services/externalConsent.js';
 
@@ -25,8 +27,8 @@ const sha256 = (s) => createHash('sha256').update(s).digest('hex');
 
 describe('agree-all consent copy — frontend/backend lock-step', () => {
   it('one era, one label: frontend version === both backend era labels', () => {
-    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_CONSENT_VERSION_V2);
-    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_THIRD_PARTY_VERSION_V2);
+    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_CONSENT_VERSION_V3);
+    expect(CONSENT_COPY_VERSION).toBe(AGREE_ALL_THIRD_PARTY_VERSION_V3);
   });
 
   it('the CLOSED v1 era is still registered, byte-untouched (evidence keeps meaning)', () => {
@@ -36,14 +38,27 @@ describe('agree-all consent copy — frontend/backend lock-step', () => {
     expect(AGREE_ALL_THIRD_PARTY_VERSION).toBe('2026-07-21-agree-all-v1');
   });
 
+  it('the CLOSED v2 era is still registered, byte-untouched', () => {
+    const v2 = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V2];
+    expect(v2.copy).toBe(AGREE_ALL_CONTACT_COPY_V2);
+    expect(AGREE_ALL_THIRD_PARTY_VERSION_V2).toBe('2026-08-19-agree-all-v2');
+  });
+
   it('v2 changed ONLY the entity casing in the contact clause', () => {
     expect(AGREE_ALL_CONTACT_COPY_V2).toBe(AGREE_ALL_CONTACT_COPY.replace('MKTR Pte. Ltd.', 'MKTR PTE. LTD.'));
+  });
+
+  it("v3 changed ONLY the dialog intro — clause bytes are v2's, and the intro no longer claims to be short", () => {
+    expect(CONSENT_COPY.intro).toBe('By submitting this form, you agree to the following:');
+    const v3 = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V3];
+    expect(v3.copy).toBe(AGREE_ALL_CONTACT_COPY_V2);
+    expect(v3.copyHash).toBe(CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V2].copyHash);
   });
 
   it('contact clause (headline + body) is BYTE-IDENTICAL to the ledger-pinned backend copy', () => {
     const onScreen = `${CONSENT_COPY.clauseContactHeadline} ${CONSENT_COPY.clauseContactBody}`;
     expect(AGREE_ALL_CONTACT_COPY_V2).toBe(onScreen);
-    const era = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V2];
+    const era = CONTACT_CONSENT_VERSIONS[AGREE_ALL_CONSENT_VERSION_V3];
     expect(era.copy).toBe(onScreen);
     expect(era.copyHash).toBe(sha256(onScreen));
     expect(era.scope).toBe('brand');

--- a/src/lib/consentCopy.js
+++ b/src/lib/consentCopy.js
@@ -18,11 +18,15 @@
 // 2026-08-19-agree-all-v2: byte-identical to v1 except the legal-entity
 // casing in the contact clause ("MKTR Pte. Ltd." → "MKTR PTE. LTD.") —
 // consistent with the campaign T&Cs and the Prudential introducer clause.
-export const CONSENT_COPY_VERSION = '2026-08-19-agree-all-v2';
+// 2026-08-20-agree-all-v3: the dialog intro drops "It's short, and it's
+// everything" (Shawn: it is not short). Both evidence clauses are
+// byte-identical to v2 — the era exists because the agreement block a person
+// reads changed, per the any-user-visible-string rule above.
+export const CONSENT_COPY_VERSION = '2026-08-20-agree-all-v3';
 
 export const CONSENT_COPY = Object.freeze({
   heading: 'Terms and conditions',
-  intro: "By submitting this form, you agree to the following. It's short, and it's everything:",
+  intro: 'By submitting this form, you agree to the following:',
   clauseContactHeadline: 'Contact from Redeem — this offer and future ones.',
   clauseContactBody:
     "MKTR PTE. LTD. (the company behind Redeem) may contact you by phone call, text message (SMS or WhatsApp) or email about your signup and reward, and about other Redeem offers, rewards and lucky draws. You can opt out anytime — every marketing email includes an unsubscribe link, or contact us using the details in our Personal Data Policy. Opting out later won't affect a reward you've already claimed.",

--- a/src/lib/designConfigV2.js
+++ b/src/lib/designConfigV2.js
@@ -190,7 +190,7 @@ export function defaultFields() {
     { id: 'name', visible: true, required: true, row: null },
     { id: 'email', visible: true, required: true, row: null },
     { id: 'phone', visible: true, required: true, row: null },
-    { id: 'dob', visible: true, required: false, row: null },
+    { id: 'dob', visible: true, required: true, row: null },
     { id: 'postal', visible: true, required: false, row: null },
     { id: 'education', visible: false, required: false, row: null },
     { id: 'salary', visible: false, required: false, row: null },


### PR DESCRIPTION
## What Shawn asked

1. *"check if DOB is optional on our forms, and make it default to required. and switch all the campaigns to DOB required, instead of optional."*
2. *"The summary block opens with \"It's short, and it's everything\". remove that. it is not short."*

## Finding

DOB was **visible but optional by default** (`defaultFields()` in the designConfigV2 twins), and 4 designed campaigns were live/paused with it optional or hidden. DOB feeds the SGT age gate and the 18+ cohort floor — a lead with no recorded age is permanently unmarketable, and `studioReadiness` already nags when a T&C age floor isn't backed by a required DOB.

## Changes

**Default flip** — `src/lib/designConfigV2.js` + `backend/src/utils/designConfigV2.js` (twins, byte-parity kept): `dob` → `visible: true, required: true`. New campaigns, canonical clamp fill-ins, and v2 docs with no `fields[]` all start required. The v1→v2 *upgrade* mapping is untouched — it faithfully translates what a legacy doc configured.

**Migration 129** — every existing v2 `design_config` gets its dob entry set `visible + required`. Verified read-only against prod before writing the migration: it changes **exactly 4 campaigns** — Free Baby Diaper Discovery, Free Pet Hotel Trial, [Retell] Luggage, Tokyo Getaway (paused; **was hidden, becomes shown + required** — flag if unwanted) — and no-ops the 5 already-required ones. The two Meta lead-ads campaigns have no designed web form and are excluded (native ingestion bypasses `createProspect` anyway, as does Retell voice — no ingest pipe can be 422'd by this).

**Server gate hardening** — `createProspect`'s dob gate is now visibility-guarded like the client gate: `requiredFields.dob === true && visibleFields.dob !== false`. Without this, required-but-hidden (two Form-panel ticks away, likelier now that required defaults on) would 422 **every** submission on that funnel while the client collects nothing. New regression test; the existing required-and-missing 422 test still passes.

**Consent era v3 (the second ask)** — the agreement dialog intro drops "It's short, and it's everything" → `By submitting this form, you agree to the following:`. That string lives in the era-governed `CONSENT_COPY` block ("editing ANY user-visible string here means a NEW era"), so this mints `2026-08-20-agree-all-v3`: registry entry reuses v2's clause bytes (both evidence clauses unchanged — the era records the changed dialog), v2/v1 close untouched, third-party KNOWN list + registry resolver extended, lockstep test pins it all. Deploy-race window (frontend sending v3 before backend restart) degrades to the legacy-label fallback, same as the v2 rollout yesterday.

**Test fixtures** — two suites created v2 campaigns with no/empty `fields[]` (canonical defaults now = dob required) and posted prospects without a DOB: `consumerEnrichment` internal-caller test now sends one (the suite's own `capture()` helper always did); `marketplaceIntake`'s v2 fixture declares dob explicitly optional (documents the override path).

## Gates

- Frontend vitest **2046/2046**
- Backend unit **2476/2476**
- Backend integration **2863 passed** — remaining 8 fails are `redeemOpsAutosend`/`redeemOpsInboxLoop`, reproduced identically on clean origin/main (pre-existing, untouched by this PR)
- Migrations **23/23** · eslint (root + backend) + typecheck clean

## Not done (deliberate)

- Diaper campaign (Shawn's mid-task note: only S size exists): verified **nothing asks for a preferred diaper size anywhere** — no custom/profile/quiz questions on that campaign at all; nothing to remove. Optional follow-up if wanted: say "Size S" explicitly in the T&C offer line.
- Studio-AI "Fill everything" may still *choose* optional/hidden dob per brief (its omission-means-hidden contract is deliberate); the readiness warning still flags it on age-gated campaigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Up3drB4LGGYF7Bq8vMccmW