### PR TITLE
fix(api): elevated rate-limit budget for Redeem Ops principals, not only admins

### DIFF
--- a/backend/src/server_internal.js
+++ b/backend/src/server_internal.js
@@ -14,6 +14,7 @@ import { notFound } from './middleware/notFound.js';
 import { bootstrapDatabase } from './database/bootstrap.js';
 import { requestId } from './middleware/requestId.js';
 import { makeLimiter } from './middleware/rateLimiters.js';
+import { isRedeemOpsUser } from './services/redeemOps/permissions.js';
 
 // Non-autodiscoverable middleware
 import leadCaptureBind from './routes/leadCaptureBind.js';
@@ -112,7 +113,13 @@ export const init = async (app) => {
     prefix: 'rl:api',
     windowMs: isProd ? parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000 : 60 * 1000, // 1 minute window in dev
     max: (req) => {
-      if (isProd && req.user && req.user.role === 'admin') return 2000;
+      // Elevated budget for authenticated staff: platform admins AND any
+      // Redeem Ops principal (isRedeemOpsUser covers role='admin',
+      // role='redeem_ops' and granted redeemOpsRole). The ops outreach queue
+      // is API-chatty — task list + draft + outcome per contact — and ops
+      // execs were exhausting the anonymous 200/15min budget mid-shift.
+      // Anonymous/customer traffic keeps the tight cap.
+      if (isProd && isRedeemOpsUser(req.user)) return 2000;
       return isProd
         ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 200
         : parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 1000000;

--- a/backend/test/unit/rateLimiters.test.js
+++ b/backend/test/unit/rateLimiters.test.js
@@ -100,6 +100,16 @@ describe('no limiter is left on the express-rate-limit defaults', () => {
     expect(src).toMatch(/makeLimiter\(\{\s*\n?\s*prefix: 'rl:api'/);
   });
 
+  it('the global /api limiter elevates every Redeem Ops principal, not only admins', () => {
+    // Ops execs grinding the outreach queue were exhausting the anonymous
+    // 200/15min budget mid-shift ("Too many requests from this IP"). The
+    // elevated budget must key off isRedeemOpsUser (admin + redeem_ops +
+    // granted redeemOpsRole), not a bare role === 'admin' check.
+    const src = read('server_internal.js');
+    expect(src).toMatch(/isRedeemOpsUser\(req\.user\)\) return 2000/);
+    expect(src).not.toMatch(/req\.user\.role === 'admin'\) return 2000/);
+  });
+
   it('every limiter declares a UNIQUE prefix', () => {
     const prefixes = [...routeFiles.map((f) => `routes/${f}`), 'server_internal.js']
       .flatMap((rel) => [...read(rel).matchAll(/prefix: '([^']+)'/g)].map((m) => m[1]));


### PR DESCRIPTION
## Why

An ops exec working the Email Outreach queue on ops.redeem.sg got blocked mid-shift with **"Too many requests from this IP, please try again later"** (stacked toasts, screenshot 24/8). That message is our own global `/api` limiter in `server_internal.js` — nothing to do with Apify or any downstream provider.

The limiter's elevated budget (2000/15min) only applied to `role === 'admin'`. Redeem Ops principals (`role='redeem_ops'` or a granted `redeemOpsRole`) fell into the anonymous 200/15min IP bucket — ~13 requests/min, which an active outreach session (queue + task + draft + outcome per contact, plus inbox polling) burns through easily.

## What

- `optionalAuth` already decodes the ops JWT before the limiter runs, so the bypass now keys off `isRedeemOpsUser(req.user)` (covers admin + redeem_ops + granted sub-roles) instead of a bare admin check. Any authenticated ops principal gets the same 2000/15min budget as admins.
- Anonymous/customer traffic (redeem.sg lead capture) keeps the tight 200 cap — no weakening of the public posture.
- Regression test added in `test/unit/rateLimiters.test.js`: the elevated budget must go through `isRedeemOpsUser`, and the old admin-only line must not come back.

## Tests

- `test/unit/rateLimiters.test.js`: 22/22 pass (run in the worktree off origin/main).
- `eslint src/server_internal.js --quiet`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BZ5RqtN6Jb2DYVhRgpbGP